### PR TITLE
feat: add tutorial level selection menu

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -54,8 +54,9 @@
   </splitpanes>
   <ToolBar
     id="toolbar"
-    v-model:tutorial-mode="tutorialMode"
+    :tutorial-mode="tutorialMode"
     :class="{ 'toolbar-debug': debugMode }"
+    @tutorial-clicked="onTutorialClicked"
     @open-export="showExportPopup = true"
     @open-options="showOptionsPopup = true"
     @copy-source="copySourceToClipboard"
@@ -71,6 +72,14 @@
     v-model:debug-mode="debugMode"
     v-model:selected-renderer="selectedRenderer"
     :renderer-options="rendererOptions"
+  />
+  <TutorialLevelSelect
+    v-model:show-dialog="showTutorialLevelSelect"
+    :modules="tutorialModules"
+    :highest-completed-index="tutorialHighestCompleted"
+    :module-start-indices="tutorialModuleStartIndices"
+    @select-puzzlet="onSelectPuzzlet"
+    @restart-tutorial="onRestartTutorial"
   />
   <ConfettiEffect ref="confettiEffect" />
 </template>
@@ -100,6 +109,7 @@ import { CompletionIndex } from "./autocomplete/autocompletion";
 import { createCompletionIndex } from "./autocomplete/autocompletionFactory";
 import { dumpImportTree } from "./compiler/importUtility";
 import { TutorialManager } from "./tutorial/tutorialManager";
+import TutorialLevelSelect from "./components/TutorialLevelSelect.vue";
 import { defaultCubic } from "./tutorial/defaultExample";
 // @ts-expect-error: remove once @types/splitpanes upgrades dependency to vue 3
 import { Splitpanes, Pane } from "splitpanes";
@@ -118,6 +128,7 @@ export default defineComponent({
     ConfettiEffect,
     ExportOptionsPopup,
     OptionsPopup,
+    TutorialLevelSelect,
   },
   data() {
     return {
@@ -141,6 +152,8 @@ export default defineComponent({
       tutorialMode: false,
       savedEditorText: "",
       tutorialManager: new TutorialManager(),
+      showTutorialLevelSelect: false,
+      tutorialStartIndex: null as number | null,
     };
   },
   computed: {
@@ -149,6 +162,15 @@ export default defineComponent({
         id,
         name: renderer.displayName,
       }));
+    },
+    tutorialModules() {
+      return this.tutorialManager.getLesson().getModules();
+    },
+    tutorialHighestCompleted(): number {
+      return this.tutorialManager.cachedHighestCompleted;
+    },
+    tutorialModuleStartIndices(): number[] {
+      return this.tutorialManager.getLesson().getAllModuleStartIndices();
     },
     supportedExportFormats(): readonly ExportFormat[] {
       return (
@@ -200,7 +222,12 @@ export default defineComponent({
       try {
         if (newVal) {
           this.savedEditorText = this.curEditorState.doc.toString();
-          this.tutorialManager.startTutorial();
+          if (this.tutorialStartIndex !== null) {
+            this.tutorialManager.startTutorialAt(this.tutorialStartIndex);
+            this.tutorialStartIndex = null;
+          } else {
+            this.tutorialManager.startTutorialAt(0);
+          }
         } else {
           this.tutorialManager.stopTutorial();
           const textEditor = this.$refs.textEditor as typeof TextEditor;
@@ -255,6 +282,25 @@ export default defineComponent({
     }) {
       const graphView = this.$refs.graphView as typeof GraphView;
       graphView.export(exportOptions);
+    },
+    onTutorialClicked() {
+      if (this.tutorialMode) {
+        this.tutorialMode = false;
+      } else if (this.tutorialManager.hasProgress()) {
+        this.showTutorialLevelSelect = true;
+      } else {
+        this.tutorialMode = true;
+      }
+    },
+    onSelectPuzzlet(puzzletIndex: number) {
+      this.showTutorialLevelSelect = false;
+      this.tutorialStartIndex = puzzletIndex;
+      this.tutorialMode = true;
+    },
+    onRestartTutorial() {
+      this.showTutorialLevelSelect = false;
+      this.tutorialManager.clearProgress();
+      this.tutorialMode = true;
     },
     async copySourceToClipboard() {
       try {

--- a/src/components/ToolBar.vue
+++ b/src/components/ToolBar.vue
@@ -3,11 +3,7 @@
     <img id="logo" src="/assets/formulavize_logo.svg" alt="Formulavize logo" />
     <h1>formulavize</h1>
     <v-btn-group density="comfortable">
-      <v-btn
-        icon
-        :active="tutorialMode"
-        @click="$emit('update:tutorialMode', !tutorialMode)"
-      >
+      <v-btn icon :active="tutorialMode" @click="$emit('tutorial-clicked')">
         <v-icon :icon="mdiSchoolOutline" />
         <v-tooltip activator="parent" text="Tutorial" location="bottom" />
       </v-btn>
@@ -60,7 +56,7 @@ export default defineComponent({
       default: false,
     },
   },
-  emits: ["open-export", "open-options", "copy-source", "update:tutorialMode"],
+  emits: ["open-export", "open-options", "copy-source", "tutorial-clicked"],
   setup() {
     return {
       mdiSchoolOutline,

--- a/src/components/TutorialLevelSelect.vue
+++ b/src/components/TutorialLevelSelect.vue
@@ -1,0 +1,159 @@
+<template>
+  <v-dialog
+    :model-value="showDialog"
+    persistent
+    max-width="500px"
+    @update:model-value="$emit('update:showDialog', $event)"
+  >
+    <v-card class="pa-4">
+      <v-card-title class="d-flex align-center">
+        <v-icon :icon="mdiSchoolOutline" class="mr-1" />
+        <span>Tutorial - Select Level</span>
+      </v-card-title>
+      <v-card-text class="py-2">
+        <v-expansion-panels variant="accordion">
+          <v-expansion-panel
+            v-for="(module, moduleIdx) in modules"
+            :key="moduleIdx"
+          >
+            <v-expansion-panel-title>
+              <div class="d-flex align-center justify-space-between w-100">
+                <span>{{ module.name }}</span>
+                <v-chip size="small" class="ml-2">
+                  {{ getModuleCompletedCount(moduleIdx) }}/{{
+                    module.puzzlets.length
+                  }}
+                </v-chip>
+              </div>
+            </v-expansion-panel-title>
+            <v-expansion-panel-text>
+              <v-list density="compact">
+                <v-list-item
+                  v-for="(puzzlet, puzzletIdx) in module.puzzlets"
+                  :key="puzzletIdx"
+                  :disabled="!isPuzzletSelectable(moduleIdx, puzzletIdx)"
+                  :class="{
+                    'bg-blue-lighten-5':
+                      getFlatIndex(moduleIdx, puzzletIdx) === resumeIndex,
+                  }"
+                  @click="onPuzzletClick(moduleIdx, puzzletIdx)"
+                >
+                  <template #prepend>
+                    <v-icon
+                      :icon="
+                        isPuzzletCompleted(moduleIdx, puzzletIdx)
+                          ? mdiCheckCircle
+                          : mdiCircleOutline
+                      "
+                      :color="
+                        isPuzzletCompleted(moduleIdx, puzzletIdx)
+                          ? 'green'
+                          : 'grey'
+                      "
+                      size="small"
+                    />
+                  </template>
+                  <v-list-item-title>{{ puzzlet.name }}</v-list-item-title>
+                </v-list-item>
+              </v-list>
+            </v-expansion-panel-text>
+          </v-expansion-panel>
+        </v-expansion-panels>
+      </v-card-text>
+      <v-card-actions>
+        <v-btn @click="$emit('restart-tutorial')">
+          <v-icon :icon="mdiRestart" class="mr-1" />
+          <span>Reset Progress</span>
+        </v-btn>
+        <v-spacer />
+        <v-btn @click="$emit('update:showDialog', false)">
+          <v-icon :icon="mdiCloseCircleOutline" class="mr-1" />
+          <span>Close</span>
+        </v-btn>
+      </v-card-actions>
+    </v-card>
+  </v-dialog>
+</template>
+
+<script lang="ts">
+import { defineComponent, PropType } from "vue";
+import {
+  mdiSchoolOutline,
+  mdiCheckCircle,
+  mdiCircleOutline,
+  mdiCloseCircleOutline,
+  mdiRestart,
+} from "@mdi/js";
+import { LudicModule } from "../tutorial/lesson";
+
+export default defineComponent({
+  name: "TutorialLevelSelect",
+  props: {
+    showDialog: {
+      type: Boolean,
+      required: true,
+    },
+    modules: {
+      type: Array as PropType<readonly LudicModule[]>,
+      required: true,
+    },
+    highestCompletedIndex: {
+      type: Number,
+      required: true,
+    },
+    moduleStartIndices: {
+      type: Array as PropType<number[]>,
+      required: true,
+    },
+  },
+  emits: ["update:showDialog", "select-puzzlet", "restart-tutorial"],
+  setup() {
+    return {
+      mdiSchoolOutline,
+      mdiCheckCircle,
+      mdiCircleOutline,
+      mdiCloseCircleOutline,
+      mdiRestart,
+    };
+  },
+  computed: {
+    resumeIndex(): number {
+      return this.highestCompletedIndex + 1;
+    },
+  },
+  methods: {
+    getFlatIndex(moduleIdx: number, puzzletIdx: number): number {
+      return this.moduleStartIndices[moduleIdx] + puzzletIdx;
+    },
+    isPuzzletCompleted(moduleIdx: number, puzzletIdx: number): boolean {
+      return (
+        this.getFlatIndex(moduleIdx, puzzletIdx) <= this.highestCompletedIndex
+      );
+    },
+    isPuzzletSelectable(moduleIdx: number, puzzletIdx: number): boolean {
+      const flatIdx = this.getFlatIndex(moduleIdx, puzzletIdx);
+      return flatIdx <= this.highestCompletedIndex + 1;
+    },
+    getModuleCompletedCount(moduleIdx: number): number {
+      const module = this.modules[moduleIdx];
+      let count = 0;
+      for (let i = 0; i < module.puzzlets.length; i++) {
+        if (this.isPuzzletCompleted(moduleIdx, i)) {
+          count++;
+        }
+      }
+      return count;
+    },
+    onPuzzletClick(moduleIdx: number, puzzletIdx: number): void {
+      if (!this.isPuzzletSelectable(moduleIdx, puzzletIdx)) return;
+      this.$emit("select-puzzlet", this.getFlatIndex(moduleIdx, puzzletIdx));
+    },
+  },
+});
+</script>
+
+<style scoped>
+.w-100 {
+  width: 100%;
+}
+</style>

--- a/src/tutorial/lesson.ts
+++ b/src/tutorial/lesson.ts
@@ -76,4 +76,25 @@ export class Lesson {
   public reset(): void {
     this.currentPuzzletIndex = 0;
   }
+
+  public jumpTo(puzzletIndex: number): void {
+    this.currentPuzzletIndex = Math.max(
+      0,
+      Math.min(puzzletIndex, this.flattenedPuzzlets.length - 1),
+    );
+  }
+
+  public getModules(): readonly LudicModule[] {
+    return this.modules;
+  }
+
+  public getAllModuleStartIndices(): number[] {
+    const startIndices: number[] = [];
+    let runningTotal = 0;
+    for (const module of this.modules) {
+      startIndices.push(runningTotal);
+      runningTotal += module.puzzlets.length;
+    }
+    return startIndices;
+  }
 }

--- a/src/tutorial/tutorialManager.ts
+++ b/src/tutorial/tutorialManager.ts
@@ -1,6 +1,7 @@
 import { Lesson, Puzzlet } from "./lesson";
 import { createFizLesson } from "./fiz/lessonPlan";
 import { Compilation } from "../compiler/compilation";
+import { TutorialProgressStore } from "./tutorialProgressStore";
 
 export class TutorialManager {
   private callbacks: {
@@ -23,6 +24,12 @@ export class TutorialManager {
   private isAdvancing: boolean = false;
   private tutorialActive: boolean = false;
   private disableAnimations: boolean = false;
+  private progressStore: TutorialProgressStore = new TutorialProgressStore();
+  public cachedHighestCompleted: number;
+
+  constructor() {
+    this.cachedHighestCompleted = this.progressStore.getHighestCompletedIndex();
+  }
 
   public setCallbacks(
     setEditorText: (text: string) => void,
@@ -56,7 +63,7 @@ export class TutorialManager {
     this.callbacks.setExamplesText?.(text);
   }
 
-  public startTutorial(): void {
+  public startTutorialAt(puzzletIndex: number): void {
     if (
       !this.callbacks.setEditorText ||
       !this.callbacks.setTutorialHeaderText ||
@@ -65,11 +72,10 @@ export class TutorialManager {
       console.warn("Text editor callbacks not set. Cannot start tutorial.");
       return;
     }
-    this.currentLesson.reset();
+    this.currentLesson.jumpTo(puzzletIndex);
     this.tutorialActive = true;
     this.setEditorText("");
-    const firstPuzzlet = this.currentLesson.getCurrentPuzzlet();
-    this.animatePuzzlet(firstPuzzlet);
+    this.animatePuzzlet(this.currentLesson.getCurrentPuzzlet());
   }
 
   public stopTutorial(): void {
@@ -84,6 +90,10 @@ export class TutorialManager {
     try {
       await this.delay(500); // Small delay before advancing to allow user to see the successful change
       if (!this.tutorialActive) return;
+      const completedIndex = this.currentLesson.getCurrentPuzzletIndex();
+      this.progressStore.markCompleted(completedIndex);
+      this.cachedHighestCompleted =
+        this.progressStore.getHighestCompletedIndex();
       this.currentLesson.advance();
       // Exit tutorial mode when the lesson is complete
       if (this.currentLesson.isComplete()) {
@@ -173,5 +183,22 @@ export class TutorialManager {
       clearTimeout(this.animationHandle);
       this.animationHandle = null;
     }
+  }
+
+  public hasProgress(): boolean {
+    return this.cachedHighestCompleted >= 0;
+  }
+
+  public getHighestCompletedIndex(): number {
+    return this.cachedHighestCompleted;
+  }
+
+  public getLesson(): Lesson {
+    return this.currentLesson;
+  }
+
+  public clearProgress(): void {
+    this.progressStore.clearProgress();
+    this.cachedHighestCompleted = -1;
   }
 }

--- a/src/tutorial/tutorialProgressStore.ts
+++ b/src/tutorial/tutorialProgressStore.ts
@@ -1,0 +1,59 @@
+interface StoredProgress {
+  version: number;
+  highestCompleted: number;
+}
+
+export class TutorialProgressStore {
+  private static readonly STORAGE_KEY = "formulavize-tutorial-progress";
+  private static readonly VERSION = 1;
+
+  getHighestCompletedIndex(): number {
+    const data = this.load();
+    return data ? data.highestCompleted : -1;
+  }
+
+  markCompleted(puzzletIndex: number): void {
+    const current = this.getHighestCompletedIndex();
+    if (puzzletIndex > current) {
+      this.save({ highestCompleted: puzzletIndex });
+    }
+  }
+
+  hasProgress(): boolean {
+    return this.getHighestCompletedIndex() >= 0;
+  }
+
+  clearProgress(): void {
+    try {
+      localStorage.removeItem(TutorialProgressStore.STORAGE_KEY);
+    } catch {
+      console.warn("Unable to clear tutorial progress from localStorage");
+    }
+  }
+
+  private load(): StoredProgress | null {
+    try {
+      const raw = localStorage.getItem(TutorialProgressStore.STORAGE_KEY);
+      if (!raw) return null;
+      const parsed = JSON.parse(raw) as StoredProgress;
+      if (parsed.version !== TutorialProgressStore.VERSION) return null;
+      return parsed;
+    } catch {
+      return null;
+    }
+  }
+
+  private save(data: Omit<StoredProgress, "version">): void {
+    try {
+      localStorage.setItem(
+        TutorialProgressStore.STORAGE_KEY,
+        JSON.stringify({
+          version: TutorialProgressStore.VERSION,
+          ...data,
+        }),
+      );
+    } catch {
+      console.warn("Unable to save tutorial progress to localStorage");
+    }
+  }
+}

--- a/tests/unit/tutorial/lesson.test.ts
+++ b/tests/unit/tutorial/lesson.test.ts
@@ -1,0 +1,182 @@
+import { describe, test, expect } from "vitest";
+import { Lesson, LudicModule, Puzzlet } from "src/tutorial/lesson";
+import { Compilation } from "src/compiler/compilation";
+
+function makePuzzlet(name: string, isSuccessful = false): Puzzlet {
+  return {
+    name,
+    instructions: [{ text: "do something", typingSpeedDelayMs: 0 }],
+    examples: [{ text: "example", typingSpeedDelayMs: 0 }],
+    successCondition: () => isSuccessful,
+  };
+}
+
+function makeModule(name: string, puzzletNames: string[]): LudicModule {
+  return { name, puzzlets: puzzletNames.map((n) => makePuzzlet(n)) };
+}
+
+function makeLesson(modules: LudicModule[]): Lesson {
+  return new Lesson("Test Lesson", modules);
+}
+
+describe("Lesson", () => {
+  const moduleA = makeModule("ModA", ["p1", "p2", "p3"]);
+  const moduleB = makeModule("ModB", ["p4", "p5"]);
+  const moduleC = makeModule("ModC", ["p6"]);
+
+  describe("basic properties", () => {
+    test("name is set", () => {
+      const lesson = makeLesson([moduleA]);
+      expect(lesson.Name).toBe("Test Lesson");
+    });
+
+    test("getNumPuzzlets returns total across all modules", () => {
+      const lesson = makeLesson([moduleA, moduleB, moduleC]);
+      expect(lesson.getNumPuzzlets()).toBe(6);
+    });
+
+    test("getModules returns all modules", () => {
+      const lesson = makeLesson([moduleA, moduleB]);
+      expect(lesson.getModules()).toEqual([moduleA, moduleB]);
+    });
+
+    test("starts at index 0", () => {
+      const lesson = makeLesson([moduleA]);
+      expect(lesson.getCurrentPuzzletIndex()).toBe(0);
+    });
+  });
+
+  describe("advance", () => {
+    test("increments puzzlet index", () => {
+      const lesson = makeLesson([moduleA, moduleB]);
+      expect(lesson.getCurrentPuzzletIndex()).toBe(0);
+      lesson.advance();
+      expect(lesson.getCurrentPuzzletIndex()).toBe(1);
+    });
+
+    test("advances across module boundaries", () => {
+      const lesson = makeLesson([moduleA, moduleB]);
+      // Advance through all of moduleA (3 puzzlets)
+      lesson.advance();
+      lesson.advance();
+      lesson.advance();
+      expect(lesson.getCurrentPuzzletIndex()).toBe(3);
+      expect(lesson.getCurrentModule().name).toBe("ModB");
+      expect(lesson.getCurrentPuzzlet().name).toBe("p4");
+    });
+
+    test("returns false when already complete", () => {
+      const lesson = makeLesson([makeModule("M", ["only"])]);
+      lesson.advance();
+      expect(lesson.isComplete()).toBe(true);
+      expect(lesson.advance()).toBe(false);
+    });
+  });
+
+  describe("isComplete", () => {
+    test("not complete at start", () => {
+      const lesson = makeLesson([moduleA]);
+      expect(lesson.isComplete()).toBe(false);
+    });
+
+    test("complete after all puzzlets advanced", () => {
+      const lesson = makeLesson([makeModule("M", ["a", "b"])]);
+      lesson.advance();
+      lesson.advance();
+      expect(lesson.isComplete()).toBe(true);
+    });
+  });
+
+  describe("reset", () => {
+    test("resets to index 0", () => {
+      const lesson = makeLesson([moduleA]);
+      lesson.advance();
+      lesson.advance();
+      lesson.reset();
+      expect(lesson.getCurrentPuzzletIndex()).toBe(0);
+      expect(lesson.getCurrentPuzzlet().name).toBe("p1");
+    });
+  });
+
+  describe("jumpTo", () => {
+    test("jumps to a specific index", () => {
+      const lesson = makeLesson([moduleA, moduleB]);
+      lesson.jumpTo(3);
+      expect(lesson.getCurrentPuzzletIndex()).toBe(3);
+      expect(lesson.getCurrentPuzzlet().name).toBe("p4");
+    });
+
+    test("clamps to 0 for negative index", () => {
+      const lesson = makeLesson([moduleA]);
+      lesson.jumpTo(-5);
+      expect(lesson.getCurrentPuzzletIndex()).toBe(0);
+    });
+
+    test("clamps to last index for out-of-bounds", () => {
+      const lesson = makeLesson([moduleA, moduleB]);
+      lesson.jumpTo(100);
+      expect(lesson.getCurrentPuzzletIndex()).toBe(4);
+      expect(lesson.getCurrentPuzzlet().name).toBe("p5");
+    });
+  });
+
+  describe("getCurrentModule", () => {
+    test("returns correct module for each puzzlet", () => {
+      const lesson = makeLesson([moduleA, moduleB, moduleC]);
+      expect(lesson.getCurrentModule().name).toBe("ModA");
+      lesson.jumpTo(3);
+      expect(lesson.getCurrentModule().name).toBe("ModB");
+      lesson.jumpTo(5);
+      expect(lesson.getCurrentModule().name).toBe("ModC");
+    });
+  });
+
+  describe("canAdvance", () => {
+    test("returns false when success condition fails", () => {
+      const lesson = makeLesson([makeModule("M", ["p"])]);
+      const compilation = {} as Compilation;
+      expect(lesson.canAdvance(compilation)).toBe(false);
+    });
+
+    test("returns true when success condition passes", () => {
+      const alwaysPass: Puzzlet = {
+        name: "pass",
+        instructions: [],
+        examples: [],
+        successCondition: () => true,
+      };
+      const lesson = new Lesson("L", [{ name: "M", puzzlets: [alwaysPass] }]);
+      const compilation = {} as Compilation;
+      expect(lesson.canAdvance(compilation)).toBe(true);
+    });
+
+    test("returns false when lesson is complete", () => {
+      const alwaysPass: Puzzlet = {
+        name: "pass",
+        instructions: [],
+        examples: [],
+        successCondition: () => true,
+      };
+      const lesson = new Lesson("L", [{ name: "M", puzzlets: [alwaysPass] }]);
+      lesson.advance();
+      expect(lesson.canAdvance({} as Compilation)).toBe(false);
+    });
+  });
+
+  describe("getAllModuleStartIndices", () => {
+    test("returns correct start indices", () => {
+      const lesson = makeLesson([moduleA, moduleB, moduleC]);
+      expect(lesson.getAllModuleStartIndices()).toEqual([0, 3, 5]);
+    });
+
+    test("single module starts at 0", () => {
+      const lesson = makeLesson([moduleA]);
+      expect(lesson.getAllModuleStartIndices()).toEqual([0]);
+    });
+
+    test("empty modules list returns empty array", () => {
+      const lesson = makeLesson([]);
+      expect(lesson.getAllModuleStartIndices()).toEqual([]);
+    });
+  });
+});

--- a/tests/unit/tutorial/tutorialManager.test.ts
+++ b/tests/unit/tutorial/tutorialManager.test.ts
@@ -1,0 +1,121 @@
+import { describe, test, expect, beforeEach, afterEach, vi } from "vitest";
+import { TutorialManager } from "src/tutorial/tutorialManager";
+
+const STORAGE_KEY = "formulavize-tutorial-progress";
+
+function createMockLocalStorage(): Storage {
+  const store = new Map<string, string>();
+  return {
+    getItem: (key: string) => store.get(key) ?? null,
+    setItem: (key: string, value: string) => store.set(key, value),
+    removeItem: (key: string) => store.delete(key),
+    clear: () => store.clear(),
+    get length() {
+      return store.size;
+    },
+    key: (index: number) => [...store.keys()][index] ?? null,
+  };
+}
+
+function setupManager(): {
+  manager: TutorialManager;
+  editorText: { value: string };
+  headerText: { value: string };
+  examplesText: { value: string };
+  onComplete: ReturnType<typeof vi.fn>;
+} {
+  const manager = new TutorialManager();
+  manager.setDisableAnimations(true);
+  const editorText = { value: "" };
+  const headerText = { value: "" };
+  const examplesText = { value: "" };
+  const onComplete = vi.fn();
+  manager.setCallbacks(
+    (t) => (editorText.value = t),
+    (t) => (headerText.value = t),
+    (t) => (examplesText.value = t),
+    onComplete,
+  );
+  return { manager, editorText, headerText, examplesText, onComplete };
+}
+
+describe("TutorialManager", () => {
+  let mockStorage: Storage;
+
+  beforeEach(() => {
+    mockStorage = createMockLocalStorage();
+    vi.stubGlobal("localStorage", mockStorage);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  describe("initial state", () => {
+    test("has no progress initially", () => {
+      const { manager } = setupManager();
+      expect(manager.hasProgress()).toBe(false);
+      expect(manager.getHighestCompletedIndex()).toBe(-1);
+    });
+
+    test("loads existing progress from localStorage", () => {
+      mockStorage.setItem(
+        STORAGE_KEY,
+        JSON.stringify({ version: 1, highestCompleted: 3 }),
+      );
+      const manager = new TutorialManager();
+      expect(manager.hasProgress()).toBe(true);
+      expect(manager.getHighestCompletedIndex()).toBe(3);
+      expect(manager.cachedHighestCompleted).toBe(3);
+    });
+  });
+
+  describe("startTutorialAt", () => {
+    test("starts at a specific puzzlet index", () => {
+      const { manager, headerText } = setupManager();
+      manager.startTutorialAt(2);
+      const lesson = manager.getLesson();
+      expect(lesson.getCurrentPuzzletIndex()).toBe(2);
+      expect(headerText.value).not.toBe("");
+    });
+
+    test("clears editor on start", () => {
+      const { manager, editorText } = setupManager();
+      editorText.value = "existing code";
+      manager.startTutorialAt(0);
+      expect(editorText.value).toBe("");
+    });
+
+    test("does nothing without callbacks", () => {
+      const manager = new TutorialManager();
+      // Should not throw
+      manager.startTutorialAt(0);
+    });
+  });
+
+  describe("progress tracking", () => {
+    test("clearProgress resets cached value and localStorage", () => {
+      mockStorage.setItem(
+        STORAGE_KEY,
+        JSON.stringify({ version: 1, highestCompleted: 5 }),
+      );
+      const manager = new TutorialManager();
+      expect(manager.cachedHighestCompleted).toBe(5);
+
+      manager.clearProgress();
+      expect(manager.hasProgress()).toBe(false);
+      expect(manager.cachedHighestCompleted).toBe(-1);
+      expect(mockStorage.getItem(STORAGE_KEY)).toBeNull();
+    });
+  });
+
+  describe("stopTutorial", () => {
+    test("stops an active tutorial", () => {
+      const { manager } = setupManager();
+      manager.startTutorialAt(0);
+      manager.stopTutorial();
+      // Starting again should work without error
+      manager.startTutorialAt(0);
+    });
+  });
+});

--- a/tests/unit/tutorial/tutorialProgressStore.test.ts
+++ b/tests/unit/tutorial/tutorialProgressStore.test.ts
@@ -1,0 +1,110 @@
+import { describe, test, expect, beforeEach, afterEach, vi } from "vitest";
+import { TutorialProgressStore } from "src/tutorial/tutorialProgressStore";
+
+const STORAGE_KEY = "formulavize-tutorial-progress";
+
+function createMockLocalStorage(): Storage {
+  const store = new Map<string, string>();
+  return {
+    getItem: (key: string) => store.get(key) ?? null,
+    setItem: (key: string, value: string) => store.set(key, value),
+    removeItem: (key: string) => store.delete(key),
+    clear: () => store.clear(),
+    get length() {
+      return store.size;
+    },
+    key: (index: number) => [...store.keys()][index] ?? null,
+  };
+}
+
+describe("TutorialProgressStore", () => {
+  let mockStorage: Storage;
+
+  beforeEach(() => {
+    mockStorage = createMockLocalStorage();
+    vi.stubGlobal("localStorage", mockStorage);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  describe("initial state", () => {
+    test("returns -1 when no progress exists", () => {
+      const store = new TutorialProgressStore();
+      expect(store.getHighestCompletedIndex()).toBe(-1);
+    });
+
+    test("hasProgress returns false with no progress", () => {
+      const store = new TutorialProgressStore();
+      expect(store.hasProgress()).toBe(false);
+    });
+  });
+
+  describe("markCompleted", () => {
+    test("stores progress", () => {
+      const store = new TutorialProgressStore();
+      store.markCompleted(0);
+      expect(store.getHighestCompletedIndex()).toBe(0);
+      expect(store.hasProgress()).toBe(true);
+    });
+
+    test("updates when new index is higher", () => {
+      const store = new TutorialProgressStore();
+      store.markCompleted(2);
+      store.markCompleted(5);
+      expect(store.getHighestCompletedIndex()).toBe(5);
+    });
+
+    test("does not regress when new index is lower", () => {
+      const store = new TutorialProgressStore();
+      store.markCompleted(5);
+      store.markCompleted(2);
+      expect(store.getHighestCompletedIndex()).toBe(5);
+    });
+
+    test("persists across instances", () => {
+      const store1 = new TutorialProgressStore();
+      store1.markCompleted(3);
+
+      const store2 = new TutorialProgressStore();
+      expect(store2.getHighestCompletedIndex()).toBe(3);
+    });
+  });
+
+  describe("clearProgress", () => {
+    test("removes all progress", () => {
+      const store = new TutorialProgressStore();
+      store.markCompleted(5);
+      store.clearProgress();
+      expect(store.getHighestCompletedIndex()).toBe(-1);
+      expect(store.hasProgress()).toBe(false);
+    });
+
+    test("cleared progress is not seen by new instances", () => {
+      const store1 = new TutorialProgressStore();
+      store1.markCompleted(3);
+      store1.clearProgress();
+
+      const store2 = new TutorialProgressStore();
+      expect(store2.hasProgress()).toBe(false);
+    });
+  });
+
+  describe("version handling", () => {
+    test("ignores data with mismatched version", () => {
+      mockStorage.setItem(
+        STORAGE_KEY,
+        JSON.stringify({ version: 999, highestCompleted: 10 }),
+      );
+      const store = new TutorialProgressStore();
+      expect(store.getHighestCompletedIndex()).toBe(-1);
+    });
+
+    test("ignores corrupted data", () => {
+      mockStorage.setItem(STORAGE_KEY, "not valid json");
+      const store = new TutorialProgressStore();
+      expect(store.getHighestCompletedIndex()).toBe(-1);
+    });
+  });
+});


### PR DESCRIPTION
This pull request introduces a new tutorial level selection dialog and persistent tutorial progress tracking that allows users to resume or restart tutorials and select specific levels. It also refactors the tutorial activation flow and simplifies the toolbar interaction. The most important changes are grouped below:

**Tutorial Progress Persistence and Management:**

* Added a new `TutorialProgressStore` class to persist the highest completed tutorial level in `localStorage`, allowing users to resume progress across sessions.
* Updated `TutorialManager` to use `TutorialProgressStore`, caching and updating the highest completed index, and exposing methods to check, clear, and retrieve progress. [[1]](diffhunk://#diff-4b3d323023761be9ce8c1371f84926437922d6465309db5a206f7491510fff3cR4) [[2]](diffhunk://#diff-4b3d323023761be9ce8c1371f84926437922d6465309db5a206f7491510fff3cR27-R32) [[3]](diffhunk://#diff-4b3d323023761be9ce8c1371f84926437922d6465309db5a206f7491510fff3cR93-R96) [[4]](diffhunk://#diff-4b3d323023761be9ce8c1371f84926437922d6465309db5a206f7491510fff3cR187-R203)

**Tutorial Level Selection Dialog:**

* Introduced the `TutorialLevelSelect` component, which displays modules and puzzlets, allows selection of accessible levels, and provides a reset progress option.
* Integrated `TutorialLevelSelect` into `App.vue`, wiring up dialog visibility, data, and event handlers for selecting and restarting tutorial levels. [[1]](diffhunk://#diff-7a7a37b12ee1265d7e27577ec286120d2cbc0940908635e264a2be44ccb9a8a0R112) [[2]](diffhunk://#diff-7a7a37b12ee1265d7e27577ec286120d2cbc0940908635e264a2be44ccb9a8a0R131) [[3]](diffhunk://#diff-7a7a37b12ee1265d7e27577ec286120d2cbc0940908635e264a2be44ccb9a8a0R155-R156) [[4]](diffhunk://#diff-7a7a37b12ee1265d7e27577ec286120d2cbc0940908635e264a2be44ccb9a8a0R166-R174) [[5]](diffhunk://#diff-7a7a37b12ee1265d7e27577ec286120d2cbc0940908635e264a2be44ccb9a8a0R76-R83) [[6]](diffhunk://#diff-7a7a37b12ee1265d7e27577ec286120d2cbc0940908635e264a2be44ccb9a8a0R286-R304)

**Tutorial Activation Flow and Toolbar Interaction:**

* Refactored tutorial activation: now, clicking the tutorial button either toggles the mode, opens the level selection dialog if progress exists, or starts from the beginning. [[1]](diffhunk://#diff-7a7a37b12ee1265d7e27577ec286120d2cbc0940908635e264a2be44ccb9a8a0L57-R59) [[2]](diffhunk://#diff-7a7a37b12ee1265d7e27577ec286120d2cbc0940908635e264a2be44ccb9a8a0L203-R230) [[3]](diffhunk://#diff-7a7a37b12ee1265d7e27577ec286120d2cbc0940908635e264a2be44ccb9a8a0R286-R304)
* Updated `ToolBar.vue` to emit a new `tutorial-clicked` event instead of directly toggling tutorial mode, delegating control to the parent component. [[1]](diffhunk://#diff-4f6c5295f8029f17f09d3c25993884e16b34e4e9222dc5f9a5f97f1a8515508cL6-R6) [[2]](diffhunk://#diff-4f6c5295f8029f17f09d3c25993884e16b34e4e9222dc5f9a5f97f1a8515508cL63-R59)

**Lesson and Module Utilities:**

* Added methods to the `Lesson` class to jump to a specific puzzlet, retrieve modules, and get start indices for modules, supporting the level selection dialog.
* Changed `TutorialManager.startTutorial()` to `startTutorialAt(puzzletIndex)`, enabling starting tutorials from any puzzlet index. [[1]](diffhunk://#diff-4b3d323023761be9ce8c1371f84926437922d6465309db5a206f7491510fff3cL59-R66) [[2]](diffhunk://#diff-4b3d323023761be9ce8c1371f84926437922d6465309db5a206f7491510fff3cL68-R78)