### PR TITLE
perf: Implement stable ID system for graph diffing to detect topological changes to trigger re-layout

### DIFF
--- a/src/compiler/dagFactory.ts
+++ b/src/compiler/dagFactory.ts
@@ -31,6 +31,16 @@ export enum ScopeKind {
   Import = "i",
 }
 
+// Stable Ids enable consistent node and edge IDs across compilations,
+// which allows the renderer to preserve element positions and styles
+// when the underlying DAG structure hasn't changed.
+// Ids are generated based on the path to the current scope
+// (e.g. root-n-a-0 for the first call to 'a' at the root level)
+// and a count of how many times that scope has been entered
+// (e.g. root-ns-a-0-n-a-0 for the first call to 'a' inside a namespace 'a').
+// DagFactory previously had a simpler, less stateful approach of generating UUIDs,
+// but that caused the entire graph to be treated as new on every compilation,
+// which made it impossible to preserve element positions and styles across compilations.
 export class StableIdContext {
   private scopePath: string;
   private nodeCounts = new Map<string, number>();

--- a/src/compiler/dagFactory.ts
+++ b/src/compiler/dagFactory.ts
@@ -1,5 +1,4 @@
 import { match } from "ts-pattern";
-import { v4 as uuidv4 } from "uuid";
 
 import {
   BaseTreeNode,
@@ -26,6 +25,46 @@ import {
   ErrorCode,
   ErrorSource,
 } from "./compilationErrors";
+
+export enum ScopeKind {
+  Namespace = "ns",
+  Import = "i",
+}
+
+export class StableIdContext {
+  private scopePath: string;
+  private nodeCounts = new Map<string, number>();
+  private edgeCounts = new Map<string, number>();
+  private childScopeCounts = new Map<string, number>();
+
+  constructor(scopePath: string) {
+    this.scopePath = scopePath;
+  }
+
+  get ScopePath(): string {
+    return this.scopePath;
+  }
+
+  nextNodeId(callName: string): string {
+    const count = this.nodeCounts.get(callName) ?? 0;
+    this.nodeCounts.set(callName, count + 1);
+    return `${this.scopePath}-n-${callName}-${count}`;
+  }
+
+  nextEdgeId(srcNodeId: string, destNodeId: string): string {
+    const key = `${srcNodeId}>${destNodeId}`;
+    const count = this.edgeCounts.get(key) ?? 0;
+    this.edgeCounts.set(key, count + 1);
+    return `${this.scopePath}-e-${key}-${count}`;
+  }
+
+  childScope(kind: ScopeKind, name: string): StableIdContext {
+    const key = `${kind}-${name}`;
+    const count = this.childScopeCounts.get(key) ?? 0;
+    this.childScopeCounts.set(key, count + 1);
+    return new StableIdContext(`${this.scopePath}-${key}-${count}`);
+  }
+}
 
 function makeDagStyle(styleNode: StyleTreeNode): DagStyle {
   return {
@@ -80,6 +119,7 @@ function argListToEdgeInfo(
   argList: ValueTreeNode[],
   workingDag: Dag,
   errors: Error[],
+  ctx: StableIdContext,
 ): IncomingEdgeInfo[] {
   return argList
     .map((arg) =>
@@ -89,6 +129,7 @@ function argListToEdgeInfo(
             arg as CallTreeNode,
             workingDag,
             errors,
+            ctx,
           );
           return { nodeId: argNodeId, varName: "", varStyle: null };
         })
@@ -133,9 +174,10 @@ function addIncomingEdgesToDag(
   incomingEdges: IncomingEdgeInfo[],
   destNodeId: NodeId,
   workingDag: Dag,
+  ctx: StableIdContext,
 ): void {
   incomingEdges.forEach((incomingEdge) => {
-    const edgeId = uuidv4();
+    const edgeId = ctx.nextEdgeId(incomingEdge.nodeId, destNodeId);
     const thisEdge = {
       id: edgeId,
       name: incomingEdge.varName,
@@ -153,8 +195,9 @@ function processCall(
   callStmt: CallTreeNode,
   workingDag: Dag,
   errors: Error[],
+  ctx: StableIdContext,
 ): NodeId {
-  const thisNodeId = uuidv4();
+  const thisNodeId = ctx.nextNodeId(callStmt.Name);
   checkStyleTagsInStyleNode(callStmt.Styling, workingDag, errors);
   const thisNode = {
     id: thisNodeId,
@@ -169,8 +212,9 @@ function processCall(
     callStmt.Args,
     workingDag,
     errors,
+    ctx,
   );
-  addIncomingEdgesToDag(incomingEdgeInfoList, thisNodeId, workingDag);
+  addIncomingEdgesToDag(incomingEdgeInfoList, thisNodeId, workingDag, ctx);
 
   return thisNodeId;
 }
@@ -181,8 +225,10 @@ async function processNamespace(
   errors: Error[],
   importer: ImportCacher,
   seenImports: Set<string>,
+  ctx: StableIdContext,
 ): Promise<NodeId> {
-  const subDagId = uuidv4();
+  const childCtx = ctx.childScope(ScopeKind.Namespace, namespaceStmt.Name);
+  const subDagId = childCtx.ScopePath;
   const childDag = makeSubDag(
     subDagId,
     namespaceStmt,
@@ -190,6 +236,7 @@ async function processNamespace(
     importer,
     seenImports,
     workingDag,
+    childCtx,
   );
   workingDag.addChildDag(await childDag);
 
@@ -197,8 +244,9 @@ async function processNamespace(
     namespaceStmt.Args,
     workingDag,
     errors,
+    ctx,
   );
-  addIncomingEdgesToDag(dagIncomingEdges, subDagId, workingDag);
+  addIncomingEdgesToDag(dagIncomingEdges, subDagId, workingDag, ctx);
 
   return subDagId;
 }
@@ -235,6 +283,7 @@ async function processImport(
   errors: Error[],
   importer: ImportCacher,
   seenImports: Set<string>,
+  ctx: StableIdContext,
 ): Promise<NodeId> {
   // Process imports referenced by a variable, always returning a node id
   const importedDag = await getImportedDag(
@@ -244,7 +293,8 @@ async function processImport(
     workingDag,
     seenImports,
   );
-  importedDag.Id = uuidv4();
+  const importName = importStmt.ImportName ?? importStmt.ImportLocation;
+  importedDag.Id = ctx.childScope(ScopeKind.Import, importName).ScopePath;
   importedDag.Name = importStmt.ImportName ?? "";
   workingDag.addChildDag(importedDag);
   return importedDag.Id;
@@ -256,6 +306,7 @@ async function processUnassignedImport(
   errors: Error[],
   importer: ImportCacher,
   seenImports: Set<string>,
+  ctx: StableIdContext,
 ) {
   // Process imports not referenced by a variable
   const importedDag = await getImportedDag(
@@ -266,7 +317,10 @@ async function processUnassignedImport(
     seenImports,
   );
   if (importStmt.ImportName) {
-    importedDag.Id = uuidv4();
+    importedDag.Id = ctx.childScope(
+      ScopeKind.Import,
+      importStmt.ImportName,
+    ).ScopePath;
     importedDag.Name = importStmt.ImportName;
     workingDag.addChildDag(importedDag);
   } else {
@@ -284,6 +338,7 @@ async function processAssignmentRhs(
   errors: Error[],
   importer: ImportCacher,
   seenImports: Set<string>,
+  ctx: StableIdContext,
 ): Promise<NodeId> {
   return match(rhsNode.Type)
     .with(NodeType.QualifiedVariable, () => {
@@ -305,7 +360,7 @@ async function processAssignmentRhs(
       return candidateSrcNodeId;
     })
     .with(NodeType.Call, () => {
-      return processCall(rhsNode as CallTreeNode, workingDag, errors);
+      return processCall(rhsNode as CallTreeNode, workingDag, errors, ctx);
     })
     .with(NodeType.Namespace, () => {
       return processNamespace(
@@ -314,6 +369,7 @@ async function processAssignmentRhs(
         errors,
         importer,
         seenImports,
+        ctx,
       );
     })
     .with(NodeType.Import, async () => {
@@ -323,6 +379,7 @@ async function processAssignmentRhs(
         errors,
         importer,
         seenImports,
+        ctx,
       );
     })
     .otherwise(() => {
@@ -344,6 +401,7 @@ async function processAssignment(
   errors: Error[],
   importer: ImportCacher,
   seenImports: Set<string>,
+  ctx: StableIdContext,
 ): Promise<void> {
   const lhsIsEmpty = assignmentStmt.Lhs.length === 0;
   if (lhsIsEmpty) {
@@ -375,6 +433,7 @@ async function processAssignment(
     errors,
     importer,
     seenImports,
+    ctx,
   ).catch((err) => {
     console.debug("Assignment failure:", err);
     return null;
@@ -443,10 +502,11 @@ async function processStatement(
   errors: Error[],
   importer: ImportCacher,
   seenImports: Set<string>,
+  ctx: StableIdContext,
 ): Promise<void> {
   await match(stmt.Type)
     .with(NodeType.Call, () => {
-      processCall(stmt as CallTreeNode, workingDag, errors);
+      processCall(stmt as CallTreeNode, workingDag, errors, ctx);
     })
     .with(NodeType.Assignment, async () => {
       await processAssignment(
@@ -455,6 +515,7 @@ async function processStatement(
         errors,
         importer,
         seenImports,
+        ctx,
       );
     })
     .with(NodeType.NamedStyle, () => {
@@ -478,6 +539,7 @@ async function processStatement(
         errors,
         importer,
         seenImports,
+        ctx,
       );
     })
     .with(NodeType.Import, async () => {
@@ -487,6 +549,7 @@ async function processStatement(
         errors,
         importer,
         seenImports,
+        ctx,
       ).catch((err) => {
         console.debug(err);
       });
@@ -510,7 +573,9 @@ export async function makeSubDag(
   importer: ImportCacher,
   seenImports: Set<string> = new Set(),
   parentDag?: Dag,
+  ctx?: StableIdContext,
 ): Promise<Dag> {
+  const idCtx = ctx ?? new StableIdContext(dagId);
   checkStyleTagsInStyleNode(dagNamespaceStmt.Styling, parentDag, errors);
   const dagStyleTags =
     dagNamespaceStmt.Styling?.StyleTags.map((tag) => tag.QualifiedTagName) ??
@@ -525,7 +590,14 @@ export async function makeSubDag(
   );
 
   for (const stmt of dagNamespaceStmt.Statements) {
-    await processStatement(stmt, curLevelDag, errors, importer, seenImports);
+    await processStatement(
+      stmt,
+      curLevelDag,
+      errors,
+      importer,
+      seenImports,
+      idCtx,
+    );
   }
   return curLevelDag;
 }
@@ -536,16 +608,19 @@ export async function makeDag(
   seenImports: Set<string> = new Set(),
 ): Promise<{ dag: Dag; errors: Error[] }> {
   const errors: Error[] = [];
+  const rootCtx = new StableIdContext("root");
   const statementList = new StatementListTreeNode(
     recipe.Statements,
     recipe.Position,
   );
   const dag = await makeSubDag(
-    uuidv4(),
+    "root",
     new NamespaceTreeNode("", statementList),
     errors,
     importer,
     seenImports,
+    undefined,
+    rootCtx,
   );
   return { dag, errors };
 }

--- a/src/renderers/cyDag/CytoscapeRenderer.vue
+++ b/src/renderers/cyDag/CytoscapeRenderer.vue
@@ -5,7 +5,12 @@
 <script lang="ts">
 import { defineComponent, PropType } from "vue";
 import { match } from "ts-pattern";
-import cytoscape, { Core, LayoutOptions, NodeSingular } from "cytoscape";
+import cytoscape, {
+  Core,
+  ElementsDefinition,
+  LayoutOptions,
+  NodeSingular,
+} from "cytoscape";
 import dagre from "cytoscape-dagre";
 import cytoscapePopper, {
   PopperFactory,
@@ -22,6 +27,8 @@ import svg from "cytoscape-svg";
 import { makeCyElements } from "./cyGraphFactory";
 import { makeCyStylesheets } from "./cyStyleSheetsFactory";
 import { extendCyPopperElements } from "./cyPopperExtender";
+import { diffCyElements } from "./cyDiffer";
+import { applyDiff } from "./cyUpdateHelpers";
 import { Dag } from "../../compiler/dag";
 import { ExportFormat } from "../../compiler/constants";
 import { saveAs } from "file-saver";
@@ -108,6 +115,7 @@ const CytoscapeRenderer = defineComponent({
   data() {
     return {
       cy: null as Core | null,
+      previousElements: null as ElementsDefinition | null,
     };
   },
   watch: {
@@ -150,6 +158,14 @@ const CytoscapeRenderer = defineComponent({
      * graph with just one added node has better performance than running on an
      * entirely new graph but still has a noticeable delay.
      */
+    runLayout(): void {
+      Promise.resolve().then(() => {
+        if (this.cy) {
+          this.cy.layout(layoutOptions).run();
+        }
+      });
+    },
+
     applyThemeStyles(): void {
       if (!this.cy) return;
       const newStylesheets = makeCyStylesheets(this.dag, this.isDark);
@@ -159,22 +175,36 @@ const CytoscapeRenderer = defineComponent({
     updateDag(dag: Dag): void {
       if (!this.cy) return;
 
-      this.cy.elements().remove();
-      this.cy.removeAllListeners();
-
       const newElements = makeCyElements(dag);
-      this.cy.add(newElements);
-
       const newStylesheets = makeCyStylesheets(dag, this.isDark);
-      this.cy.style(newStylesheets);
 
-      extendCyPopperElements(this.cy, dag, this.$refs.container as HTMLElement);
+      if (!this.previousElements) {
+        // First render: full build
+        this.cy.add(newElements);
+        this.cy.style(newStylesheets);
+        extendCyPopperElements(
+          this.cy,
+          dag,
+          this.$refs.container as HTMLElement,
+        );
+        this.runLayout();
+      } else {
+        const diff = diffCyElements(this.previousElements, newElements);
+        applyDiff(this.cy, diff);
 
-      Promise.resolve().then(() => {
-        if (this.cy) {
-          this.cy.layout(layoutOptions).run(); // most expensive operation
+        this.cy.style(newStylesheets);
+        extendCyPopperElements(
+          this.cy,
+          dag,
+          this.$refs.container as HTMLElement,
+        );
+
+        if (diff.topologyChanged) {
+          this.runLayout();
         }
-      });
+      }
+
+      this.previousElements = newElements;
     },
 
     export(exportOptions: FileExportOptions): void {

--- a/src/renderers/cyDag/CytoscapeRenderer.vue
+++ b/src/renderers/cyDag/CytoscapeRenderer.vue
@@ -148,16 +148,7 @@ const CytoscapeRenderer = defineComponent({
       this.updateDag(this.dag);
     },
 
-    /**
-     * Re-painting the entire graph is an expensive operation.
-     * We could slightly optimize it by creating an AST/DAG in a way
-     * that allows us to diff across graph copies and only update
-     * the affected elements. Doing so for unlabelled DAGs is difficult.
-     * https://stackoverflow.com/questions/16553343/diff-for-directed-acyclic-graphs
-     * Moreover, layout is the fundamental bottleneck. Running layout on a large
-     * graph with just one added node has better performance than running on an
-     * entirely new graph but still has a noticeable delay.
-     */
+    // Layout is an expensive operation regardless of a change's size.
     runLayout(): void {
       Promise.resolve().then(() => {
         if (this.cy) {
@@ -199,6 +190,7 @@ const CytoscapeRenderer = defineComponent({
           this.$refs.container as HTMLElement,
         );
 
+        // Avoid unnecessary layout runs by checking if the topology has changed
         if (diff.topologyChanged) {
           this.runLayout();
         }

--- a/src/renderers/cyDag/cyDiffer.ts
+++ b/src/renderers/cyDag/cyDiffer.ts
@@ -1,0 +1,174 @@
+import {
+  NodeDefinition,
+  EdgeDefinition,
+  ElementsDefinition,
+  NodeDataDefinition,
+  EdgeDataDefinition,
+} from "cytoscape";
+
+type ElementId = string;
+type ElementDef = NodeDefinition | EdgeDefinition;
+type ElementDataDef = NodeDataDefinition | EdgeDataDefinition;
+
+export interface NodeUpdate {
+  id: ElementId;
+  data: ElementDataDef;
+  classes?: string;
+}
+
+export interface EdgeUpdate {
+  id: ElementId;
+  data: ElementDataDef;
+  classes?: string;
+}
+
+export interface CyDiffResult {
+  nodesToAdd: NodeDefinition[];
+  nodesToRemove: ElementId[];
+  nodesToUpdate: NodeUpdate[];
+  edgesToAdd: EdgeDefinition[];
+  edgesToRemove: ElementId[];
+  edgesToUpdate: EdgeUpdate[];
+  topologyChanged: boolean;
+}
+
+type CyScalarValue =
+  | string
+  | number
+  | boolean
+  | null
+  | undefined
+  | CyScalarValue[];
+
+function valueEqual(a: CyScalarValue, b: CyScalarValue): boolean {
+  if (a === b) return true;
+  if (Array.isArray(a) && Array.isArray(b)) {
+    if (a.length !== b.length) return false;
+    return a.every((val, i) => valueEqual(val, b[i]));
+  }
+  return false;
+}
+
+function dataEqual(a: ElementDataDef, b: ElementDataDef): boolean {
+  const keysA = Object.keys(a);
+  const keysB = Object.keys(b);
+  if (keysA.length !== keysB.length) return false;
+  for (const key of keysA) {
+    if (!valueEqual(a[key], b[key])) return false;
+  }
+  return true;
+}
+
+function normalizeClasses(
+  classes: string | string[] | undefined,
+): string | undefined {
+  if (classes === undefined) return undefined;
+  if (Array.isArray(classes)) return classes.join(" ");
+  return classes;
+}
+
+function elementChanged(
+  oldEl: ElementDef,
+  newEl: ElementDef,
+): { changed: boolean; newClasses: string | undefined } {
+  const oldClasses = normalizeClasses(oldEl.classes);
+  const newClasses = normalizeClasses(newEl.classes);
+  return {
+    changed: !dataEqual(oldEl.data, newEl.data) || oldClasses !== newClasses,
+    newClasses,
+  };
+}
+
+function indexById(elements: ElementDef[]): Map<ElementId, ElementDef> {
+  return new Map(
+    elements
+      .filter((element) => element.data.id)
+      .map((element) => [element.data.id as ElementId, element]),
+  );
+}
+
+export function diffCyElements(
+  oldElements: ElementsDefinition,
+  newElements: ElementsDefinition,
+): CyDiffResult {
+  const oldNodes = indexById(oldElements.nodes);
+  const newNodes = indexById(newElements.nodes);
+  const oldEdges = indexById(oldElements.edges);
+  const newEdges = indexById(newElements.edges);
+
+  const nodesToAdd: NodeDefinition[] = [];
+  const nodesToRemove: ElementId[] = [];
+  const nodesToUpdate: NodeUpdate[] = [];
+  const edgesToAdd: EdgeDefinition[] = [];
+  const edgesToRemove: ElementId[] = [];
+  const edgesToUpdate: EdgeUpdate[] = [];
+  let topologyChanged = false;
+
+  // Diff nodes
+  for (const [id, newNode] of newNodes) {
+    const oldNode = oldNodes.get(id);
+    if (!oldNode) {
+      nodesToAdd.push(newNode as NodeDefinition);
+      topologyChanged = true;
+    } else {
+      const { changed, newClasses } = elementChanged(oldNode, newNode);
+      if (changed) {
+        nodesToUpdate.push({
+          id,
+          data: newNode.data as ElementDataDef,
+          classes: newClasses,
+        });
+      }
+    }
+  }
+  for (const id of oldNodes.keys()) {
+    if (!newNodes.has(id)) {
+      nodesToRemove.push(id);
+      topologyChanged = true;
+    }
+  }
+
+  // Diff edges
+  for (const [id, newEdge] of newEdges) {
+    const oldEdge = oldEdges.get(id);
+    if (!oldEdge) {
+      edgesToAdd.push(newEdge as EdgeDefinition);
+      topologyChanged = true;
+    } else {
+      if (
+        oldEdge.data.source !== newEdge.data.source ||
+        oldEdge.data.target !== newEdge.data.target
+      ) {
+        // Cytoscape edges have immutable source/target — must remove and re-add
+        edgesToRemove.push(id);
+        edgesToAdd.push(newEdge as EdgeDefinition);
+        topologyChanged = true;
+      } else {
+        const { changed, newClasses } = elementChanged(oldEdge, newEdge);
+        if (changed) {
+          edgesToUpdate.push({
+            id,
+            data: newEdge.data as ElementDataDef,
+            classes: newClasses,
+          });
+        }
+      }
+    }
+  }
+  for (const id of oldEdges.keys()) {
+    if (!newEdges.has(id)) {
+      edgesToRemove.push(id);
+      topologyChanged = true;
+    }
+  }
+
+  return {
+    nodesToAdd,
+    nodesToRemove,
+    nodesToUpdate,
+    edgesToAdd,
+    edgesToRemove,
+    edgesToUpdate,
+    topologyChanged,
+  };
+}

--- a/src/renderers/cyDag/cyPopperExtender.ts
+++ b/src/renderers/cyDag/cyPopperExtender.ts
@@ -113,19 +113,28 @@ function getElementDescriptions(
 }
 export function getNodeDescriptions(dag: Dag): SelectorDescriptionPair[] {
   const nodeDescs = getElementDescriptions(dag, dag.getNodeList());
-  return Array.from(nodeDescs, ([id, descData]) => [`node#${id}`, descData]);
+  return Array.from(nodeDescs, ([id, descData]) => [
+    `node[id = '${id}']`,
+    descData,
+  ]);
 }
 
 export function getEdgeDescriptions(dag: Dag): SelectorDescriptionPair[] {
   const edgeDescs = getElementDescriptions(dag, dag.getEdgeList());
-  return Array.from(edgeDescs, ([id, descData]) => [`edge#${id}`, descData]);
+  return Array.from(edgeDescs, ([id, descData]) => [
+    `edge[id = '${id}']`,
+    descData,
+  ]);
 }
 
 export function getCompoundNodeDescriptions(
   dag: Dag,
 ): SelectorDescriptionPair[] {
   const compNodeDesc = getElementDescriptions(dag, [dag.getDagAsDagNode()]);
-  return Array.from(compNodeDesc, ([id, descData]) => [`node#${id}`, descData]);
+  return Array.from(compNodeDesc, ([id, descData]) => [
+    `node[id = '${id}']`,
+    descData,
+  ]);
 }
 
 function clearAllPopperDivs(canvasElement: HTMLElement) {
@@ -221,11 +230,11 @@ export function extendCyPopperElements(
   canvasElement: HTMLElement,
 ) {
   clearAllPopperDivs(canvasElement);
+  cy.removeAllListeners();
 
   addCyPopperElementsFromDag(cy, canvasElement, dag);
 
-  // scale popper divs with zoom level
-  cy.on("zoom", () => {
+  function applyZoomScale() {
     const zoomLevel = cy.zoom();
     const popperInnerDivArray = Array.from(
       canvasElement.getElementsByClassName(POPPER_INNER_DIV_CLASS),
@@ -234,5 +243,9 @@ export function extendCyPopperElements(
       const popperDivElement = popperInnerDiv as HTMLElement;
       popperDivElement.style.transform = `scale(${zoomLevel})`;
     });
-  });
+  }
+
+  // Apply current zoom scale immediately, then track future changes
+  applyZoomScale();
+  cy.on("zoom", applyZoomScale);
 }

--- a/src/renderers/cyDag/cyStyleSheetsFactory.ts
+++ b/src/renderers/cyDag/cyStyleSheetsFactory.ts
@@ -71,16 +71,24 @@ export function makeElementStylesheets(
 }
 
 export function makeNodeStylesheets(dag: Dag): StylesheetCSS[] {
-  return makeElementStylesheets(dag, dag.getNodeList(), (id) => `node#${id}`);
+  return makeElementStylesheets(
+    dag,
+    dag.getNodeList(),
+    (id) => `node[id = '${id}']`,
+  );
 }
 
 export function makeEdgeStyleSheets(dag: Dag): StylesheetCSS[] {
-  return makeElementStylesheets(dag, dag.getEdgeList(), (id) => `edge#${id}`);
+  return makeElementStylesheets(
+    dag,
+    dag.getEdgeList(),
+    (id) => `edge[id = '${id}']`,
+  );
 }
 
 export function makeCompoundNodeStylesheet(dag: Dag): StylesheetCSS[] {
   const dagNode = dag.getDagAsDagNode();
-  return makeElementStylesheets(dag, [dagNode], (id) => `node#${id}`);
+  return makeElementStylesheets(dag, [dagNode], (id) => `node[id = '${id}']`);
 }
 
 export function makeDagLineageSelector(dag: Dag): string {

--- a/src/renderers/cyDag/cyUpdateHelpers.ts
+++ b/src/renderers/cyDag/cyUpdateHelpers.ts
@@ -1,0 +1,17 @@
+import { Core } from "cytoscape";
+import { CyDiffResult } from "./cyDiffer";
+
+export function applyDiff(cy: Core, diff: CyDiffResult): void {
+  cy.batch(() => {
+    for (const id of [...diff.nodesToRemove, ...diff.edgesToRemove]) {
+      cy.getElementById(id).remove();
+    }
+    cy.add(diff.nodesToAdd);
+    cy.add(diff.edgesToAdd);
+    for (const upd of [...diff.nodesToUpdate, ...diff.edgesToUpdate]) {
+      const ele = cy.getElementById(upd.id);
+      ele.data(upd.data);
+      if (upd.classes !== undefined) ele.classes(upd.classes);
+    }
+  });
+}

--- a/tests/unit/compiler/stableIds.test.ts
+++ b/tests/unit/compiler/stableIds.test.ts
@@ -1,0 +1,313 @@
+import { describe, test, expect } from "vitest";
+import {
+  RecipeTreeNode as Recipe,
+  CallTreeNode as Call,
+  AssignmentTreeNode as Assignment,
+  LocalVarTreeNode as LocalVariable,
+  QualifiedVarTreeNode as QualifiedVariable,
+  NamespaceTreeNode as Namespace,
+  ValueListTreeNode as ValueList,
+  StatementListTreeNode as StatementList,
+} from "src/compiler/ast";
+import { makeDag } from "src/compiler/dagFactory";
+import { Compiler } from "src/compiler/driver";
+import { ImportCacher } from "src/compiler/importCacher";
+
+const dummyImporter = {} as ImportCacher;
+
+function getNodeIds(dag: Awaited<ReturnType<typeof makeDag>>["dag"]): string[] {
+  return dag.getNodeList().map((n) => n.id);
+}
+
+function getEdgeIds(dag: Awaited<ReturnType<typeof makeDag>>["dag"]): string[] {
+  return dag.getEdgeList().map((e) => e.id);
+}
+
+describe("stable ID generation", () => {
+  test("same source compiled twice produces identical IDs", async () => {
+    const makeRecipe = () =>
+      new Recipe([
+        new Call("a", new ValueList([])),
+        new Call("b", new ValueList([])),
+      ]);
+    const { dag: dag1 } = await makeDag(makeRecipe(), dummyImporter);
+    const { dag: dag2 } = await makeDag(makeRecipe(), dummyImporter);
+    expect(getNodeIds(dag1)).toEqual(getNodeIds(dag2));
+    expect(getEdgeIds(dag1)).toEqual(getEdgeIds(dag2));
+  });
+
+  test("full pipeline: a(a(a(), a()), a(a(), a())) produces correct tree", async () => {
+    const compiler = new Compiler();
+    const compilation = await compiler.compileFromSource(
+      "a(a(a(), a()), a(a(), a()))",
+    );
+    const dag = compilation.DAG;
+    const nodes = dag.getNodeList();
+    const edges = dag.getEdgeList();
+
+    expect(nodes).toHaveLength(7);
+    expect(edges).toHaveLength(6);
+
+    // All IDs unique
+    const nodeIds = new Set(nodes.map((n) => n.id));
+    expect(nodeIds.size).toBe(7);
+
+    // Build adjacency: count incoming edges per node
+    const inDegree = new Map<string, number>();
+    for (const node of nodes) inDegree.set(node.id, 0);
+    for (const edge of edges) {
+      inDegree.set(edge.destNodeId, (inDegree.get(edge.destNodeId) ?? 0) + 1);
+    }
+
+    const degrees = Array.from(inDegree.values()).sort();
+    // 4 leaves (0 incoming), 2 mid nodes (2 incoming each), 1 root (2 incoming)
+    expect(degrees).toEqual([0, 0, 0, 0, 2, 2, 2]);
+  });
+
+  describe("nodes", () => {
+    test("root dag has stable ID 'root'", async () => {
+      const recipe = new Recipe([]);
+      const { dag } = await makeDag(recipe, dummyImporter);
+      expect(dag.Id).toBe("root");
+    });
+
+    test("node IDs include call name and occurrence index", async () => {
+      const recipe = new Recipe([
+        new Call("f", new ValueList([])),
+        new Call("g", new ValueList([])),
+        new Call("f", new ValueList([])),
+      ]);
+      const { dag } = await makeDag(recipe, dummyImporter);
+      const nodeIds = getNodeIds(dag);
+      expect(nodeIds).toContain("root-n-f-0");
+      expect(nodeIds).toContain("root-n-g-0");
+      expect(nodeIds).toContain("root-n-f-1");
+    });
+
+    test("adding a node at end preserves existing IDs", async () => {
+      const recipe1 = new Recipe([
+        new Call("a", new ValueList([])),
+        new Call("b", new ValueList([])),
+      ]);
+      const recipe2 = new Recipe([
+        new Call("a", new ValueList([])),
+        new Call("b", new ValueList([])),
+        new Call("c", new ValueList([])),
+      ]);
+      const { dag: dag1 } = await makeDag(recipe1, dummyImporter);
+      const { dag: dag2 } = await makeDag(recipe2, dummyImporter);
+
+      const ids1 = getNodeIds(dag1);
+      const ids2 = getNodeIds(dag2);
+      // All original IDs are preserved
+      for (const id of ids1) {
+        expect(ids2).toContain(id);
+      }
+      // New node has expected ID
+      expect(ids2).toContain("root-n-c-0");
+    });
+
+    test("changing a node name changes only that node's ID", async () => {
+      const recipe1 = new Recipe([
+        new Call("a", new ValueList([])),
+        new Call("b", new ValueList([])),
+      ]);
+      const recipe2 = new Recipe([
+        new Call("a", new ValueList([])),
+        new Call("c", new ValueList([])),
+      ]);
+      const { dag: dag1 } = await makeDag(recipe1, dummyImporter);
+      const { dag: dag2 } = await makeDag(recipe2, dummyImporter);
+
+      const ids1 = getNodeIds(dag1);
+      const ids2 = getNodeIds(dag2);
+      // "a" ID preserved
+      expect(ids1).toContain("root-n-a-0");
+      expect(ids2).toContain("root-n-a-0");
+      // "b" gone, "c" appeared
+      expect(ids1).toContain("root-n-b-0");
+      expect(ids2).not.toContain("root-n-b-0");
+      expect(ids2).toContain("root-n-c-0");
+    });
+
+    test("node named 'n' does not collide with ID structure", async () => {
+      const recipe = new Recipe([
+        new Call("n", new ValueList([])),
+        new Call("e", new ValueList([])),
+        new Call("ns", new ValueList([])),
+      ]);
+      const { dag } = await makeDag(recipe, dummyImporter);
+      const nodeIds = getNodeIds(dag);
+      expect(nodeIds).toContain("root-n-n-0");
+      expect(nodeIds).toContain("root-n-e-0");
+      expect(nodeIds).toContain("root-n-ns-0");
+      // All three must be unique
+      expect(new Set(nodeIds).size).toBe(3);
+    });
+
+    test("unicode node names produce valid IDs", async () => {
+      const recipe = new Recipe([
+        new Call("sauté", new ValueList([])),
+        new Call("慢火", new ValueList([])),
+        new Call("_under", new ValueList([])),
+      ]);
+      const { dag } = await makeDag(recipe, dummyImporter);
+      const nodeIds = getNodeIds(dag);
+      expect(nodeIds).toContain("root-n-sauté-0");
+      expect(nodeIds).toContain("root-n-慢火-0");
+      expect(nodeIds).toContain("root-n-_under-0");
+      expect(new Set(nodeIds).size).toBe(3);
+    });
+
+    test("nested calls with same name produce unique IDs and correct edges", async () => {
+      // a(a(a(), a()), a(a(), a()))
+      const recipe = new Recipe([
+        new Call(
+          "a",
+          new ValueList([
+            new Call(
+              "a",
+              new ValueList([
+                new Call("a", new ValueList([])),
+                new Call("a", new ValueList([])),
+              ]),
+            ),
+            new Call(
+              "a",
+              new ValueList([
+                new Call("a", new ValueList([])),
+                new Call("a", new ValueList([])),
+              ]),
+            ),
+          ]),
+        ),
+      ]);
+      const { dag } = await makeDag(recipe, dummyImporter);
+      const nodes = dag.getNodeList();
+      const edges = dag.getEdgeList();
+      expect(nodes).toHaveLength(7);
+      expect(edges).toHaveLength(6);
+
+      // All node IDs must be unique
+      const nodeIds = nodes.map((n) => n.id);
+      expect(new Set(nodeIds).size).toBe(7);
+
+      // All edge source/target must reference existing nodes
+      const nodeIdSet = new Set(nodeIds);
+      for (const edge of edges) {
+        expect(nodeIdSet.has(edge.srcNodeId)).toBe(true);
+        expect(nodeIdSet.has(edge.destNodeId)).toBe(true);
+      }
+    });
+  });
+
+  describe("edges", () => {
+    test("edge IDs encode endpoints", async () => {
+      const recipe = new Recipe([
+        new Assignment(
+          [new LocalVariable("x")],
+          new Call("a", new ValueList([])),
+        ),
+        new Call("b", new ValueList([new QualifiedVariable(["x"])])),
+      ]);
+      const { dag } = await makeDag(recipe, dummyImporter);
+      const edgeIds = getEdgeIds(dag);
+      expect(edgeIds).toContain("root-e-root-n-a-0>root-n-b-0-0");
+    });
+
+    test("parallel edges between same nodes get unique IDs", async () => {
+      // x = a(); b(x, x) — two edges from a to b
+      const recipe = new Recipe([
+        new Assignment(
+          [new LocalVariable("x")],
+          new Call("a", new ValueList([])),
+        ),
+        new Call(
+          "b",
+          new ValueList([
+            new QualifiedVariable(["x"]),
+            new QualifiedVariable(["x"]),
+          ]),
+        ),
+      ]);
+      const { dag } = await makeDag(recipe, dummyImporter);
+      const edgeIds = getEdgeIds(dag);
+      expect(edgeIds).toHaveLength(2);
+      expect(edgeIds).toContain("root-e-root-n-a-0>root-n-b-0-0");
+      expect(edgeIds).toContain("root-e-root-n-a-0>root-n-b-0-1");
+    });
+
+    test("edge IDs are stable across identical compilations", async () => {
+      const makeRecipe = () =>
+        new Recipe([
+          new Assignment(
+            [new LocalVariable("x")],
+            new Call("a", new ValueList([])),
+          ),
+          new Call("b", new ValueList([new QualifiedVariable(["x"])])),
+        ]);
+      const { dag: dag1 } = await makeDag(makeRecipe(), dummyImporter);
+      const { dag: dag2 } = await makeDag(makeRecipe(), dummyImporter);
+      expect(getEdgeIds(dag1)).toEqual(getEdgeIds(dag2));
+    });
+  });
+
+  describe("namespaces", () => {
+    test("namespace nodes get scoped IDs", async () => {
+      const recipe = new Recipe([
+        new Namespace(
+          "myNs",
+          new StatementList([new Call("inner", new ValueList([]))]),
+        ),
+      ]);
+      const { dag } = await makeDag(recipe, dummyImporter);
+      const childDags = dag.getChildDags();
+      expect(childDags).toHaveLength(1);
+      expect(childDags[0].Id).toBe("root-ns-myNs-0");
+
+      const innerNodeIds = childDags[0].getNodeList().map((n) => n.id);
+      expect(innerNodeIds).toContain("root-ns-myNs-0-n-inner-0");
+    });
+
+    test("duplicate namespace names get unique scoped IDs", async () => {
+      const recipe = new Recipe([
+        new Namespace(
+          "foo",
+          new StatementList([new Call("a", new ValueList([]))]),
+        ),
+        new Namespace(
+          "foo",
+          new StatementList([new Call("b", new ValueList([]))]),
+        ),
+      ]);
+      const { dag } = await makeDag(recipe, dummyImporter);
+      const childDags = dag.getChildDags();
+      expect(childDags).toHaveLength(2);
+
+      expect(childDags[0].Id).toBe("root-ns-foo-0");
+      expect(childDags[1].Id).toBe("root-ns-foo-1");
+
+      const ids0 = childDags[0].getNodeList().map((n) => n.id);
+      const ids1 = childDags[1].getNodeList().map((n) => n.id);
+      expect(ids0).toContain("root-ns-foo-0-n-a-0");
+      expect(ids1).toContain("root-ns-foo-1-n-b-0");
+    });
+
+    test("node named 'n' does not collide with namespace named 'n'", async () => {
+      const recipe = new Recipe([
+        new Call("n", new ValueList([])),
+        new Namespace(
+          "n",
+          new StatementList([new Call("inner", new ValueList([]))]),
+        ),
+      ]);
+      const { dag } = await makeDag(recipe, dummyImporter);
+      const nodeId = "root-n-n-0";
+      const nsScope = "root-ns-n-0";
+
+      expect(getNodeIds(dag)).toContain(nodeId);
+      expect(dag.getChildDags()[0].Id).toBe(nsScope);
+      expect(nodeId).not.toBe(nsScope);
+    });
+  });
+});

--- a/tests/unit/renderers/cyDag/cyDiffer.test.ts
+++ b/tests/unit/renderers/cyDag/cyDiffer.test.ts
@@ -1,0 +1,191 @@
+import { describe, test, expect } from "vitest";
+import { diffCyElements } from "src/renderers/cyDag/cyDiffer";
+import { ElementsDefinition } from "cytoscape";
+
+describe("diffCyElements", () => {
+  test("identical elements produce empty diff with no topology change", () => {
+    const elements: ElementsDefinition = {
+      nodes: [{ data: { id: "n1", name: "a" } }],
+      edges: [{ data: { id: "e1", source: "n1", target: "n2" } }],
+    };
+    const diff = diffCyElements(elements, elements);
+    expect(diff.nodesToAdd).toEqual([]);
+    expect(diff.nodesToRemove).toEqual([]);
+    expect(diff.nodesToUpdate).toEqual([]);
+    expect(diff.edgesToAdd).toEqual([]);
+    expect(diff.edgesToRemove).toEqual([]);
+    expect(diff.edgesToUpdate).toEqual([]);
+    expect(diff.topologyChanged).toBe(false);
+  });
+
+  test("added node sets topologyChanged", () => {
+    const oldElements: ElementsDefinition = {
+      nodes: [{ data: { id: "n1", name: "a" } }],
+      edges: [],
+    };
+    const newElements: ElementsDefinition = {
+      nodes: [
+        { data: { id: "n1", name: "a" } },
+        { data: { id: "n2", name: "b" } },
+      ],
+      edges: [],
+    };
+    const diff = diffCyElements(oldElements, newElements);
+    expect(diff.nodesToAdd).toEqual([{ data: { id: "n2", name: "b" } }]);
+    expect(diff.topologyChanged).toBe(true);
+  });
+
+  test("removed node sets topologyChanged", () => {
+    const oldElements: ElementsDefinition = {
+      nodes: [
+        { data: { id: "n1", name: "a" } },
+        { data: { id: "n2", name: "b" } },
+      ],
+      edges: [],
+    };
+    const newElements: ElementsDefinition = {
+      nodes: [{ data: { id: "n1", name: "a" } }],
+      edges: [],
+    };
+    const diff = diffCyElements(oldElements, newElements);
+    expect(diff.nodesToRemove).toEqual(["n2"]);
+    expect(diff.topologyChanged).toBe(true);
+  });
+
+  test("changed node data produces update without topology change", () => {
+    const oldElements: ElementsDefinition = {
+      nodes: [{ data: { id: "n1", name: "a" } }],
+      edges: [],
+    };
+    const newElements: ElementsDefinition = {
+      nodes: [{ data: { id: "n1", name: "b" } }],
+      edges: [],
+    };
+    const diff = diffCyElements(oldElements, newElements);
+    expect(diff.nodesToUpdate).toEqual([
+      { id: "n1", data: { id: "n1", name: "b" }, classes: undefined },
+    ]);
+    expect(diff.topologyChanged).toBe(false);
+  });
+
+  test("changed node classes produces update without topology change", () => {
+    const oldElements: ElementsDefinition = {
+      nodes: [{ data: { id: "n1", name: "a" }, classes: "foo" }],
+      edges: [],
+    };
+    const newElements: ElementsDefinition = {
+      nodes: [{ data: { id: "n1", name: "a" }, classes: "bar" }],
+      edges: [],
+    };
+    const diff = diffCyElements(oldElements, newElements);
+    expect(diff.nodesToUpdate).toEqual([
+      { id: "n1", data: { id: "n1", name: "a" }, classes: "bar" },
+    ]);
+    expect(diff.topologyChanged).toBe(false);
+  });
+
+  test("added edge sets topologyChanged", () => {
+    const oldElements: ElementsDefinition = {
+      nodes: [],
+      edges: [],
+    };
+    const newElements: ElementsDefinition = {
+      nodes: [],
+      edges: [{ data: { id: "e1", source: "n1", target: "n2" } }],
+    };
+    const diff = diffCyElements(oldElements, newElements);
+    expect(diff.edgesToAdd).toHaveLength(1);
+    expect(diff.topologyChanged).toBe(true);
+  });
+
+  test("removed edge sets topologyChanged", () => {
+    const oldElements: ElementsDefinition = {
+      nodes: [],
+      edges: [{ data: { id: "e1", source: "n1", target: "n2" } }],
+    };
+    const newElements: ElementsDefinition = {
+      nodes: [],
+      edges: [],
+    };
+    const diff = diffCyElements(oldElements, newElements);
+    expect(diff.edgesToRemove).toEqual(["e1"]);
+    expect(diff.topologyChanged).toBe(true);
+  });
+
+  test("changed edge source/target sets topologyChanged", () => {
+    const oldElements: ElementsDefinition = {
+      nodes: [],
+      edges: [{ data: { id: "e1", source: "n1", target: "n2" } }],
+    };
+    const newElements: ElementsDefinition = {
+      nodes: [],
+      edges: [{ data: { id: "e1", source: "n1", target: "n3" } }],
+    };
+    const diff = diffCyElements(oldElements, newElements);
+    expect(diff.topologyChanged).toBe(true);
+    // Cytoscape edges have immutable source/target, so changed edges must be removed and re-added
+    expect(diff.edgesToRemove).toEqual(["e1"]);
+    expect(diff.edgesToAdd).toEqual([
+      { data: { id: "e1", source: "n1", target: "n3" } },
+    ]);
+    expect(diff.edgesToUpdate).toHaveLength(0);
+  });
+
+  test("changed edge data without source/target change does not set topologyChanged", () => {
+    const oldElements: ElementsDefinition = {
+      nodes: [],
+      edges: [{ data: { id: "e1", source: "n1", target: "n2", name: "x" } }],
+    };
+    const newElements: ElementsDefinition = {
+      nodes: [],
+      edges: [{ data: { id: "e1", source: "n1", target: "n2", name: "y" } }],
+    };
+    const diff = diffCyElements(oldElements, newElements);
+    expect(diff.topologyChanged).toBe(false);
+    expect(diff.edgesToUpdate).toEqual([
+      {
+        id: "e1",
+        data: { id: "e1", source: "n1", target: "n2", name: "y" },
+        classes: undefined,
+      },
+    ]);
+  });
+
+  test("identical array data does not produce update", () => {
+    const oldElements: ElementsDefinition = {
+      nodes: [{ data: { id: "n1", name: "a", order: [0, 1] } }],
+      edges: [],
+    };
+    const newElements: ElementsDefinition = {
+      nodes: [{ data: { id: "n1", name: "a", order: [0, 1] } }],
+      edges: [],
+    };
+    const diff = diffCyElements(oldElements, newElements);
+    expect(diff.nodesToUpdate).toEqual([]);
+    expect(diff.topologyChanged).toBe(false);
+  });
+
+  test("changed array data produces update", () => {
+    const oldElements: ElementsDefinition = {
+      nodes: [{ data: { id: "n1", name: "a", order: [0, 1] } }],
+      edges: [],
+    };
+    const newElements: ElementsDefinition = {
+      nodes: [{ data: { id: "n1", name: "a", order: [0, 2] } }],
+      edges: [],
+    };
+    const diff = diffCyElements(oldElements, newElements);
+    expect(diff.nodesToUpdate).toHaveLength(1);
+    expect(diff.topologyChanged).toBe(false);
+  });
+
+  test("empty old and new elements produce empty diff", () => {
+    const elements: ElementsDefinition = { nodes: [], edges: [] };
+    const diff = diffCyElements(elements, elements);
+    expect(diff.topologyChanged).toBe(false);
+    expect(diff.nodesToAdd).toEqual([]);
+    expect(diff.nodesToRemove).toEqual([]);
+    expect(diff.edgesToAdd).toEqual([]);
+    expect(diff.edgesToRemove).toEqual([]);
+  });
+});

--- a/tests/unit/renderers/cyDag/cyDifferIntegration.test.ts
+++ b/tests/unit/renderers/cyDag/cyDifferIntegration.test.ts
@@ -1,0 +1,144 @@
+import { describe, test, expect } from "vitest";
+import { diffCyElements } from "src/renderers/cyDag/cyDiffer";
+import { applyDiff } from "src/renderers/cyDag/cyUpdateHelpers";
+import cytoscape from "cytoscape";
+import { Compiler } from "src/compiler/driver";
+import { Dag } from "src/compiler/dag";
+import { makeCyElements } from "src/renderers/cyDag/cyGraphFactory";
+
+describe("diffCyElements integration", () => {
+  test("diff from empty to tree produces correct adds", async () => {
+    const compiler = new Compiler();
+    const compilation = await compiler.compileFromSource(
+      "a(a(a(), a()), a(a(), a()))",
+    );
+    const dag = compilation.DAG;
+    const newElements = makeCyElements(dag);
+
+    // Simulate the initial state: empty dag
+    const emptyElements = makeCyElements(new Dag(""));
+
+    const diff = diffCyElements(emptyElements, newElements);
+
+    expect(diff.nodesToAdd).toHaveLength(7);
+    expect(diff.edgesToAdd).toHaveLength(6);
+    expect(diff.nodesToRemove).toHaveLength(0);
+    expect(diff.edgesToRemove).toHaveLength(0);
+    expect(diff.topologyChanged).toBe(true);
+
+    // All added edges reference valid added node IDs
+    const addedNodeIds = new Set(diff.nodesToAdd.map((n) => n.data.id));
+    for (const edge of diff.edgesToAdd) {
+      expect(addedNodeIds.has(edge.data.source)).toBe(true);
+      expect(addedNodeIds.has(edge.data.target)).toBe(true);
+    }
+  });
+
+  test("headless Cytoscape handles diff path correctly", async () => {
+    const compiler = new Compiler();
+    const compilation = await compiler.compileFromSource(
+      "a(a(a(), a()), a(a(), a()))",
+    );
+    const newElements = makeCyElements(compilation.DAG);
+    const emptyDag = new Dag("");
+    const emptyElements = makeCyElements(emptyDag);
+
+    // Simulate diff path: start with empty, diff to tree
+    const cy = cytoscape({ headless: true });
+    cy.add(emptyElements);
+
+    const diff = diffCyElements(emptyElements, newElements);
+
+    // Apply diff in same order as CytoscapeRenderer
+    applyDiff(cy, diff);
+
+    // Verify same structure as full add
+    expect(cy.nodes().length).toBe(7);
+    expect(cy.edges().length).toBe(6);
+
+    cy.edges().forEach((edge) => {
+      expect(edge.source().length).toBe(1);
+      expect(edge.target().length).toBe(1);
+    });
+
+    const rootNode = cy.getElementById("root-n-a-0");
+    expect(rootNode.incomers("edge").length).toBe(2);
+
+    cy.destroy();
+  });
+
+  test("diff from partial tree to full tree preserves existing edges", async () => {
+    const compiler = new Compiler();
+    // Partial: a(a(a(), a()))  — only left subtree
+    const partial = await compiler.compileFromSource("a(a(a(), a()))");
+    const partialElements = makeCyElements(partial.DAG);
+
+    // Full: a(a(a(), a()), a(a(), a()))  — both subtrees
+    const full = await compiler.compileFromSource(
+      "a(a(a(), a()), a(a(), a()))",
+    );
+    const fullElements = makeCyElements(full.DAG);
+
+    // Build headless Cytoscape with partial tree
+    const cy = cytoscape({ headless: true });
+    cy.add(partialElements);
+    expect(cy.nodes().length).toBe(4);
+    expect(cy.edges().length).toBe(3);
+
+    // Apply diff to transition to full tree
+    const diff = diffCyElements(partialElements, fullElements);
+
+    // With endpoint-based edge IDs, all existing edges are preserved
+    // (no source/target changes), only new edges are added
+    expect(diff.edgesToRemove).toHaveLength(0);
+    expect(diff.edgesToUpdate).toHaveLength(0);
+    expect(diff.edgesToAdd).toHaveLength(3);
+    expect(diff.nodesToAdd).toHaveLength(3);
+    expect(diff.nodesToRemove).toHaveLength(0);
+
+    applyDiff(cy, diff);
+
+    // Verify correct binary tree structure
+    expect(cy.nodes().length).toBe(7);
+    expect(cy.edges().length).toBe(6);
+
+    // Root has exactly 2 incoming edges
+    const root = cy.getElementById("root-n-a-0");
+    expect(root.incomers("edge").length).toBe(2);
+
+    // Mid nodes each have exactly 2 incoming edges
+    expect(cy.getElementById("root-n-a-1").incomers("edge").length).toBe(2);
+    expect(cy.getElementById("root-n-a-4").incomers("edge").length).toBe(2);
+
+    // Leaves have 0 incoming edges
+    for (const leafId of [
+      "root-n-a-2",
+      "root-n-a-3",
+      "root-n-a-5",
+      "root-n-a-6",
+    ]) {
+      expect(cy.getElementById(leafId).incomers("edge").length).toBe(0);
+    }
+
+    cy.destroy();
+  });
+
+  test("recompiling same source produces empty diff", async () => {
+    const compiler = new Compiler();
+    const source = "a(a(a(), a()), a(a(), a()))";
+    const comp1 = await compiler.compileFromSource(source);
+    const comp2 = await compiler.compileFromSource(source);
+    const elements1 = makeCyElements(comp1.DAG);
+    const elements2 = makeCyElements(comp2.DAG);
+
+    const diff = diffCyElements(elements1, elements2);
+
+    expect(diff.nodesToAdd).toHaveLength(0);
+    expect(diff.nodesToRemove).toHaveLength(0);
+    expect(diff.nodesToUpdate).toHaveLength(0);
+    expect(diff.edgesToAdd).toHaveLength(0);
+    expect(diff.edgesToRemove).toHaveLength(0);
+    expect(diff.edgesToUpdate).toHaveLength(0);
+    expect(diff.topologyChanged).toBe(false);
+  });
+});

--- a/tests/unit/renderers/cyDag/cyPopperExtender.test.ts
+++ b/tests/unit/renderers/cyDag/cyPopperExtender.test.ts
@@ -196,7 +196,10 @@ describe("makes element descriptions", () => {
     });
 
     const expectedDescs: SelectorDescriptionPair[] = [
-      ["node#idX", makeDescriptionData("d1", new Map([["color", "red"]]))],
+      [
+        "node[id = 'idX']",
+        makeDescriptionData("d1", new Map([["color", "red"]])),
+      ],
     ];
     expect(getNodeDescriptions(testDag)).toEqual(expectedDescs);
   });
@@ -216,8 +219,8 @@ describe("makes element descriptions", () => {
     });
 
     const expectedDescs: SelectorDescriptionPair[] = [
-      ["node#idX", makeDescriptionData("d1")],
-      ["node#idY", makeDescriptionData("d2")],
+      ["node[id = 'idX']", makeDescriptionData("d1")],
+      ["node[id = 'idY']", makeDescriptionData("d2")],
     ];
     expect(getNodeDescriptions(testDag)).toEqual(expectedDescs);
   });
@@ -274,7 +277,10 @@ describe("makes element descriptions", () => {
     });
 
     const expectedDescs: SelectorDescriptionPair[] = [
-      ["edge#id1", makeDescriptionData("d1", new Map([["color", "red"]]))],
+      [
+        "edge[id = 'id1']",
+        makeDescriptionData("d1", new Map([["color", "red"]])),
+      ],
     ];
     expect(getEdgeDescriptions(testDag)).toEqual(expectedDescs);
   });
@@ -316,8 +322,8 @@ describe("makes element descriptions", () => {
     });
 
     const expectedDescs: SelectorDescriptionPair[] = [
-      ["edge#id1", makeDescriptionData("d1")],
-      ["edge#id2", makeDescriptionData("d2")],
+      ["edge[id = 'id1']", makeDescriptionData("d1")],
+      ["edge[id = 'id2']", makeDescriptionData("d2")],
     ];
     expect(getEdgeDescriptions(testDag)).toEqual(expectedDescs);
   });
@@ -326,7 +332,9 @@ describe("makes element descriptions", () => {
     const stylePropMap = new Map([[DESCRIPTION_PROPERTY, "d1"]]);
     const subdag = new Dag("subDagId", testDag, "subdag", [], stylePropMap);
 
-    const expectedDescs = [["node#subDagId", makeDescriptionData("d1")]];
+    const expectedDescs = [
+      ["node[id = 'subDagId']", makeDescriptionData("d1")],
+    ];
     expect(getCompoundNodeDescriptions(subdag)).toEqual(expectedDescs);
   });
 });
@@ -352,7 +360,7 @@ describe("subdag descriptions", () => {
     });
 
     const mockCoreSpy = addCyPoppersAndReturnMockCyCore(testDag);
-    expect(mockCoreSpy).toHaveBeenCalledWith("node#idX");
+    expect(mockCoreSpy).toHaveBeenCalledWith("node[id = 'idX']");
   });
   test("description on child dag", () => {
     const testDag = new Dag("DagId");
@@ -360,7 +368,7 @@ describe("subdag descriptions", () => {
     new Dag("childIdX", testDag, "child", [], descStyle);
 
     const mock = addCyPoppersAndReturnMockCyCore(testDag);
-    expect(mock).toHaveBeenCalledWith("node#childIdX");
+    expect(mock).toHaveBeenCalledWith("node[id = 'childIdX']");
   });
   test("description in root dag style", () => {
     const testDag = new Dag("DagId");
@@ -446,13 +454,13 @@ describe("subdag descriptions", () => {
 
     const mock = addCyPoppersAndReturnMockCyCore(testDag);
     expect(mock).toHaveBeenCalledWith(".childStyle1[lineagePath*='/childId1']");
-    expect(mock).toHaveBeenCalledWith("node#childId2");
+    expect(mock).toHaveBeenCalledWith("node[id = 'childId2']");
 
     // like name bindings, conflicting descriptions are likely impractical
     // except as a defensive measure for styles not intended to be reused
     const expectedDescs: SelectorDescriptionPair[] = [
-      ["node#childId2", makeDescriptionData("d2")],
-      ["node#childId2", makeDescriptionData("d1")],
+      ["node[id = 'childId2']", makeDescriptionData("d2")],
+      ["node[id = 'childId2']", makeDescriptionData("d1")],
     ];
     expect(getNodeDescriptions(childDag2)).toEqual(expectedDescs);
   });

--- a/tests/unit/renderers/cyDag/cyStyleSheetsFactory.test.ts
+++ b/tests/unit/renderers/cyDag/cyStyleSheetsFactory.test.ts
@@ -130,7 +130,7 @@ describe("makes cytoscape stylesheets", () => {
     });
     const expectedCyNodeStyles = [
       {
-        selector: "node#idY",
+        selector: "node[id = 'idY']",
         css: { a: "1" },
       },
     ];
@@ -160,7 +160,7 @@ describe("makes cytoscape stylesheets", () => {
     });
     const expectedCyEdgeStyles = [
       {
-        selector: "edge#idZ",
+        selector: "edge[id = 'idZ']",
         css: { a: "1" },
       },
     ];
@@ -345,7 +345,7 @@ describe("makes cytoscape stylesheets", () => {
 
     const expectedCyStyles = getBaseStylesheet().concat([
       {
-        selector: "node#x",
+        selector: "node[id = 'x']",
         css: { "background-color": "blue" },
       },
     ]);
@@ -411,7 +411,7 @@ describe("makes cytoscape stylesheets", () => {
     });
     const expectedCyStyles = getBaseStylesheet().concat([
       {
-        selector: "node#idX",
+        selector: "node[id = 'idX']",
         css: { "background-color": "red" },
       },
       {
@@ -438,7 +438,7 @@ describe("makes cytoscape stylesheets", () => {
         css: { "background-color": "red" },
       },
       {
-        selector: "node#idX",
+        selector: "node[id = 'idX']",
         css: { "background-color": "red" },
       },
     ]);

--- a/tests/unit/renderers/cyDag/stableIdsCyIntegration.test.ts
+++ b/tests/unit/renderers/cyDag/stableIdsCyIntegration.test.ts
@@ -1,0 +1,166 @@
+import { describe, test, expect } from "vitest";
+import {
+  RecipeTreeNode as Recipe,
+  CallTreeNode as Call,
+  AssignmentTreeNode as Assignment,
+  LocalVarTreeNode as LocalVariable,
+  QualifiedVarTreeNode as QualifiedVariable,
+  ValueListTreeNode as ValueList,
+} from "src/compiler/ast";
+import { makeDag } from "src/compiler/dagFactory";
+import { Compiler } from "src/compiler/driver";
+import { ImportCacher } from "src/compiler/importCacher";
+import { makeCyElements } from "src/renderers/cyDag/cyGraphFactory";
+import cytoscape from "cytoscape";
+
+const dummyImporter = {} as ImportCacher;
+
+describe("stable IDs with Cytoscape integration", () => {
+  test("unicode node IDs work in headless Cytoscape selectors", async () => {
+    const recipe = new Recipe([
+      new Assignment(
+        [new LocalVariable("x")],
+        new Call("sauté", new ValueList([])),
+      ),
+      new Call("慢火", new ValueList([new QualifiedVariable(["x"])])),
+    ]);
+    const { dag } = await makeDag(recipe, dummyImporter);
+    const cyElements = makeCyElements(dag);
+
+    const cy = cytoscape({ headless: true });
+    cy.add(cyElements);
+
+    // Attribute selectors must resolve unicode IDs
+    const sauteNode = cy.elements("node[id = 'root-n-sauté-0']");
+    expect(sauteNode.length).toBe(1);
+
+    const simmerNode = cy.elements("node[id = 'root-n-慢火-0']");
+    expect(simmerNode.length).toBe(1);
+
+    // Edge with unicode endpoint IDs must resolve
+    const edges = cy.edges();
+    expect(edges.length).toBe(1);
+    expect(edges[0].source().id()).toBe("root-n-sauté-0");
+    expect(edges[0].target().id()).toBe("root-n-慢火-0");
+
+    // Edge attribute selector with > separator must work
+    const edgeSel = cy.elements(
+      "edge[id = 'root-e-root-n-sauté-0>root-n-慢火-0-0']",
+    );
+    expect(edgeSel.length).toBe(1);
+
+    cy.destroy();
+  });
+
+  test("edge IDs with > work in Cytoscape attribute selectors but not # selectors", async () => {
+    const recipe = new Recipe([
+      new Assignment(
+        [new LocalVariable("x")],
+        new Call("a", new ValueList([])),
+      ),
+      new Call("b", new ValueList([new QualifiedVariable(["x"])])),
+    ]);
+    const { dag } = await makeDag(recipe, dummyImporter);
+    const cyElements = makeCyElements(dag);
+
+    const cy = cytoscape({ headless: true });
+    cy.add(cyElements);
+
+    const edgeId = "root-e-root-n-a-0>root-n-b-0-0";
+
+    // getElementById: always works
+    expect(cy.getElementById(edgeId).length).toBe(1);
+
+    // Attribute selector: works (> is inside quotes)
+    expect(cy.elements(`edge[id = '${edgeId}']`).length).toBe(1);
+
+    // # selector: fails (> is a CSS combinator outside quotes)
+    expect(cy.elements(`#${edgeId}`).length).toBe(0);
+
+    cy.destroy();
+  });
+
+  test("CyElements for tree have correct edge source/target", async () => {
+    const compiler = new Compiler();
+    const compilation = await compiler.compileFromSource(
+      "a(a(a(), a()), a(a(), a()))",
+    );
+    const dag = compilation.DAG;
+    const cyElements = makeCyElements(dag);
+
+    expect(cyElements.nodes).toHaveLength(7);
+    expect(cyElements.edges).toHaveLength(6);
+
+    // All node IDs are unique
+    const nodeIds = new Set(cyElements.nodes.map((n) => n.data.id));
+    expect(nodeIds.size).toBe(7);
+
+    // All edge source/target reference valid node IDs
+    for (const edge of cyElements.edges) {
+      expect(nodeIds.has(edge.data.source)).toBe(true);
+      expect(nodeIds.has(edge.data.target)).toBe(true);
+    }
+
+    // Verify correct tree structure via in-degree
+    const inDegree = new Map<string, number>();
+    for (const node of cyElements.nodes)
+      inDegree.set(node.data.id as string, 0);
+    for (const edge of cyElements.edges) {
+      const target = edge.data.target as string;
+      inDegree.set(target, (inDegree.get(target) ?? 0) + 1);
+    }
+    const degrees = Array.from(inDegree.values()).sort();
+    expect(degrees).toEqual([0, 0, 0, 0, 2, 2, 2]);
+  });
+
+  test("headless Cytoscape resolves edges correctly with stable IDs", async () => {
+    const compiler = new Compiler();
+    const compilation = await compiler.compileFromSource(
+      "a(a(a(), a()), a(a(), a()))",
+    );
+    const cyElements = makeCyElements(compilation.DAG);
+
+    // Create headless Cytoscape instance and add elements
+    const cy = cytoscape({ headless: true });
+    cy.add(cyElements);
+
+    // Verify all 7 nodes exist
+    expect(cy.nodes().length).toBe(7);
+    // Verify all 6 edges exist
+    expect(cy.edges().length).toBe(6);
+
+    // Verify every edge has valid source and target
+    cy.edges().forEach((edge) => {
+      const src = edge.source();
+      const tgt = edge.target();
+      expect(src.length).toBe(1);
+      expect(tgt.length).toBe(1);
+      // Source and target should be different nodes
+      expect(src.id()).not.toBe(tgt.id());
+    });
+
+    // Verify tree structure: root node (a-0) should have 2 incoming edges
+    const rootNode = cy.getElementById("root-n-a-0");
+    expect(rootNode.length).toBe(1);
+    expect(rootNode.incomers("edge").length).toBe(2);
+
+    // Mid nodes should each have 2 incoming edges
+    const mid1 = cy.getElementById("root-n-a-1");
+    const mid2 = cy.getElementById("root-n-a-4");
+    expect(mid1.incomers("edge").length).toBe(2);
+    expect(mid2.incomers("edge").length).toBe(2);
+
+    // Leaf nodes should have 0 incoming edges
+    for (const leafId of [
+      "root-n-a-2",
+      "root-n-a-3",
+      "root-n-a-5",
+      "root-n-a-6",
+    ]) {
+      const leaf = cy.getElementById(leafId);
+      expect(leaf.incomers("edge").length).toBe(0);
+    }
+
+    cy.destroy();
+  });
+});


### PR DESCRIPTION
This pull request introduces stable, deterministic IDs for DAG nodes and edges in the compiler, replacing the previous use of random UUIDs. This change enables the renderer to preserve element positions and styles across recompilations. Additionally, the Cytoscape renderer is updated to efficiently diff and update the graph, only applying changes as needed rather than re-rendering the entire graph, which improves overall performance for incremental updates.

**Compiler: Stable ID generation and propagation**
- Added a new `StableIdContext` class and `ScopeKind` enum in `dagFactory.ts` to generate stable, hierarchical IDs for nodes and edges based on their scope and order, replacing all usages of `uuidv4()` for node and edge IDs. [[1]](diffhunk://#diff-92468ff1ea4315eda133b70335b2bfd6f2fe66581931bab996f19d26cfa4da22R29-R78) [[2]](diffhunk://#diff-92468ff1ea4315eda133b70335b2bfd6f2fe66581931bab996f19d26cfa4da22R187-R190) [[3]](diffhunk://#diff-92468ff1ea4315eda133b70335b2bfd6f2fe66581931bab996f19d26cfa4da22R208-R210) [[4]](diffhunk://#diff-92468ff1ea4315eda133b70335b2bfd6f2fe66581931bab996f19d26cfa4da22R238-R259) [[5]](diffhunk://#diff-92468ff1ea4315eda133b70335b2bfd6f2fe66581931bab996f19d26cfa4da22L247-R307) [[6]](diffhunk://#diff-92468ff1ea4315eda133b70335b2bfd6f2fe66581931bab996f19d26cfa4da22L269-R333)
- Updated all DAG construction and processing functions (`processCall`, `processNamespace`, `processImport`, `processAssignment`, etc.) to pass and use the new `StableIdContext`, ensuring all IDs are generated deterministically. [[1]](diffhunk://#diff-92468ff1ea4315eda133b70335b2bfd6f2fe66581931bab996f19d26cfa4da22R132) [[2]](diffhunk://#diff-92468ff1ea4315eda133b70335b2bfd6f2fe66581931bab996f19d26cfa4da22L308-R373) [[3]](diffhunk://#diff-92468ff1ea4315eda133b70335b2bfd6f2fe66581931bab996f19d26cfa4da22R382) [[4]](diffhunk://#diff-92468ff1ea4315eda133b70335b2bfd6f2fe66581931bab996f19d26cfa4da22R392) [[5]](diffhunk://#diff-92468ff1ea4315eda133b70335b2bfd6f2fe66581931bab996f19d26cfa4da22R414) [[6]](diffhunk://#diff-92468ff1ea4315eda133b70335b2bfd6f2fe66581931bab996f19d26cfa4da22R446) [[7]](diffhunk://#diff-92468ff1ea4315eda133b70335b2bfd6f2fe66581931bab996f19d26cfa4da22R515-R519) [[8]](diffhunk://#diff-92468ff1ea4315eda133b70335b2bfd6f2fe66581931bab996f19d26cfa4da22R586-R588) [[9]](diffhunk://#diff-92468ff1ea4315eda133b70335b2bfd6f2fe66581931bab996f19d26cfa4da22L528-R610) [[10]](diffhunk://#diff-92468ff1ea4315eda133b70335b2bfd6f2fe66581931bab996f19d26cfa4da22R621-R633)

**Renderer: Efficient graph updates**
- Added diffing and patching logic to the Cytoscape renderer: now, instead of removing and re-adding all elements, the renderer computes the difference between the previous and new graph elements and applies only the necessary updates. [[1]](diffhunk://#diff-27890629883e60f7d2ae757d1f5209067b326824b0eb4e47d79bf4cefee7912bR30-R31) [[2]](diffhunk://#diff-27890629883e60f7d2ae757d1f5209067b326824b0eb4e47d79bf4cefee7912bL162-R199)
- Introduced a `previousElements` field to track the last rendered state and avoid unnecessary layout recalculations when the topology hasn't changed. [[1]](diffhunk://#diff-27890629883e60f7d2ae757d1f5209067b326824b0eb4e47d79bf4cefee7912bR118) [[2]](diffhunk://#diff-27890629883e60f7d2ae757d1f5209067b326824b0eb4e47d79bf4cefee7912bL162-R199)
- Refactored layout and style application to only run when needed, further improving performance for incremental changes. [[1]](diffhunk://#diff-27890629883e60f7d2ae757d1f5209067b326824b0eb4e47d79bf4cefee7912bL143-R159) [[2]](diffhunk://#diff-27890629883e60f7d2ae757d1f5209067b326824b0eb4e47d79bf4cefee7912bL162-R199)

These changes together enable more responsive updates, especially when editing large DAGs.