### PR TITLE
feat: persist user selected options between sessions

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -108,6 +108,7 @@ import { errorToDiagnostic, ErrorReporter } from "./compiler/errorReporter";
 import { CompletionIndex } from "./autocomplete/autocompletion";
 import { createCompletionIndex } from "./autocomplete/autocompletionFactory";
 import { dumpImportTree } from "./compiler/importUtility";
+import { OptionsStore } from "./optionsStore";
 import { TutorialManager } from "./tutorial/tutorialManager";
 import TutorialLevelSelect from "./components/TutorialLevelSelect.vue";
 import { defaultCubic } from "./tutorial/defaultExample";
@@ -134,6 +135,7 @@ export default defineComponent({
     return {
       debugMode: false,
       editorDebounceDelay: 300, // ms
+      optionsStore: new OptionsStore(),
       compiler: new Compiler(),
       curEditorState: EditorState.create(),
       curAst: new RecipeTreeNode(),
@@ -205,9 +207,13 @@ export default defineComponent({
         this.tutorialManager.onCompilation(curCompilation);
       }
     },
+    tabToIndent() {
+      this.persistOptions();
+    },
     debugMode(newVal: boolean) {
       this.tutorialManager.setDisableAnimations(newVal);
       this.repaint(); // repaint the conditionally rendered GraphView
+      this.persistOptions();
     },
     selectedRenderer(newRendererId: string) {
       const renderer = this.registeredRenderers.get(newRendererId);
@@ -217,6 +223,7 @@ export default defineComponent({
       } else {
         console.error(`Renderer with id "${newRendererId}" not found`);
       }
+      this.persistOptions();
     },
     tutorialMode(newVal: boolean) {
       try {
@@ -248,6 +255,11 @@ export default defineComponent({
       "minimal",
       markRaw(MinimalExampleRenderer) as RendererComponent,
     );
+
+    const savedOptions = this.optionsStore.load();
+    this.tabToIndent = savedOptions.tabToIndent;
+    this.debugMode = savedOptions.debugMode;
+    this.selectedRenderer = savedOptions.selectedRenderer;
     const textEditor = this.$refs.textEditor as typeof TextEditor;
     const confettiEffect = this.$refs.confettiEffect as typeof ConfettiEffect;
     this.tutorialManager.setCallbacks(
@@ -265,6 +277,13 @@ export default defineComponent({
     textEditor?.setEditorText(defaultCubic);
   },
   methods: {
+    persistOptions() {
+      this.optionsStore.save({
+        tabToIndent: this.tabToIndent,
+        debugMode: this.debugMode,
+        selectedRenderer: this.selectedRenderer,
+      });
+    },
     repaint() {
       const existingEditorState = cloneDeep(this.curEditorState);
       this.updateEditorState(existingEditorState as EditorState);

--- a/src/optionsStore.ts
+++ b/src/optionsStore.ts
@@ -1,9 +1,4 @@
-interface StoredOptions {
-  version: number;
-  tabToIndent: boolean;
-  debugMode: boolean;
-  selectedRenderer: string;
-}
+import { VersionedStore } from "./versionedStore";
 
 export interface Options {
   tabToIndent: boolean;
@@ -17,37 +12,8 @@ const DEFAULTS: Options = {
   selectedRenderer: "cytoscape",
 };
 
-export class OptionsStore {
-  private static readonly STORAGE_KEY = "formulavize-options";
-  private static readonly VERSION = 1;
-
-  load(): Options {
-    try {
-      const raw = localStorage.getItem(OptionsStore.STORAGE_KEY);
-      if (!raw) return DEFAULTS;
-      const parsed = JSON.parse(raw) as StoredOptions;
-      if (parsed.version !== OptionsStore.VERSION) return DEFAULTS;
-      return {
-        tabToIndent: parsed.tabToIndent,
-        debugMode: parsed.debugMode,
-        selectedRenderer: parsed.selectedRenderer,
-      };
-    } catch {
-      return DEFAULTS;
-    }
-  }
-
-  save(options: Options): void {
-    try {
-      localStorage.setItem(
-        OptionsStore.STORAGE_KEY,
-        JSON.stringify({
-          version: OptionsStore.VERSION,
-          ...options,
-        }),
-      );
-    } catch {
-      console.warn("Unable to save options to localStorage");
-    }
+export class OptionsStore extends VersionedStore<Options> {
+  constructor() {
+    super("formulavize-options", 1, DEFAULTS);
   }
 }

--- a/src/optionsStore.ts
+++ b/src/optionsStore.ts
@@ -1,0 +1,53 @@
+interface StoredOptions {
+  version: number;
+  tabToIndent: boolean;
+  debugMode: boolean;
+  selectedRenderer: string;
+}
+
+export interface Options {
+  tabToIndent: boolean;
+  debugMode: boolean;
+  selectedRenderer: string;
+}
+
+const DEFAULTS: Options = {
+  tabToIndent: false,
+  debugMode: false,
+  selectedRenderer: "cytoscape",
+};
+
+export class OptionsStore {
+  private static readonly STORAGE_KEY = "formulavize-options";
+  private static readonly VERSION = 1;
+
+  load(): Options {
+    try {
+      const raw = localStorage.getItem(OptionsStore.STORAGE_KEY);
+      if (!raw) return DEFAULTS;
+      const parsed = JSON.parse(raw) as StoredOptions;
+      if (parsed.version !== OptionsStore.VERSION) return DEFAULTS;
+      return {
+        tabToIndent: parsed.tabToIndent,
+        debugMode: parsed.debugMode,
+        selectedRenderer: parsed.selectedRenderer,
+      };
+    } catch {
+      return DEFAULTS;
+    }
+  }
+
+  save(options: Options): void {
+    try {
+      localStorage.setItem(
+        OptionsStore.STORAGE_KEY,
+        JSON.stringify({
+          version: OptionsStore.VERSION,
+          ...options,
+        }),
+      );
+    } catch {
+      console.warn("Unable to save options to localStorage");
+    }
+  }
+}

--- a/src/tutorial/tutorialProgressStore.ts
+++ b/src/tutorial/tutorialProgressStore.ts
@@ -1,15 +1,26 @@
-interface StoredProgress {
-  version: number;
+import { VersionedStore } from "../versionedStore";
+
+interface TutorialProgress {
   highestCompleted: number;
 }
 
-export class TutorialProgressStore {
-  private static readonly STORAGE_KEY = "formulavize-tutorial-progress";
-  private static readonly VERSION = 1;
+const DEFAULTS: TutorialProgress = {
+  highestCompleted: -1,
+};
+
+export class TutorialProgressStore extends VersionedStore<TutorialProgress> {
+  constructor() {
+    super("formulavize-tutorial-progress", 1, DEFAULTS);
+  }
+
+  protected extract(
+    parsed: { version: number } & TutorialProgress,
+  ): TutorialProgress {
+    return { highestCompleted: parsed.highestCompleted };
+  }
 
   getHighestCompletedIndex(): number {
-    const data = this.load();
-    return data ? data.highestCompleted : -1;
+    return this.load().highestCompleted;
   }
 
   markCompleted(puzzletIndex: number): void {
@@ -24,36 +35,6 @@ export class TutorialProgressStore {
   }
 
   clearProgress(): void {
-    try {
-      localStorage.removeItem(TutorialProgressStore.STORAGE_KEY);
-    } catch {
-      console.warn("Unable to clear tutorial progress from localStorage");
-    }
-  }
-
-  private load(): StoredProgress | null {
-    try {
-      const raw = localStorage.getItem(TutorialProgressStore.STORAGE_KEY);
-      if (!raw) return null;
-      const parsed = JSON.parse(raw) as StoredProgress;
-      if (parsed.version !== TutorialProgressStore.VERSION) return null;
-      return parsed;
-    } catch {
-      return null;
-    }
-  }
-
-  private save(data: Omit<StoredProgress, "version">): void {
-    try {
-      localStorage.setItem(
-        TutorialProgressStore.STORAGE_KEY,
-        JSON.stringify({
-          version: TutorialProgressStore.VERSION,
-          ...data,
-        }),
-      );
-    } catch {
-      console.warn("Unable to save tutorial progress to localStorage");
-    }
+    this.clear();
   }
 }

--- a/src/tutorial/tutorialProgressStore.ts
+++ b/src/tutorial/tutorialProgressStore.ts
@@ -13,12 +13,6 @@ export class TutorialProgressStore extends VersionedStore<TutorialProgress> {
     super("formulavize-tutorial-progress", 1, DEFAULTS);
   }
 
-  protected extract(
-    parsed: { version: number } & TutorialProgress,
-  ): TutorialProgress {
-    return { highestCompleted: parsed.highestCompleted };
-  }
-
   getHighestCompletedIndex(): number {
     return this.load().highestCompleted;
   }

--- a/src/versionedStore.ts
+++ b/src/versionedStore.ts
@@ -1,0 +1,39 @@
+export class VersionedStore<T> {
+  constructor(
+    private readonly storageKey: string,
+    private readonly version: number,
+    private readonly defaults: T,
+  ) {}
+
+  load(): T {
+    try {
+      const raw = localStorage.getItem(this.storageKey);
+      if (!raw) return this.defaults;
+      const parsed = JSON.parse(raw) as { version: number } & T;
+      if (parsed.version !== this.version) return this.defaults;
+      const { version: _version, ...rest } = parsed;
+      return rest as T;
+    } catch {
+      return this.defaults;
+    }
+  }
+
+  save(data: T): void {
+    try {
+      localStorage.setItem(
+        this.storageKey,
+        JSON.stringify({ version: this.version, ...data }),
+      );
+    } catch {
+      console.warn(`Unable to save to localStorage key "${this.storageKey}"`);
+    }
+  }
+
+  clear(): void {
+    try {
+      localStorage.removeItem(this.storageKey);
+    } catch {
+      console.warn(`Unable to clear localStorage key "${this.storageKey}"`);
+    }
+  }
+}

--- a/tests/unit/optionsStore.test.ts
+++ b/tests/unit/optionsStore.test.ts
@@ -1,0 +1,36 @@
+import { describe, test, expect, beforeEach, afterEach, vi } from "vitest";
+import { OptionsStore } from "src/optionsStore";
+import { createMockLocalStorage } from "./versionedStoreTestHelpers";
+
+describe("OptionsStore", () => {
+  beforeEach(() => {
+    vi.stubGlobal("localStorage", createMockLocalStorage());
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  test("defaults to tabToIndent false", () => {
+    expect(new OptionsStore().load().tabToIndent).toBe(false);
+  });
+
+  test("defaults to debugMode false", () => {
+    expect(new OptionsStore().load().debugMode).toBe(false);
+  });
+
+  test("defaults to cytoscape renderer", () => {
+    expect(new OptionsStore().load().selectedRenderer).toBe("cytoscape");
+  });
+
+  test("round-trips all option fields", () => {
+    const store = new OptionsStore();
+    const options = {
+      tabToIndent: true,
+      debugMode: true,
+      selectedRenderer: "minimal",
+    };
+    store.save(options);
+    expect(store.load()).toEqual(options);
+  });
+});

--- a/tests/unit/tutorial/tutorialManager.test.ts
+++ b/tests/unit/tutorial/tutorialManager.test.ts
@@ -1,21 +1,8 @@
 import { describe, test, expect, beforeEach, afterEach, vi } from "vitest";
 import { TutorialManager } from "src/tutorial/tutorialManager";
+import { createMockLocalStorage } from "../versionedStoreTestHelpers";
 
 const STORAGE_KEY = "formulavize-tutorial-progress";
-
-function createMockLocalStorage(): Storage {
-  const store = new Map<string, string>();
-  return {
-    getItem: (key: string) => store.get(key) ?? null,
-    setItem: (key: string, value: string) => store.set(key, value),
-    removeItem: (key: string) => store.delete(key),
-    clear: () => store.clear(),
-    get length() {
-      return store.size;
-    },
-    key: (index: number) => [...store.keys()][index] ?? null,
-  };
-}
 
 function setupManager(): {
   manager: TutorialManager;

--- a/tests/unit/tutorial/tutorialProgressStore.test.ts
+++ b/tests/unit/tutorial/tutorialProgressStore.test.ts
@@ -1,48 +1,26 @@
 import { describe, test, expect, beforeEach, afterEach, vi } from "vitest";
 import { TutorialProgressStore } from "src/tutorial/tutorialProgressStore";
-
-const STORAGE_KEY = "formulavize-tutorial-progress";
-
-function createMockLocalStorage(): Storage {
-  const store = new Map<string, string>();
-  return {
-    getItem: (key: string) => store.get(key) ?? null,
-    setItem: (key: string, value: string) => store.set(key, value),
-    removeItem: (key: string) => store.delete(key),
-    clear: () => store.clear(),
-    get length() {
-      return store.size;
-    },
-    key: (index: number) => [...store.keys()][index] ?? null,
-  };
-}
+import { createMockLocalStorage } from "../versionedStoreTestHelpers";
 
 describe("TutorialProgressStore", () => {
-  let mockStorage: Storage;
-
   beforeEach(() => {
-    mockStorage = createMockLocalStorage();
-    vi.stubGlobal("localStorage", mockStorage);
+    vi.stubGlobal("localStorage", createMockLocalStorage());
   });
 
   afterEach(() => {
     vi.unstubAllGlobals();
   });
 
-  describe("initial state", () => {
-    test("returns -1 when no progress exists", () => {
-      const store = new TutorialProgressStore();
-      expect(store.getHighestCompletedIndex()).toBe(-1);
-    });
+  test("returns -1 with no progress", () => {
+    expect(new TutorialProgressStore().getHighestCompletedIndex()).toBe(-1);
+  });
 
-    test("hasProgress returns false with no progress", () => {
-      const store = new TutorialProgressStore();
-      expect(store.hasProgress()).toBe(false);
-    });
+  test("hasProgress returns false with no progress", () => {
+    expect(new TutorialProgressStore().hasProgress()).toBe(false);
   });
 
   describe("markCompleted", () => {
-    test("stores progress", () => {
+    test("stores progress and reports hasProgress", () => {
       const store = new TutorialProgressStore();
       store.markCompleted(0);
       expect(store.getHighestCompletedIndex()).toBe(0);
@@ -62,49 +40,15 @@ describe("TutorialProgressStore", () => {
       store.markCompleted(2);
       expect(store.getHighestCompletedIndex()).toBe(5);
     });
-
-    test("persists across instances", () => {
-      const store1 = new TutorialProgressStore();
-      store1.markCompleted(3);
-
-      const store2 = new TutorialProgressStore();
-      expect(store2.getHighestCompletedIndex()).toBe(3);
-    });
   });
 
   describe("clearProgress", () => {
-    test("removes all progress", () => {
+    test("resets to initial state", () => {
       const store = new TutorialProgressStore();
       store.markCompleted(5);
       store.clearProgress();
       expect(store.getHighestCompletedIndex()).toBe(-1);
       expect(store.hasProgress()).toBe(false);
-    });
-
-    test("cleared progress is not seen by new instances", () => {
-      const store1 = new TutorialProgressStore();
-      store1.markCompleted(3);
-      store1.clearProgress();
-
-      const store2 = new TutorialProgressStore();
-      expect(store2.hasProgress()).toBe(false);
-    });
-  });
-
-  describe("version handling", () => {
-    test("ignores data with mismatched version", () => {
-      mockStorage.setItem(
-        STORAGE_KEY,
-        JSON.stringify({ version: 999, highestCompleted: 10 }),
-      );
-      const store = new TutorialProgressStore();
-      expect(store.getHighestCompletedIndex()).toBe(-1);
-    });
-
-    test("ignores corrupted data", () => {
-      mockStorage.setItem(STORAGE_KEY, "not valid json");
-      const store = new TutorialProgressStore();
-      expect(store.getHighestCompletedIndex()).toBe(-1);
     });
   });
 });

--- a/tests/unit/versionedStore.test.ts
+++ b/tests/unit/versionedStore.test.ts
@@ -1,0 +1,128 @@
+import { describe, test, expect, beforeEach, afterEach, vi } from "vitest";
+import { VersionedStore } from "src/versionedStore";
+import { createMockLocalStorage } from "./versionedStoreTestHelpers";
+
+interface TestData {
+  name: string;
+  count: number;
+}
+
+const STORAGE_KEY = "test-store";
+const VERSION = 1;
+const DEFAULTS: TestData = { name: "default", count: 0 };
+
+class TestStore extends VersionedStore<TestData> {
+  constructor() {
+    super(STORAGE_KEY, VERSION, DEFAULTS);
+  }
+}
+
+describe("VersionedStore", () => {
+  let mockStorage: Storage;
+
+  beforeEach(() => {
+    mockStorage = createMockLocalStorage();
+    vi.stubGlobal("localStorage", mockStorage);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  describe("load", () => {
+    test("returns defaults when nothing is stored", () => {
+      const store = new TestStore();
+      expect(store.load()).toEqual(DEFAULTS);
+    });
+
+    test("returns saved data", () => {
+      const store = new TestStore();
+      store.save({ name: "fizz", count: 6 });
+      expect(store.load()).toEqual({ name: "fizz", count: 6 });
+    });
+
+    test("persists across instances", () => {
+      new TestStore().save({ name: "buzz", count: 7 });
+      expect(new TestStore().load()).toEqual({ name: "buzz", count: 7 });
+    });
+
+    test("returns defaults for mismatched version", () => {
+      mockStorage.setItem(
+        STORAGE_KEY,
+        JSON.stringify({ version: 999, name: "stale", count: 1 }),
+      );
+      expect(new TestStore().load()).toEqual(DEFAULTS);
+    });
+
+    test("returns defaults for corrupted JSON", () => {
+      mockStorage.setItem(STORAGE_KEY, "not valid json");
+      expect(new TestStore().load()).toEqual(DEFAULTS);
+    });
+
+    test("does not include version field in returned data", () => {
+      const store = new TestStore();
+      store.save({ name: "test", count: 1 });
+      const loaded = store.load();
+      expect(loaded).not.toHaveProperty("version");
+    });
+  });
+
+  describe("save", () => {
+    test("overwrites previous data", () => {
+      const store = new TestStore();
+      store.save({ name: "first", count: 1 });
+      store.save({ name: "second", count: 2 });
+      expect(store.load()).toEqual({ name: "second", count: 2 });
+    });
+
+    test("stores version in localStorage", () => {
+      new TestStore().save({ name: "test", count: 1 });
+      const raw = JSON.parse(mockStorage.getItem(STORAGE_KEY)!);
+      expect(raw.version).toBe(VERSION);
+    });
+
+    test("warns on localStorage failure", () => {
+      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+      mockStorage.setItem = () => {
+        throw new Error("quota exceeded");
+      };
+
+      new TestStore().save({ name: "fail", count: 0 });
+
+      expect(warnSpy).toHaveBeenCalledWith(
+        `Unable to save to localStorage key "${STORAGE_KEY}"`,
+      );
+      warnSpy.mockRestore();
+    });
+  });
+
+  describe("clear", () => {
+    test("removes stored data", () => {
+      const store = new TestStore();
+      store.save({ name: "data", count: 5 });
+      store.clear();
+      expect(store.load()).toEqual(DEFAULTS);
+    });
+
+    test("cleared data is not seen by new instances", () => {
+      const store = new TestStore();
+      store.save({ name: "data", count: 5 });
+      store.clear();
+      expect(new TestStore().load()).toEqual(DEFAULTS);
+    });
+
+    test("warns on localStorage failure", () => {
+      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+      mockStorage.removeItem = () => {
+        throw new Error("access denied");
+      };
+
+      new TestStore().clear();
+
+      expect(warnSpy).toHaveBeenCalledWith(
+        `Unable to clear localStorage key "${STORAGE_KEY}"`,
+      );
+      warnSpy.mockRestore();
+    });
+  });
+});

--- a/tests/unit/versionedStoreTestHelpers.ts
+++ b/tests/unit/versionedStoreTestHelpers.ts
@@ -1,0 +1,13 @@
+export function createMockLocalStorage(): Storage {
+  const store = new Map<string, string>();
+  return {
+    getItem: (key: string) => store.get(key) ?? null,
+    setItem: (key: string, value: string) => store.set(key, value),
+    removeItem: (key: string) => store.delete(key),
+    clear: () => store.clear(),
+    get length() {
+      return store.size;
+    },
+    key: (index: number) => [...store.keys()][index] ?? null,
+  };
+}


### PR DESCRIPTION
This pull request introduces a reusable, versioned localStorage utility (`VersionedStore`) to standardize and simplify persistent storage of user options and tutorial progress. It refactors the tutorial progress storage to use this new utility, adds a persistent user options store, and provides comprehensive unit tests for both.

**Persistent storage improvements:**

* Introduced a generic `VersionedStore` class for versioned, type-safe localStorage management, with robust handling of version mismatches and corrupted data. (`src/versionedStore.ts`, [src/versionedStore.tsR1-R39](diffhunk://#diff-e6bc6d91e3944a101ec89a73b782794eebdaf1db088504af19e66e8c22b3bb01R1-R39))
* Refactored `TutorialProgressStore` to extend `VersionedStore`, removing custom serialization logic and ensuring consistent version handling and error resilience. (`src/tutorial/tutorialProgressStore.ts`, [[1]](diffhunk://#diff-77a831437cceaa9b5c329bbffc80681aca1c4975ab94ee1183a5c7854782e66cL1-R17) [[2]](diffhunk://#diff-77a831437cceaa9b5c329bbffc80681aca1c4975ab94ee1183a5c7854782e66cL27-R32)

**User options persistence:**

* Added a new `OptionsStore` (extending `VersionedStore`) to persist user settings such as `tabToIndent`, `debugMode`, and `selectedRenderer`, and integrated it into the main app lifecycle for automatic loading and saving of options. (`src/optionsStore.ts`, [[1]](diffhunk://#diff-3097e5a929d195c38b5f1dc093e1f8660b88f17e51dbaec8a9d7e2de4b82c1dbR1-R19); `src/App.vue`, [[2]](diffhunk://#diff-7a7a37b12ee1265d7e27577ec286120d2cbc0940908635e264a2be44ccb9a8a0R111) [[3]](diffhunk://#diff-7a7a37b12ee1265d7e27577ec286120d2cbc0940908635e264a2be44ccb9a8a0R138) [[4]](diffhunk://#diff-7a7a37b12ee1265d7e27577ec286120d2cbc0940908635e264a2be44ccb9a8a0R210-R216) [[5]](diffhunk://#diff-7a7a37b12ee1265d7e27577ec286120d2cbc0940908635e264a2be44ccb9a8a0R226) [[6]](diffhunk://#diff-7a7a37b12ee1265d7e27577ec286120d2cbc0940908635e264a2be44ccb9a8a0R258-R262) [[7]](diffhunk://#diff-7a7a37b12ee1265d7e27577ec286120d2cbc0940908635e264a2be44ccb9a8a0R280-R286)

**Testing infrastructure and coverage:**

* Added comprehensive unit tests for `VersionedStore`, `OptionsStore`, and updated tests for `TutorialProgressStore` to ensure correct versioning, error handling, and persistence behavior. (`tests/unit/versionedStore.test.ts`, [[1]](diffhunk://#diff-0fa2b0dc45064e316bd76cb24460dbf7b91c37d5e2b86cefdab6c9a1b2506f6cR1-R128); `tests/unit/optionsStore.test.ts`, [[2]](diffhunk://#diff-7831dd7653f3f1cff9e3efd4d546fb42bea4b7e1af6fcfef8434d99d894922f2R1-R36); `tests/unit/tutorial/tutorialProgressStore.test.ts`, [[3]](diffhunk://#diff-ebcbeadc7e7f850e91d10d4d017e2cbb128d6d8b8386995e7ac3115f4db166c5L3-R23) [[4]](diffhunk://#diff-ebcbeadc7e7f850e91d10d4d017e2cbb128d6d8b8386995e7ac3115f4db166c5L65-L108)
* Extracted and reused a `createMockLocalStorage` helper to simplify and standardize localStorage mocking in tests. (`tests/unit/versionedStoreTestHelpers.ts`, [[1]](diffhunk://#diff-89f686e72be33725987e7f91ff629ef247ee49bfb5ccb7e3e7c1d5010e9da0d1R1-R13); test file imports, [[2]](diffhunk://#diff-5f0f2f4062535ed5911b7b205bb6fd000584a87119840ea1c95b1e0eff5da9f1R3-L19) [[3]](diffhunk://#diff-ebcbeadc7e7f850e91d10d4d017e2cbb128d6d8b8386995e7ac3115f4db166c5L3-R23)

These changes lay the groundwork for robust, maintainable client-side persistence across the application.