### PR TITLE
fix: adjust dark mode colors and add tab to autocomplete

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -4,7 +4,7 @@
       <TextEditor
         ref="textEditor"
         :editor-debounce-delay="editorDebounceDelay"
-        :tab-to-indent="tabToIndent"
+        :enable-tabbing-in-editor="enableTabbingInEditor"
         :code-diagnostics="curDiagnostics"
         :completion-index="curCompletionIndex"
         :debug-mode="debugMode"
@@ -71,7 +71,7 @@
   />
   <OptionsPopup
     v-model:show-options="showOptionsPopup"
-    v-model:tab-to-indent="tabToIndent"
+    v-model:enable-tabbing-in-editor="enableTabbingInEditor"
     v-model:debug-mode="debugMode"
     v-model:theme-mode="themeMode"
     v-model:selected-renderer="selectedRenderer"
@@ -120,7 +120,7 @@ const confettiEffect = ref<InstanceType<typeof ConfettiEffect> | null>(null);
 const editorDebounceDelay = 300; // ms
 const optionsStore = new OptionsStore();
 const debugMode = ref(false);
-const tabToIndent = ref(false);
+const enableTabbingInEditor = ref(false);
 const showExportPopup = ref(false);
 const showOptionsPopup = ref(false);
 const tutorialMode = ref(false);
@@ -174,14 +174,14 @@ const tutorialModuleStartIndices = computed(() =>
 // Options persistence
 function persistOptions() {
   optionsStore.save({
-    tabToIndent: tabToIndent.value,
+    enableTabbingInEditor: enableTabbingInEditor.value,
     debugMode: debugMode.value,
     selectedRenderer: selectedRenderer.value,
     themeMode: themeMode.value,
   });
 }
 
-watch(tabToIndent, () => persistOptions());
+watch(enableTabbingInEditor, () => persistOptions());
 watch(debugMode, (newVal: boolean) => {
   tutorialManager.setDisableAnimations(newVal);
   repaint();
@@ -245,7 +245,7 @@ function onRestartTutorial() {
 // Lifecycle
 onMounted(() => {
   const savedOptions = optionsStore.load();
-  tabToIndent.value = savedOptions.tabToIndent;
+  enableTabbingInEditor.value = savedOptions.enableTabbingInEditor;
   debugMode.value = savedOptions.debugMode;
   selectedRenderer.value = savedOptions.selectedRenderer;
   themeMode.value = savedOptions.themeMode ?? "system";

--- a/src/components/OptionsPopup.vue
+++ b/src/components/OptionsPopup.vue
@@ -13,17 +13,17 @@
       <v-card-text class="py-1">
         <div>
           <v-checkbox
-            label="Tab to Indent"
+            label="Tab to Indent / Autocomplete"
             hide-details
-            :model-value="tabToIndent"
-            @update:model-value="$emit('update:tabToIndent', $event)"
+            :model-value="enableTabbingInEditor"
+            @update:model-value="$emit('update:enableTabbingInEditor', $event)"
           />
           <v-tooltip
             activator="parent"
-            :model-value="tabToIndent"
+            :model-value="enableTabbingInEditor"
             :open-on-hover="false"
             location="start"
-            text="Press Esc to ignore next Tab indent"
+            text="Press Esc to ignore next Tab"
           />
         </div>
         <v-checkbox
@@ -76,7 +76,7 @@ export default defineComponent({
       type: Boolean,
       required: true,
     },
-    tabToIndent: {
+    enableTabbingInEditor: {
       type: Boolean,
       required: true,
     },
@@ -99,7 +99,7 @@ export default defineComponent({
   },
   emits: [
     "update:showOptions",
-    "update:tabToIndent",
+    "update:enableTabbingInEditor",
     "update:debugMode",
     "update:themeMode",
     "update:selectedRenderer",

--- a/src/components/TextEditor.vue
+++ b/src/components/TextEditor.vue
@@ -10,6 +10,8 @@ import {
   closeBrackets,
   closeBracketsKeymap,
   autocompletion,
+  completionKeymap,
+  acceptCompletion,
 } from "@codemirror/autocomplete";
 import {
   defaultKeymap,
@@ -125,7 +127,7 @@ export default defineComponent({
       type: Number,
       default: 300, // ms
     },
-    tabToIndent: {
+    enableTabbingInEditor: {
       type: Boolean,
       default: false,
     },
@@ -258,7 +260,10 @@ export default defineComponent({
         ...searchKeymap,
         ...foldKeymap,
         ...closeBracketsKeymap,
-        ...(isTabbingOn ? [indentWithTab] : []),
+        ...completionKeymap,
+        ...(isTabbingOn
+          ? [{ key: "Tab", run: acceptCompletion }, indentWithTab]
+          : []),
       ]);
     };
 
@@ -295,7 +300,7 @@ export default defineComponent({
         EditorView.updateListener.of((v: ViewUpdate): void => {
           if (v.docChanged) emitEditorState(v.state);
         }),
-        keymapCompartment.of(getKeymap(this.tabToIndent)),
+        keymapCompartment.of(getKeymap(this.enableTabbingInEditor)),
         autocompletionCompartment.of(
           createAutocompletion(this.completionIndex, this.selectedRenderer),
         ),
@@ -317,7 +322,7 @@ export default defineComponent({
     view.focus();
 
     watch(
-      () => this.tabToIndent,
+      () => this.enableTabbingInEditor,
       (isTabbingOn) => {
         view.dispatch({
           effects: keymapCompartment.reconfigure(getKeymap(isTabbingOn)),

--- a/src/optionsStore.ts
+++ b/src/optionsStore.ts
@@ -3,14 +3,14 @@ import { VersionedStore } from "./versionedStore";
 export type ThemeMode = "light" | "dark" | "system";
 
 export interface Options {
-  tabToIndent: boolean;
+  enableTabbingInEditor: boolean;
   debugMode: boolean;
   selectedRenderer: string;
   themeMode?: ThemeMode;
 }
 
 const DEFAULTS: Options = {
-  tabToIndent: false,
+  enableTabbingInEditor: false, // off by default to avoid focus trapping
   debugMode: false,
   selectedRenderer: "cytoscape",
 };

--- a/src/renderers/cyDag/cyStyleSheetsFactory.ts
+++ b/src/renderers/cyDag/cyStyleSheetsFactory.ts
@@ -156,6 +156,7 @@ export function makeNameStyleSheets(dag: Dag): StylesheetCSS[] {
 export function getBaseStylesheet(isDark = false): StylesheetCSS[] {
   const labelColor = isDark ? "#e0e0e0" : "#000";
   const edgeColor = isDark ? "#aaa" : "#999";
+  const namespaceBackground = isDark ? "#2a2a2a" : "#f0f0f0";
   return [
     {
       selector: "node",
@@ -164,6 +165,12 @@ export function getBaseStylesheet(isDark = false): StylesheetCSS[] {
         color: labelColor,
         "text-valign": "bottom",
         "text-wrap": "wrap",
+      },
+    },
+    {
+      selector: "node:parent",
+      css: {
+        "background-color": namespaceBackground,
       },
     },
     {

--- a/src/renderers/minExample/MinimalExampleRenderer.vue
+++ b/src/renderers/minExample/MinimalExampleRenderer.vue
@@ -1,5 +1,9 @@
 <template>
-  <div ref="container" class="minimal-example-renderer">
+  <div
+    ref="container"
+    class="minimal-example-renderer"
+    :class="{ 'dark-mode': isDark }"
+  >
     <div class="stats">
       <h3>Basic DAG Statistics</h3>
       <ul>
@@ -30,6 +34,10 @@ const MinimalExampleRenderer = defineComponent({
     dag: {
       type: Object as PropType<Dag>,
       required: true,
+    },
+    isDark: {
+      type: Boolean,
+      default: false,
     },
   },
   computed: {
@@ -93,15 +101,29 @@ export default Object.assign(MinimalExampleRenderer, {
   overflow: auto;
 }
 
+.minimal-example-renderer.dark-mode {
+  background-color: #0d0d0d;
+  border-color: #2a2a2a;
+}
+
 .stats {
   margin-bottom: 20px;
   padding: 15px;
   border-radius: 4px;
+  background-color: #ffffff;
+}
+
+.minimal-example-renderer.dark-mode .stats {
+  background-color: #1a1a1a;
 }
 
 .stats h3 {
   margin-top: 0;
-  color: #333;
+  color: #333333;
+}
+
+.minimal-example-renderer.dark-mode .stats h3 {
+  color: #ffffff;
 }
 
 .stats ul {
@@ -111,6 +133,10 @@ export default Object.assign(MinimalExampleRenderer, {
 
 .stats li {
   padding: 5px 0;
-  color: #666;
+  color: #666666;
+}
+
+.minimal-example-renderer.dark-mode .stats li {
+  color: #d0d0d0;
 }
 </style>

--- a/tests/unit/optionsStore.test.ts
+++ b/tests/unit/optionsStore.test.ts
@@ -11,8 +11,8 @@ describe("OptionsStore", () => {
     vi.unstubAllGlobals();
   });
 
-  test("defaults to tabToIndent false", () => {
-    expect(new OptionsStore().load().tabToIndent).toBe(false);
+  test("defaults to enableTabbingInEditor false", () => {
+    expect(new OptionsStore().load().enableTabbingInEditor).toBe(false);
   });
 
   test("defaults to debugMode false", () => {
@@ -26,7 +26,7 @@ describe("OptionsStore", () => {
   test("round-trips all option fields", () => {
     const store = new OptionsStore();
     const options = {
-      tabToIndent: true,
+      enableTabbingInEditor: true,
       debugMode: true,
       selectedRenderer: "minimal",
     };


### PR DESCRIPTION
This pull request primarily refactors the "Tab to Indent" option throughout the codebase, renaming it to "Enable Tabbing in Editor" for clarity and expanding its functionality to better handle both indentation and autocompletion behaviors. Additionally, it introduces dark mode support for the minimal example renderer and improves the appearance of parent nodes in the Cytoscape DAG renderer.

**Refactor and Option Renaming:**

- Renamed the `tabToIndent` option to `enableTabbingInEditor` across all components, stores, and tests for improved clarity and consistency. This includes updating prop names, option persistence, and event emissions in `App.vue`, `OptionsPopup.vue`, `TextEditor.vue`, and `optionsStore.ts`. [[1]](diffhunk://#diff-7a7a37b12ee1265d7e27577ec286120d2cbc0940908635e264a2be44ccb9a8a0L7-R7) [[2]](diffhunk://#diff-7a7a37b12ee1265d7e27577ec286120d2cbc0940908635e264a2be44ccb9a8a0L74-R74) [[3]](diffhunk://#diff-7a7a37b12ee1265d7e27577ec286120d2cbc0940908635e264a2be44ccb9a8a0L123-R123) [[4]](diffhunk://#diff-7a7a37b12ee1265d7e27577ec286120d2cbc0940908635e264a2be44ccb9a8a0L177-R184) [[5]](diffhunk://#diff-7a7a37b12ee1265d7e27577ec286120d2cbc0940908635e264a2be44ccb9a8a0L248-R248) [[6]](diffhunk://#diff-149dbdb82579d247699a9fc6f9e878aa278b05935d0c3cfcb8dbaba98da7ff25L16-R26) [[7]](diffhunk://#diff-149dbdb82579d247699a9fc6f9e878aa278b05935d0c3cfcb8dbaba98da7ff25L79-R79) [[8]](diffhunk://#diff-149dbdb82579d247699a9fc6f9e878aa278b05935d0c3cfcb8dbaba98da7ff25L102-R102) [[9]](diffhunk://#diff-4d78bcb24e7711ce742202801b7f3196426a9ee8d6a0749aa88f5b571c020737L128-R130) [[10]](diffhunk://#diff-4d78bcb24e7711ce742202801b7f3196426a9ee8d6a0749aa88f5b571c020737L298-R303) [[11]](diffhunk://#diff-4d78bcb24e7711ce742202801b7f3196426a9ee8d6a0749aa88f5b571c020737L320-R325) [[12]](diffhunk://#diff-3097e5a929d195c38b5f1dc093e1f8660b88f17e51dbaec8a9d7e2de4b82c1dbL6-R13) [[13]](diffhunk://#diff-7831dd7653f3f1cff9e3efd4d546fb42bea4b7e1af6fcfef8434d99d894922f2L14-R15) [[14]](diffhunk://#diff-7831dd7653f3f1cff9e3efd4d546fb42bea4b7e1af6fcfef8434d99d894922f2L29-R29)

- Updated the keyboard handling logic in `TextEditor.vue` to better support both tab indentation and autocompletion: pressing Tab now accepts completions when available and indents otherwise, and pressing Esc can escape the next Tab action. [[1]](diffhunk://#diff-4d78bcb24e7711ce742202801b7f3196426a9ee8d6a0749aa88f5b571c020737R13-R14) [[2]](diffhunk://#diff-4d78bcb24e7711ce742202801b7f3196426a9ee8d6a0749aa88f5b571c020737L261-R266)

**UI/UX Improvements:**

- Updated the label and tooltip for the tabbing option in `OptionsPopup.vue` to clarify its dual purpose ("Tab to Indent / Autocomplete") and improved the tooltip text.

**Renderer and Visual Updates:**

- Added dark mode styling support to the minimal example renderer (`MinimalExampleRenderer.vue`), including background, border, and text color adjustments for dark themes. [[1]](diffhunk://#diff-2df046ca3a4a35b2130b8c11e1920be1aaebc37f64a20b1c0a5fad2b97756250L2-R6) [[2]](diffhunk://#diff-2df046ca3a4a35b2130b8c11e1920be1aaebc37f64a20b1c0a5fad2b97756250R38-R41) [[3]](diffhunk://#diff-2df046ca3a4a35b2130b8c11e1920be1aaebc37f64a20b1c0a5fad2b97756250R104-R126) [[4]](diffhunk://#diff-2df046ca3a4a35b2130b8c11e1920be1aaebc37f64a20b1c0a5fad2b97756250L114-R140)

- Improved appearance of parent nodes in the Cytoscape DAG renderer by introducing a dedicated background color that adapts to light/dark mode. [[1]](diffhunk://#diff-5442c4a1fbc5214f69dd8c316cf71b80aaef40de15ff26e53d734a58ad5665c3R159) [[2]](diffhunk://#diff-5442c4a1fbc5214f69dd8c316cf71b80aaef40de15ff26e53d734a58ad5665c3R170-R175)