### PR TITLE
fix(CytoscapeRenderer): ensure consistent visual order between DAG changes

### DIFF
--- a/src/renderers/cyDag/CytoscapeRenderer.vue
+++ b/src/renderers/cyDag/CytoscapeRenderer.vue
@@ -35,7 +35,7 @@ import {
   addDescriptionGhostNodes,
   PopperCleanup,
 } from "./cyPopperExtender";
-import { diffCyElements, applyDiff } from "./cyDiffer";
+import { diffCyElements, applyDataUpdates } from "./cyDiffer";
 import { Dag } from "../../compiler/dag";
 import { ExportFormat } from "../../compiler/constants";
 import { saveAs } from "file-saver";
@@ -201,7 +201,18 @@ const CytoscapeRenderer = defineComponent({
         this.runLayout();
       } else {
         const diff = diffCyElements(this.previousElements, newElements);
-        applyDiff(this.cy, diff);
+
+        if (diff.topologyChanged) {
+          // Full replace to preserve elements' visual ordering in Dagre layout.
+          // Re-added nodes would otherwise appear at the end of Cytoscape's
+          // internal collection, causing Dagre's sort hint to lose to its
+          // crossing minimization heuristic.
+          // This ensures we get consistent layouts for the same DAG structure.
+          this.cy.elements().remove();
+          this.cy.add(newElements);
+        } else {
+          applyDataUpdates(this.cy, diff);
+        }
 
         this.applyStyles(newStylesheets);
         this.popperCleanup?.();
@@ -212,9 +223,7 @@ const CytoscapeRenderer = defineComponent({
         );
 
         // Avoid unnecessary layout runs by checking if the topology has changed
-        if (diff.topologyChanged) {
-          this.runLayout();
-        }
+        if (diff.topologyChanged) this.runLayout();
       }
 
       this.previousElements = newElements;

--- a/src/renderers/cyDag/cyDiffer.ts
+++ b/src/renderers/cyDag/cyDiffer.ts
@@ -174,6 +174,16 @@ export function diffCyElements(
   };
 }
 
+export function applyDataUpdates(cy: Core, diff: CyDiffResult): void {
+  cy.batch(() => {
+    for (const upd of [...diff.nodesToUpdate, ...diff.edgesToUpdate]) {
+      const ele = cy.getElementById(upd.id);
+      ele.data(upd.data);
+      if (upd.classes !== undefined) ele.classes(upd.classes);
+    }
+  });
+}
+
 export function applyDiff(cy: Core, diff: CyDiffResult): void {
   cy.batch(() => {
     for (const id of [...diff.nodesToRemove, ...diff.edgesToRemove]) {
@@ -181,10 +191,6 @@ export function applyDiff(cy: Core, diff: CyDiffResult): void {
     }
     cy.add(diff.nodesToAdd);
     cy.add(diff.edgesToAdd);
-    for (const upd of [...diff.nodesToUpdate, ...diff.edgesToUpdate]) {
-      const ele = cy.getElementById(upd.id);
-      ele.data(upd.data);
-      if (upd.classes !== undefined) ele.classes(upd.classes);
-    }
+    applyDataUpdates(cy, diff);
   });
 }

--- a/tests/unit/renderers/cyDag/cyDifferIntegration.test.ts
+++ b/tests/unit/renderers/cyDag/cyDifferIntegration.test.ts
@@ -1,6 +1,10 @@
-import { describe, test, expect } from "vitest";
-import { diffCyElements, applyDiff } from "src/renderers/cyDag/cyDiffer";
-import cytoscape from "cytoscape";
+import { afterEach, describe, test, expect } from "vitest";
+import {
+  diffCyElements,
+  applyDiff,
+  applyDataUpdates,
+} from "src/renderers/cyDag/cyDiffer";
+import cytoscape, { Core, ElementsDefinition } from "cytoscape";
 import { Compiler } from "src/compiler/driver";
 import { Dag } from "src/compiler/dag";
 import { makeCyElements } from "src/renderers/cyDag/cyGraphFactory";
@@ -122,6 +126,44 @@ describe("diffCyElements integration", () => {
     cy.destroy();
   });
 
+  test("element order data is stable after remove and re-add", async () => {
+    const compiler = new Compiler();
+
+    // Original: x = f(), a(x), b(x)
+    const original = await compiler.compileFromSource("x = f()\na(x)\nb(x)");
+    const originalElements = makeCyElements(original.DAG);
+
+    // Remove a(x): x = f(), b(x)
+    const reduced = await compiler.compileFromSource("x = f()\nb(x)");
+    const reducedElements = makeCyElements(reduced.DAG);
+
+    // Restore a(x): x = f(), a(x), b(x)
+    const restored = await compiler.compileFromSource("x = f()\na(x)\nb(x)");
+    const restoredElements = makeCyElements(restored.DAG);
+
+    // Build a map of node id → order for easy comparison
+    const getOrderMap = (elements: ReturnType<typeof makeCyElements>) => {
+      const map = new Map<string, number[]>();
+      for (const node of elements.nodes) {
+        map.set(node.data.id as string, node.data.order as number[]);
+      }
+      return map;
+    };
+
+    const originalOrders = getOrderMap(originalElements);
+    const restoredOrders = getOrderMap(restoredElements);
+
+    // Verify the reduced compilation actually removed a node (sanity check)
+    const reducedOrders = getOrderMap(reducedElements);
+    expect(reducedOrders.size).toBeLessThan(originalOrders.size);
+
+    // The restored elements should have the same order values as the originals
+    expect(restoredOrders.size).toBe(originalOrders.size);
+    for (const [id, order] of originalOrders) {
+      expect(restoredOrders.get(id)).toEqual(order);
+    }
+  });
+
   test("recompiling same source produces empty diff", async () => {
     const compiler = new Compiler();
     const source = "a(a(a(), a()), a(a(), a()))";
@@ -139,5 +181,107 @@ describe("diffCyElements integration", () => {
     expect(diff.edgesToRemove).toHaveLength(0);
     expect(diff.edgesToUpdate).toHaveLength(0);
     expect(diff.topologyChanged).toBe(false);
+  });
+});
+
+describe("applyDataUpdates", () => {
+  let cy: Core;
+
+  afterEach(() => {
+    cy.destroy();
+  });
+
+  function applyDataUpdateScenario(
+    oldElements: ElementsDefinition,
+    newElements: ElementsDefinition,
+    initialElements: ElementsDefinition = oldElements,
+  ) {
+    cy = cytoscape({ headless: true });
+    cy.add(initialElements);
+
+    const diff = diffCyElements(oldElements, newElements);
+    applyDataUpdates(cy, diff);
+
+    return { diff, cy };
+  }
+
+  test("updates node data in place", () => {
+    const oldElements: ElementsDefinition = {
+      nodes: [{ data: { id: "n1", name: "old" } }],
+      edges: [],
+    };
+    const newElements: ElementsDefinition = {
+      nodes: [{ data: { id: "n1", name: "new" } }],
+      edges: [],
+    };
+
+    const { diff, cy } = applyDataUpdateScenario(oldElements, newElements);
+
+    expect(diff.topologyChanged).toBe(false);
+    expect(cy.getElementById("n1").data("name")).toBe("new");
+  });
+
+  test("updates node classes in place", () => {
+    const oldElements: ElementsDefinition = {
+      nodes: [{ data: { id: "n1" }, classes: "foo" }],
+      edges: [],
+    };
+    const newElements: ElementsDefinition = {
+      nodes: [{ data: { id: "n1" }, classes: "bar" }],
+      edges: [],
+    };
+
+    const { diff, cy } = applyDataUpdateScenario(oldElements, newElements);
+
+    expect(diff.topologyChanged).toBe(false);
+    expect(cy.getElementById("n1").hasClass("bar")).toBe(true);
+    expect(cy.getElementById("n1").hasClass("foo")).toBe(false);
+  });
+
+  test("updates edge data in place", () => {
+    const oldElements: ElementsDefinition = {
+      nodes: [{ data: { id: "n1" } }, { data: { id: "n2" } }],
+      edges: [{ data: { id: "e1", source: "n1", target: "n2", label: "old" } }],
+    };
+    const newElements: ElementsDefinition = {
+      nodes: [{ data: { id: "n1" } }, { data: { id: "n2" } }],
+      edges: [{ data: { id: "e1", source: "n1", target: "n2", label: "new" } }],
+    };
+
+    const { diff, cy } = applyDataUpdateScenario(oldElements, newElements);
+
+    expect(diff.topologyChanged).toBe(false);
+    expect(cy.getElementById("e1").data("label")).toBe("new");
+  });
+
+  test("does not add or remove elements", () => {
+    const oldElements: ElementsDefinition = {
+      nodes: [{ data: { id: "n1", name: "a" } }],
+      edges: [],
+    };
+    const newElements: ElementsDefinition = {
+      nodes: [
+        { data: { id: "n1", name: "a" } },
+        { data: { id: "n2", name: "b" } },
+      ],
+      edges: [],
+    };
+
+    const { diff, cy } = applyDataUpdateScenario(oldElements, newElements);
+
+    expect(diff.topologyChanged).toBe(true);
+    expect(cy.nodes().length).toBe(1);
+  });
+
+  test("no-op on empty diff", () => {
+    const elements: ElementsDefinition = {
+      nodes: [{ data: { id: "n1", name: "a" } }],
+      edges: [],
+    };
+
+    const { diff, cy } = applyDataUpdateScenario(elements, elements);
+
+    expect(diff.topologyChanged).toBe(false);
+    expect(cy.getElementById("n1").data("name")).toBe("a");
   });
 });


### PR DESCRIPTION
This pull request refactors how Cytoscape element updates are applied for layout consistency and splits data/class updates for efficiency. It introduces a new `applyDataUpdates` function, updates usages in the renderer, and adds comprehensive tests for element update behaviors.

Previously, removing and adding nodes back would result in a different visual ordering. This change ensure that visual layout is consistent for the same code regardless of edits.

**Renderer and Differ Refactoring:**

* Replaces calls to `applyDiff` with `applyDataUpdates` in `CytoscapeRenderer.vue` for cases where only node/edge data or classes change, and performs a full element replacement only when the topology changes, ensuring consistent element ordering and layouts. [[1]](diffhunk://#diff-27890629883e60f7d2ae757d1f5209067b326824b0eb4e47d79bf4cefee7912bL38-R38) [[2]](diffhunk://#diff-27890629883e60f7d2ae757d1f5209067b326824b0eb4e47d79bf4cefee7912bL204-R215) [[3]](diffhunk://#diff-27890629883e60f7d2ae757d1f5209067b326824b0eb4e47d79bf4cefee7912bL215-R226)
* Refactors `cyDiffer.ts` by extracting data/class updates into the new `applyDataUpdates` function.

**Testing Improvements:**

* Adds a new test suite for `applyDataUpdates` that verifies in-place updates for node/edge data and classes, ensures no elements are added/removed, and checks no-ops on empty diffs.
* Introduces an integration test to confirm that node ordering is preserved after removing and re-adding nodes, ensuring stable layouts.