### PR TITLE
feat: Add autocompletion for Cytoscape style properties

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -9,6 +9,7 @@
         :completion-index="curCompletionIndex"
         :debug-mode="debugMode"
         :tutorial-mode="tutorialMode"
+        :selected-renderer="selectedRenderer"
         @update-editorstate="updateEditorState"
       />
     </pane>

--- a/src/autocomplete/rendererProperties.ts
+++ b/src/autocomplete/rendererProperties.ts
@@ -1,0 +1,203 @@
+import { Completion } from "@codemirror/autocomplete";
+
+// Cytoscape properties sourced from https://js.cytoscape.org/#style
+
+// Node body
+const CYTOSCAPE_NODE_BODY_PROPERTIES = [
+  "height",
+  "width",
+  "shape",
+  "shape-polygon-points",
+  "corner-radius",
+  "background-color",
+  "background-fill",
+  "background-opacity",
+  "background-blacken",
+  "background-gradient-stop-colors",
+  "background-gradient-stop-positions",
+  "background-gradient-direction",
+  "padding",
+  "padding-relative-to",
+  "bounds-expansion",
+];
+
+// Node border
+const CYTOSCAPE_NODE_BORDER_PROPERTIES = [
+  "border-color",
+  "border-opacity",
+  "border-width",
+  "border-style",
+  "border-cap",
+  "border-join",
+  "border-dash-pattern",
+  "border-dash-offset",
+  "border-position",
+];
+
+// Node outline
+const CYTOSCAPE_NODE_OUTLINE_PROPERTIES = [
+  "outline-color",
+  "outline-opacity",
+  "outline-width",
+  "outline-style",
+  "outline-offset",
+];
+
+// Background image
+const CYTOSCAPE_BACKGROUND_IMAGE_PROPERTIES = [
+  "background-image",
+  "background-image-crossorigin",
+  "background-image-opacity",
+  "background-image-containment",
+  "background-image-smoothing",
+  "background-position-x",
+  "background-position-y",
+  "background-width-relative-to",
+  "background-height-relative-to",
+  "background-repeat",
+  "background-fit",
+  "background-clip",
+  "background-width",
+  "background-height",
+  "background-offset-x",
+  "background-offset-y",
+];
+
+// Labels — main, source, target
+const CYTOSCAPE_LABEL_PROPERTIES = [
+  "label",
+  "text-rotation",
+  "text-margin-x",
+  "text-margin-y",
+  "source-label",
+  "source-text-rotation",
+  "source-text-margin-x",
+  "source-text-margin-y",
+  "source-text-offset",
+  "target-label",
+  "target-text-rotation",
+  "target-text-margin-x",
+  "target-text-margin-y",
+  "target-text-offset",
+];
+
+// Label dimensions and styling
+const CYTOSCAPE_LABEL_STYLE_PROPERTIES = [
+  "font-family",
+  "font-style",
+  "font-weight",
+  "font-size",
+  "text-transform",
+  "text-wrap",
+  "text-overflow-wrap",
+  "text-max-width",
+  "text-outline-width",
+  "line-height",
+  "text-valign",
+  "text-halign",
+  "color",
+  "text-outline-color",
+  "text-outline-opacity",
+  "text-background-color",
+  "text-background-opacity",
+  "text-background-padding",
+  "text-border-opacity",
+  "text-border-color",
+  "text-border-width",
+  "text-border-style",
+  "text-background-shape",
+  "text-justification",
+];
+
+// Visibility
+const CYTOSCAPE_VISIBILITY_PROPERTIES = [
+  "display",
+  "visibility",
+  "opacity",
+  "text-opacity",
+  "min-zoomed-font-size",
+  "z-index",
+];
+
+// Edge line
+const CYTOSCAPE_EDGE_LINE_PROPERTIES = [
+  "line-style",
+  "line-color",
+  "line-fill",
+  "line-cap",
+  "line-opacity",
+  "line-dash-pattern",
+  "line-dash-offset",
+  "line-outline-width",
+  "line-outline-color",
+  "line-gradient-stop-colors",
+  "line-gradient-stop-positions",
+  "curve-style",
+  "haystack-radius",
+  "source-endpoint",
+  "target-endpoint",
+  "control-point-step-size",
+  "control-point-distances",
+  "control-point-weights",
+  "segment-distances",
+  "segment-weights",
+  "segment-radii",
+  "radius-type",
+  "taxi-turn",
+  "taxi-turn-min-distance",
+  "taxi-direction",
+  "taxi-radius",
+  "edge-distances",
+  "arrow-scale",
+  "loop-direction",
+  "loop-sweep",
+  "source-distance-from-node",
+  "target-distance-from-node",
+];
+
+// Edge arrows (source, mid-source, target, mid-target)
+const CYTOSCAPE_EDGE_ARROW_PROPERTIES = [
+  "source-arrow-shape",
+  "source-arrow-color",
+  "source-arrow-fill",
+  "source-arrow-width",
+  "mid-source-arrow-shape",
+  "mid-source-arrow-color",
+  "mid-source-arrow-fill",
+  "mid-source-arrow-width",
+  "target-arrow-shape",
+  "target-arrow-color",
+  "target-arrow-fill",
+  "target-arrow-width",
+  "mid-target-arrow-shape",
+  "mid-target-arrow-color",
+  "mid-target-arrow-fill",
+  "mid-target-arrow-width",
+];
+
+function buildCompletions(properties: string[]): Completion[] {
+  const unique = [...new Set(properties)].sort();
+  return unique.map((label) => ({ label, type: "property" }));
+}
+
+const cytoscapeCompletions = buildCompletions([
+  ...CYTOSCAPE_NODE_BODY_PROPERTIES,
+  ...CYTOSCAPE_NODE_BORDER_PROPERTIES,
+  ...CYTOSCAPE_NODE_OUTLINE_PROPERTIES,
+  ...CYTOSCAPE_BACKGROUND_IMAGE_PROPERTIES,
+  ...CYTOSCAPE_LABEL_PROPERTIES,
+  ...CYTOSCAPE_LABEL_STYLE_PROPERTIES,
+  ...CYTOSCAPE_VISIBILITY_PROPERTIES,
+  ...CYTOSCAPE_EDGE_LINE_PROPERTIES,
+  ...CYTOSCAPE_EDGE_ARROW_PROPERTIES,
+]);
+
+const rendererPropertyRegistry: Record<string, Completion[]> = {
+  cytoscape: cytoscapeCompletions,
+};
+
+export function getRendererPropertyCompletions(
+  rendererId: string,
+): Completion[] {
+  return rendererPropertyRegistry[rendererId] ?? [];
+}

--- a/src/autocomplete/rendererPropertyCompleter.ts
+++ b/src/autocomplete/rendererPropertyCompleter.ts
@@ -1,0 +1,63 @@
+import {
+  Completion,
+  CompletionContext,
+  CompletionResult,
+  CompletionSource,
+} from "@codemirror/autocomplete";
+
+import { CompletionIndex, ContextScenarioType } from "./autocompletion";
+
+export function createRendererPropertyCompletionSource(
+  completionIndex: CompletionIndex,
+  rendererProperties: Completion[],
+): CompletionSource {
+  return (context: CompletionContext): CompletionResult | null => {
+    if (rendererProperties.length === 0) return null;
+
+    const contextScenario = completionIndex.getContextScenarioAt(context.pos);
+    const isStyleContext =
+      contextScenario?.type === ContextScenarioType.StyleArgList;
+
+    // Reject if cursor follows '#' (style tag position — handled by existing completers)
+    const hashMatch = isStyleContext
+      ? context.matchBefore(/#[\w-]*/)
+      : context.matchBefore(/\{[^{}]*#[\w-]*/);
+    if (hashMatch) return null;
+
+    // Reject if cursor is in property value position (after ':')
+    const colonMatch = context.matchBefore(/:\s*[^\n;{}]*/);
+    if (colonMatch) return null;
+
+    // Match CSS-identifier-like input (supports hyphens)
+    let match;
+    if (isStyleContext) {
+      match = context.matchBefore(/[\w-]*/);
+    } else {
+      // Fallback: inside braces but context not yet registered (debounce lag)
+      match = context.matchBefore(/\{[^{}]*?(?:^|;)\s*[\w-]*/);
+    }
+
+    if (!match || (match.from === match.to && !context.explicit)) return null;
+
+    // Extract the property name prefix from the match
+    let word: string;
+    let from: number;
+    if (isStyleContext) {
+      word = match.text;
+      from = match.from;
+    } else {
+      // Extract trailing word from fallback match
+      const wordMatch = /(?:^|;)\s*([\w-]*)$/.exec(match.text);
+      if (!wordMatch) return null;
+      word = wordMatch[1];
+      from = match.to - word.length;
+    }
+
+    const filtered = rendererProperties.filter((c) => c.label.startsWith(word));
+
+    return {
+      from,
+      options: filtered,
+    };
+  };
+}

--- a/src/components/TextEditor.vue
+++ b/src/components/TextEditor.vue
@@ -54,6 +54,8 @@ import {
 import { fizLanguage } from "@formulavize/lang-fiz";
 import { CompletionIndex } from "../autocomplete/autocompletion";
 import { getAllDynamicCompletionSources } from "../autocomplete/autocompleter";
+import { getRendererPropertyCompletions } from "../autocomplete/rendererProperties";
+import { createRendererPropertyCompletionSource } from "../autocomplete/rendererPropertyCompleter";
 
 // Tutorial header protection logic
 // This logic ensures that the tutorial header (a section of the editor
@@ -141,6 +143,10 @@ export default defineComponent({
       type: Boolean,
       default: false,
     },
+    selectedRenderer: {
+      type: String,
+      default: "",
+    },
   },
   emits: ["update-editorstate"],
   expose: ["setEditorText", "setTutorialHeaderText", "setExamplesText"],
@@ -154,13 +160,21 @@ export default defineComponent({
       this.$emit("update-editorstate", updatedState);
     }, this.editorDebounceDelay);
 
-    const createAutocompletion = (completionIndex?: CompletionIndex) => {
+    const createAutocompletion = (
+      completionIndex?: CompletionIndex,
+      selectedRenderer?: string,
+    ) => {
       if (!completionIndex) {
         return autocompletion();
       }
-      return autocompletion({
-        override: getAllDynamicCompletionSources(completionIndex),
-      });
+      const sources = getAllDynamicCompletionSources(completionIndex);
+      if (selectedRenderer) {
+        const properties = getRendererPropertyCompletions(selectedRenderer);
+        sources.push(
+          createRendererPropertyCompletionSource(completionIndex, properties),
+        );
+      }
+      return autocompletion({ override: sources });
     };
 
     const createTooltipText = (
@@ -268,7 +282,7 @@ export default defineComponent({
         }),
         keymapCompartment.of(getKeymap(this.tabToIndent)),
         autocompletionCompartment.of(
-          createAutocompletion(this.completionIndex),
+          createAutocompletion(this.completionIndex, this.selectedRenderer),
         ),
         cursorTooltipCompartment.of(createCursorTooltip(this.debugMode)),
         readOnlyHeaderLengthField,
@@ -318,11 +332,22 @@ export default defineComponent({
       (completionIndex) => {
         view.dispatch({
           effects: autocompletionCompartment.reconfigure(
-            createAutocompletion(completionIndex),
+            createAutocompletion(completionIndex, this.selectedRenderer),
           ),
         });
       },
       { deep: true },
+    );
+
+    watch(
+      () => this.selectedRenderer,
+      (selectedRenderer) => {
+        view.dispatch({
+          effects: autocompletionCompartment.reconfigure(
+            createAutocompletion(this.completionIndex, selectedRenderer),
+          ),
+        });
+      },
     );
 
     watch(

--- a/tests/unit/autocomplete/autocompleteTestHelpers.ts
+++ b/tests/unit/autocomplete/autocompleteTestHelpers.ts
@@ -1,0 +1,66 @@
+import { CompletionContext, CompletionSource } from "@codemirror/autocomplete";
+
+// Mock CompletionContext for testing
+export function createMockContext(
+  pos: number,
+  text: string,
+  explicit: boolean = false,
+): CompletionContext {
+  return {
+    pos,
+    explicit,
+    matchBefore: (pattern: RegExp) => {
+      // In CodeMirror, `pos` is an absolute document position.
+      // These tests often pass a short snippet that ends at the cursor,
+      // so we left-pad the snippet to make `textBeforeCursor.length === pos`.
+      const textBeforeCursor =
+        text.length >= pos
+          ? text.slice(0, pos)
+          : " ".repeat(pos - text.length) + text;
+
+      // Emulate `CompletionContext.matchBefore`: find a match that ends at the cursor.
+      // Prefer the longest match that reaches the end (to avoid empty matches like /\w*/).
+      const baseFlags = pattern.flags.replaceAll("y", "");
+      const flags = baseFlags.includes("g") ? baseFlags : `${baseFlags}g`;
+      const re = new RegExp(pattern.source, flags);
+
+      let bestFrom: number | null = null;
+      let bestText: string | null = null;
+
+      let match: RegExpExecArray | null;
+      while ((match = re.exec(textBeforeCursor)) !== null) {
+        const from = match.index;
+        const text = match[0];
+        const to = from + text.length;
+
+        if (to === textBeforeCursor.length) {
+          if (bestText === null || text.length > bestText.length) {
+            bestFrom = from;
+            bestText = text;
+          }
+        }
+
+        // Avoid infinite loops on zero-length matches.
+        if (text.length === 0) {
+          re.lastIndex++;
+        }
+      }
+
+      if (bestFrom === null || bestText === null) return null;
+      return {
+        from: bestFrom,
+        to: textBeforeCursor.length,
+        text: bestText,
+      };
+    },
+    // Add other required CompletionContext properties as stubs
+    state: {} as unknown as CompletionContext["state"],
+    aborted: false,
+    tokenBefore: () => null,
+  } as unknown as CompletionContext;
+}
+
+export const runSource = (source: CompletionSource, ctx: CompletionContext) =>
+  Promise.resolve()
+    .then(() => source(ctx))
+    .catch(() => null);

--- a/tests/unit/autocomplete/autocompleter.test.ts
+++ b/tests/unit/autocomplete/autocompleter.test.ts
@@ -1,5 +1,5 @@
 import { describe, test, expect, beforeEach } from "vitest";
-import { CompletionContext, CompletionSource } from "@codemirror/autocomplete";
+import { CompletionSource } from "@codemirror/autocomplete";
 import {
   createCompletions,
   createStatementCompletionSource,
@@ -21,71 +21,7 @@ import {
   NamespaceInfo,
   ContextScenario,
 } from "src/autocomplete/autocompletion";
-
-// Mock CompletionContext for testing
-function createMockContext(
-  pos: number,
-  text: string,
-  explicit: boolean = false,
-): CompletionContext {
-  return {
-    pos,
-    explicit,
-    matchBefore: (pattern: RegExp) => {
-      // In CodeMirror, `pos` is an absolute document position.
-      // These tests often pass a short snippet that ends at the cursor,
-      // so we left-pad the snippet to make `textBeforeCursor.length === pos`.
-      const textBeforeCursor =
-        text.length >= pos
-          ? text.slice(0, pos)
-          : " ".repeat(pos - text.length) + text;
-
-      // Emulate `CompletionContext.matchBefore`: find a match that ends at the cursor.
-      // Prefer the longest match that reaches the end (to avoid empty matches like /\w*/).
-      const baseFlags = pattern.flags.replaceAll("y", "");
-      const flags = baseFlags.includes("g") ? baseFlags : `${baseFlags}g`;
-      const re = new RegExp(pattern.source, flags);
-
-      let bestFrom: number | null = null;
-      let bestText: string | null = null;
-
-      let match: RegExpExecArray | null;
-      while ((match = re.exec(textBeforeCursor)) !== null) {
-        const from = match.index;
-        const text = match[0];
-        const to = from + text.length;
-
-        if (to === textBeforeCursor.length) {
-          if (bestText === null || text.length > bestText.length) {
-            bestFrom = from;
-            bestText = text;
-          }
-        }
-
-        // Avoid infinite loops on zero-length matches.
-        if (text.length === 0) {
-          re.lastIndex++;
-        }
-      }
-
-      if (bestFrom === null || bestText === null) return null;
-      return {
-        from: bestFrom,
-        to: textBeforeCursor.length,
-        text: bestText,
-      };
-    },
-    // Add other required CompletionContext properties as stubs
-    state: {} as unknown as CompletionContext["state"],
-    aborted: false,
-    tokenBefore: () => null,
-  } as unknown as CompletionContext;
-}
-
-const runSource = (source: CompletionSource, ctx: CompletionContext) =>
-  Promise.resolve()
-    .then(() => source(ctx))
-    .catch(() => null);
+import { createMockContext, runSource } from "./autocompleteTestHelpers";
 
 function cloneWithOverrides<T extends object>(
   base: T,

--- a/tests/unit/autocomplete/rendererProperties.test.ts
+++ b/tests/unit/autocomplete/rendererProperties.test.ts
@@ -1,0 +1,27 @@
+import { describe, test, expect } from "vitest";
+import { getRendererPropertyCompletions } from "src/autocomplete/rendererProperties";
+
+describe("rendererProperties", () => {
+  test("cytoscape returns a non-empty array", () => {
+    const completions = getRendererPropertyCompletions("cytoscape");
+    expect(completions.length).toBeGreaterThan(0);
+  });
+
+  test("all completions have type 'property'", () => {
+    const completions = getRendererPropertyCompletions("cytoscape");
+    for (const completion of completions) {
+      expect(completion.type).toBe("property");
+    }
+  });
+
+  test("no duplicate labels", () => {
+    const completions = getRendererPropertyCompletions("cytoscape");
+    const labels = completions.map((c) => c.label);
+    expect(new Set(labels).size).toBe(labels.length);
+  });
+
+  test("unknown renderer returns empty array", () => {
+    const completions = getRendererPropertyCompletions("nonexistent");
+    expect(completions).toEqual([]);
+  });
+});

--- a/tests/unit/autocomplete/rendererPropertyCompleter.test.ts
+++ b/tests/unit/autocomplete/rendererPropertyCompleter.test.ts
@@ -1,0 +1,121 @@
+import { describe, test, expect } from "vitest";
+import { createRendererPropertyCompletionSource } from "src/autocomplete/rendererPropertyCompleter";
+import {
+  CompletionIndex,
+  ContextScenarioType,
+} from "src/autocomplete/autocompletion";
+import { getRendererPropertyCompletions } from "src/autocomplete/rendererProperties";
+import { createMockContext, runSource } from "./autocompleteTestHelpers";
+
+const cytoscapeProperties = getRendererPropertyCompletions("cytoscape");
+
+describe("rendererPropertyCompleter", () => {
+  test("returns property completions in StyleArgList context", async () => {
+    const completionIndex = new CompletionIndex(
+      [],
+      [{ type: ContextScenarioType.StyleArgList, from: 10, to: 30 }],
+      [],
+    );
+    const source = createRendererPropertyCompletionSource(
+      completionIndex,
+      cytoscapeProperties,
+    );
+    // Cursor at position 15, typing "back" inside style block
+    const ctx = createMockContext(15, "func() { back", false);
+    const result = await runSource(source, ctx);
+    expect(result).not.toBeNull();
+    const labels = result!.options.map((o) => o.label);
+    expect(labels).toContain("background-color");
+    expect(labels).toContain("background-opacity");
+  });
+
+  test("filters by prefix", async () => {
+    const completionIndex = new CompletionIndex(
+      [],
+      [{ type: ContextScenarioType.StyleArgList, from: 10, to: 30 }],
+      [],
+    );
+    const source = createRendererPropertyCompletionSource(
+      completionIndex,
+      cytoscapeProperties,
+    );
+    const ctx = createMockContext(15, "func() { line-", false);
+    const result = await runSource(source, ctx);
+    expect(result).not.toBeNull();
+    const labels = result!.options.map((o) => o.label);
+    expect(labels).toContain("line-color");
+    expect(labels).toContain("line-style");
+  });
+
+  test("returns null outside StyleArgList context", async () => {
+    const completionIndex = new CompletionIndex(
+      [],
+      [{ type: ContextScenarioType.ValueName, from: 10, to: 30 }],
+      [],
+    );
+    const source = createRendererPropertyCompletionSource(
+      completionIndex,
+      cytoscapeProperties,
+    );
+    // No braces in text — neither style context nor fallback should match
+    const ctx = createMockContext(15, "func(back", false);
+    const result = await runSource(source, ctx);
+    expect(result).toBeNull();
+  });
+
+  test("returns null after # (style tag position)", async () => {
+    const completionIndex = new CompletionIndex(
+      [],
+      [{ type: ContextScenarioType.StyleArgList, from: 10, to: 30 }],
+      [],
+    );
+    const source = createRendererPropertyCompletionSource(
+      completionIndex,
+      cytoscapeProperties,
+    );
+    const ctx = createMockContext(15, "func() { #tag", false);
+    const result = await runSource(source, ctx);
+    expect(result).toBeNull();
+  });
+
+  test("returns null after : (property value position)", async () => {
+    const completionIndex = new CompletionIndex(
+      [],
+      [{ type: ContextScenarioType.StyleArgList, from: 10, to: 50 }],
+      [],
+    );
+    const source = createRendererPropertyCompletionSource(
+      completionIndex,
+      cytoscapeProperties,
+    );
+    const ctx = createMockContext(30, 'func() { background-color: "re', false);
+    const result = await runSource(source, ctx);
+    expect(result).toBeNull();
+  });
+
+  test("handles fallback path (inside { without registered context)", async () => {
+    const completionIndex = new CompletionIndex([], [], []);
+    const source = createRendererPropertyCompletionSource(
+      completionIndex,
+      cytoscapeProperties,
+    );
+    // Inside braces, after semicolon, typing a property name
+    const ctx = createMockContext(30, "func() { color: red; back", false);
+    const result = await runSource(source, ctx);
+    expect(result).not.toBeNull();
+    const labels = result!.options.map((o) => o.label);
+    expect(labels).toContain("background-color");
+  });
+
+  test("returns empty completions with empty property list", async () => {
+    const completionIndex = new CompletionIndex(
+      [],
+      [{ type: ContextScenarioType.StyleArgList, from: 10, to: 30 }],
+      [],
+    );
+    const source = createRendererPropertyCompletionSource(completionIndex, []);
+    const ctx = createMockContext(15, "func() { back", false);
+    const result = await runSource(source, ctx);
+    expect(result).toBeNull();
+  });
+});


### PR DESCRIPTION
This pull request adds context-aware autocompletion for renderer-specific style properties in the text editor, with an initial focus on Cytoscape renderer support. It introduces a registry of renderer property completions, a new completion source for property names in style contexts, and integrates these completions into the editor based on the selected renderer. Unit tests are included for both the property registry and the new completion logic.

**Renderer property autocompletion:**
* Adds a registry of Cytoscape renderer style properties and exposes a function `getRendererPropertyCompletions` to retrieve completions for a given renderer (`src/autocomplete/rendererProperties.ts`).
* Implements `createRendererPropertyCompletionSource`, a context-aware CodeMirror completion source that suggests property names only in style argument contexts, filtering by prefix and avoiding value positions (`src/autocomplete/rendererPropertyCompleter.ts`).

**Integration into the editor:**
* Updates `TextEditor.vue` to accept a `selectedRenderer` prop, and injects the appropriate renderer property completion source into CodeMirror's autocompletion pipeline whenever the renderer changes (`src/components/TextEditor.vue`).