### PR TITLE
feat(tutorial): enhance tutorial with goal checklists

### DIFF
--- a/src/tutorial/fiz/assignmentModule.ts
+++ b/src/tutorial/fiz/assignmentModule.ts
@@ -8,6 +8,45 @@ import {
   createNodeIdToVarNameCount,
 } from "../winCheckHelpers";
 
+const onAssignmentPuzzlet: Puzzlet = {
+  name: "On Assignment",
+  instructions: [
+    normal("Functions can be assigned to variables using '='.\n"),
+    normal("variable_name = function_name()\n"),
+    normal("Uncomment the assignment below:"),
+  ],
+  examples: [fast("// x = f()")],
+  clearEditorOnStart: true,
+  successCriteria: [
+    {
+      description: "Assign a function output to a variable",
+      check: (compilation: Compilation) =>
+        compilation.DAG.getVarNameToNodeIdMap().size > 0,
+    },
+  ],
+};
+
+const understandTheAssignmentPuzzlet: Puzzlet = {
+  name: "Understand the Assignment",
+  instructions: [
+    normal("Once assigned, variables can be input to functions.\n"),
+    normal("On a new line, input the variable into another function."),
+  ],
+  examples: [],
+  successCriteria: [
+    {
+      description: "Input an assigned variable to a function",
+      check: (compilation: Compilation) => {
+        const varNameToNodeIdMap = compilation.DAG.getVarNameToNodeIdMap();
+        const assignedNodeIds = new Set(varNameToNodeIdMap.values());
+        return compilation.DAG.getEdgeList().some((edge) =>
+          assignedNodeIds.has(edge.srcNodeId),
+        );
+      },
+    },
+  ],
+};
+
 const getAssignedVariableUsageCount = (compilation: Compilation): number => {
   const varNameToNodeIdMap = compilation.DAG.getVarNameToNodeIdMap();
   const assignedNodeIds = new Set(varNameToNodeIdMap.values());
@@ -16,209 +55,180 @@ const getAssignedVariableUsageCount = (compilation: Compilation): number => {
   ).length;
 };
 
-const assignmentPuzzlets: Puzzlet[] = [
-  {
-    name: "On Assignment",
-    instructions: [
-      normal("Functions can be assigned to variables using '='.\n"),
-      normal("variable_name = function_name()\n"),
-      normal("Uncomment the assignment below:"),
-    ],
-    examples: [fast("// x = f()")],
-    clearEditorOnStart: true,
-    successCriteria: [
-      {
-        description: "Assign a function output to a variable",
-        check: (compilation: Compilation) =>
-          compilation.DAG.getVarNameToNodeIdMap().size > 0,
+const makingAStatementPuzzlet: Puzzlet = {
+  name: "Making a Statement",
+  instructions: [
+    normal("Stand-alone function calls and assignments are statements.\n"),
+    normal("There should only be one statement per line,\n"),
+    normal("unless separated by a semicolon ';'.\n"),
+    normal("Statements are run in the order they appear.\n"),
+    normal("Reorder the lines so the variable is assigned before used."),
+  ],
+  examples: [fast("g(x); h(x)")],
+  successCriteria: [
+    {
+      description: "Use a single variable as input to at least 1 function",
+      check: (compilation: Compilation) =>
+        getAssignedVariableUsageCount(compilation) >= 1,
+    },
+    {
+      description: "Use a single variable as input to at least 2 functions",
+      check: (compilation: Compilation) =>
+        getAssignedVariableUsageCount(compilation) >= 2,
+    },
+  ],
+};
+
+const legalAliasesPuzzlet: Puzzlet = {
+  name: "Legal Aliases",
+  instructions: [
+    normal("Variables can be assigned to other variables.\n"),
+    normal("The new variable is an alias for the original variable.\n"),
+    normal("Uncomment the function calls to use the alias"),
+  ],
+  examples: [
+    fast("long_variable_name = f()\n"),
+    fast("alias = long_variable_name\n"),
+    fast("// g(long_variable_name); h(alias)"),
+  ],
+  successCriteria: [
+    {
+      description: "Assign a variable to another variable (an alias)",
+      check: (compilation: Compilation) =>
+        compilation.AST.Statements.some((stmt) => {
+          if (stmt.Type !== NodeType.Assignment) return false;
+          const assignment = stmt as AssignmentTreeNode;
+          if (assignment.Lhs.length !== 1) return false;
+          return assignment.Rhs?.Type === NodeType.QualifiedVariable;
+        }),
+    },
+    {
+      description: "Use the alias as input to a function",
+      check: (compilation: Compilation) => {
+        const varNameToNodeIdMap = compilation.DAG.getVarNameToNodeIdMap();
+        const nodeIdToVarNameCount =
+          createNodeIdToVarNameCount(varNameToNodeIdMap);
+        const edgeList = compilation.DAG.getEdgeList();
+        return Array.from(nodeIdToVarNameCount.entries()).some(
+          ([nodeId, count]) =>
+            count >= 2 && getOutDegree(nodeId, edgeList) >= 2,
+        );
       },
-    ],
-  },
-  {
-    name: "Understand the Assignment",
-    instructions: [
-      normal("Once assigned, variables can be input to functions.\n"),
-      normal("On a new line, input the variable into another function."),
-    ],
-    examples: [],
-    successCriteria: [
-      {
-        description: "Input an assigned variable to a function",
-        check: (compilation: Compilation) => {
-          const varNameToNodeIdMap = compilation.DAG.getVarNameToNodeIdMap();
-          const assignedNodeIds = new Set(varNameToNodeIdMap.values());
-          return compilation.DAG.getEdgeList().some((edge) =>
-            assignedNodeIds.has(edge.srcNodeId),
-          );
-        },
+    },
+  ],
+};
+
+const doTheSplitsPuzzlet: Puzzlet = {
+  name: "Do the Splits",
+  instructions: [
+    normal("Multiple variables can be assigned in one statement.\n"),
+    normal("Separate the variables with a comma ',' like x, y, z = f()\n"),
+    normal("Uncomment the assignment below:"),
+  ],
+  examples: [
+    fast("// yolk, white = split(egg())\n"),
+    fast("whisk(yolk); whip(white)\n"),
+  ],
+  successCriteria: [
+    {
+      description: "Create a multi-variable assignment",
+      check: (compilation: Compilation) =>
+        compilation.AST.Statements.some((stmt) => {
+          if (stmt.Type !== NodeType.Assignment) return false;
+          const assignment = stmt as AssignmentTreeNode;
+          return assignment.Lhs.length >= 2;
+        }),
+    },
+    {
+      description: "Use the parallelly assigned variables as inputs",
+      check: (compilation: Compilation) => {
+        const varNameToNodeIdMap = compilation.DAG.getVarNameToNodeIdMap();
+        const nodeIdToVarNameCount =
+          createNodeIdToVarNameCount(varNameToNodeIdMap);
+        const edgeList = compilation.DAG.getEdgeList();
+        return Array.from(nodeIdToVarNameCount.entries()).some(
+          ([nodeId, count]) =>
+            count >= 2 && getOutDegree(nodeId, edgeList) >= 2,
+        );
       },
-    ],
-  },
-  {
-    name: "Making a Statement",
-    instructions: [
-      normal("Stand-alone function calls and assignments are statements.\n"),
-      normal("There should only be one statement per line,\n"),
-      normal("unless separated by a semicolon ';'.\n"),
-      normal("Statements are run in the order they appear.\n"),
-      normal("Reorder the lines so the variable is assigned before used."),
-    ],
-    examples: [fast("g(x); h(x)")],
-    successCriteria: [
-      {
-        description: "Use a single variable as input to at least 1 function",
-        check: (compilation: Compilation) =>
-          getAssignedVariableUsageCount(compilation) >= 1,
+    },
+  ],
+};
+
+const aceOfDiamondsPuzzlet: Puzzlet = {
+  name: "Ace of Diamonds",
+  instructions: [
+    normal("Formulas form DAGs (Directed Acyclic Graphs).\n"),
+    ...dramatic("FUNCTION IS NODE"),
+    ...dramatic("ARG IS EDGE"),
+    ...dramatic("CODER IS YOU!"),
+    normal("Make a 4-node diamond-shaped DAG to continue."),
+  ],
+  examples: [],
+  clearEditorOnStart: true,
+  successCriteria: [
+    {
+      description: "Create a top node (0 in, 2 out)",
+      check: (compilation: Compilation) => {
+        const edgeList = compilation.DAG.getEdgeList();
+        return compilation.DAG.getNodeList().some(
+          (node) =>
+            getInDegree(node.id, edgeList) === 0 &&
+            getOutDegree(node.id, edgeList) === 2,
+        );
       },
-      {
-        description: "Use a single variable as input to at least 2 functions",
-        check: (compilation: Compilation) =>
-          getAssignedVariableUsageCount(compilation) >= 2,
+    },
+    {
+      description: "Create a side node (1 in, 1 out)",
+      check: (compilation: Compilation) => {
+        const edgeList = compilation.DAG.getEdgeList();
+        return compilation.DAG.getNodeList().some(
+          (node) =>
+            getInDegree(node.id, edgeList) === 1 &&
+            getOutDegree(node.id, edgeList) === 1,
+        );
       },
-    ],
-  },
-  {
-    name: "Legal Aliases",
-    instructions: [
-      normal("Variables can be assigned to other variables.\n"),
-      normal("The new variable is an alias for the original variable.\n"),
-      normal("Uncomment the function calls to use the alias"),
-    ],
-    examples: [
-      fast("long_variable_name = f()\n"),
-      fast("alias = long_variable_name\n"),
-      fast("// g(long_variable_name); h(alias)"),
-    ],
-    successCriteria: [
-      {
-        description: "Assign a variable to another variable (an alias)",
-        check: (compilation: Compilation) =>
-          compilation.AST.Statements.some((stmt) => {
-            if (stmt.Type !== NodeType.Assignment) return false;
-            const assignment = stmt as AssignmentTreeNode;
-            if (assignment.Lhs.length !== 1) return false;
-            return assignment.Rhs?.Type === NodeType.QualifiedVariable;
-          }),
+    },
+    {
+      description: "Create 2 side nodes (1 in, 1 out)",
+      check: (compilation: Compilation) => {
+        const edgeList = compilation.DAG.getEdgeList();
+        const sideNodeCount = compilation.DAG.getNodeList().filter(
+          (node) =>
+            getInDegree(node.id, edgeList) === 1 &&
+            getOutDegree(node.id, edgeList) === 1,
+        ).length;
+        return sideNodeCount === 2;
       },
-      {
-        description: "Use the alias as input to a function",
-        check: (compilation: Compilation) => {
-          const varNameToNodeIdMap = compilation.DAG.getVarNameToNodeIdMap();
-          const nodeIdToVarNameCount =
-            createNodeIdToVarNameCount(varNameToNodeIdMap);
-          const edgeList = compilation.DAG.getEdgeList();
-          return Array.from(nodeIdToVarNameCount.entries()).some(
-            ([nodeId, count]) =>
-              count >= 2 && getOutDegree(nodeId, edgeList) >= 2,
-          );
-        },
+    },
+    {
+      description: "Create a bottom node (2 in, 0 out)",
+      check: (compilation: Compilation) => {
+        const edgeList = compilation.DAG.getEdgeList();
+        return compilation.DAG.getNodeList().some(
+          (node) =>
+            getInDegree(node.id, edgeList) === 2 &&
+            getOutDegree(node.id, edgeList) === 0,
+        );
       },
-    ],
-  },
-  {
-    name: "Do the Splits",
-    instructions: [
-      normal("Multiple variables can be assigned in one statement.\n"),
-      normal("Separate the variables with a comma ',' like x, y, z = f()\n"),
-      normal("Uncomment the assignment below:"),
-    ],
-    examples: [
-      fast("// yolk, white = split(egg())\n"),
-      fast("whisk(yolk); whip(white)\n"),
-    ],
-    successCriteria: [
-      {
-        description: "Create a multi-variable assignment",
-        check: (compilation: Compilation) =>
-          compilation.AST.Statements.some((stmt) => {
-            if (stmt.Type !== NodeType.Assignment) return false;
-            const assignment = stmt as AssignmentTreeNode;
-            return assignment.Lhs.length >= 2;
-          }),
-      },
-      {
-        description: "Use the parallelly assigned variables as inputs",
-        check: (compilation: Compilation) => {
-          const varNameToNodeIdMap = compilation.DAG.getVarNameToNodeIdMap();
-          const nodeIdToVarNameCount =
-            createNodeIdToVarNameCount(varNameToNodeIdMap);
-          const edgeList = compilation.DAG.getEdgeList();
-          return Array.from(nodeIdToVarNameCount.entries()).some(
-            ([nodeId, count]) =>
-              count >= 2 && getOutDegree(nodeId, edgeList) >= 2,
-          );
-        },
-      },
-    ],
-  },
-  {
-    name: "Ace of Diamonds",
-    instructions: [
-      normal("Formulas form DAGs (Directed Acyclic Graphs).\n"),
-      ...dramatic("FUNCTION IS NODE"),
-      ...dramatic("ARG IS EDGE"),
-      ...dramatic("CODER IS YOU!"),
-      normal("Make a 4-node diamond-shaped DAG to continue."),
-    ],
-    examples: [],
-    clearEditorOnStart: true,
-    successCriteria: [
-      {
-        description: "Create a top node (0 in, 2 out)",
-        check: (compilation: Compilation) => {
-          const edgeList = compilation.DAG.getEdgeList();
-          return compilation.DAG.getNodeList().some(
-            (node) =>
-              getInDegree(node.id, edgeList) === 0 &&
-              getOutDegree(node.id, edgeList) === 2,
-          );
-        },
-      },
-      {
-        description: "Create a side node (1 in, 1 out)",
-        check: (compilation: Compilation) => {
-          const edgeList = compilation.DAG.getEdgeList();
-          return compilation.DAG.getNodeList().some(
-            (node) =>
-              getInDegree(node.id, edgeList) === 1 &&
-              getOutDegree(node.id, edgeList) === 1,
-          );
-        },
-      },
-      {
-        description: "Create 2 side nodes (1 in, 1 out)",
-        check: (compilation: Compilation) => {
-          const edgeList = compilation.DAG.getEdgeList();
-          const sideNodeCount = compilation.DAG.getNodeList().filter(
-            (node) =>
-              getInDegree(node.id, edgeList) === 1 &&
-              getOutDegree(node.id, edgeList) === 1,
-          ).length;
-          return sideNodeCount === 2;
-        },
-      },
-      {
-        description: "Create a bottom node (2 in, 0 out)",
-        check: (compilation: Compilation) => {
-          const edgeList = compilation.DAG.getEdgeList();
-          return compilation.DAG.getNodeList().some(
-            (node) =>
-              getInDegree(node.id, edgeList) === 2 &&
-              getOutDegree(node.id, edgeList) === 0,
-          );
-        },
-      },
-      {
-        description: "Create exactly 4 nodes and 4 edges",
-        check: (compilation: Compilation) =>
-          compilation.DAG.getNodeList().length === 4 &&
-          compilation.DAG.getEdgeList().length === 4,
-      },
-    ],
-  },
-];
+    },
+    {
+      description: "Create exactly 4 nodes and 4 edges",
+      check: (compilation: Compilation) =>
+        compilation.DAG.getNodeList().length === 4 &&
+        compilation.DAG.getEdgeList().length === 4,
+    },
+  ],
+};
 
 export const assignmentModule = {
   name: "Assignment",
-  puzzlets: assignmentPuzzlets,
+  puzzlets: [
+    onAssignmentPuzzlet,
+    understandTheAssignmentPuzzlet,
+    makingAStatementPuzzlet,
+    legalAliasesPuzzlet,
+    doTheSplitsPuzzlet,
+    aceOfDiamondsPuzzlet,
+  ],
 };

--- a/src/tutorial/fiz/assignmentModule.ts
+++ b/src/tutorial/fiz/assignmentModule.ts
@@ -8,6 +8,14 @@ import {
   createNodeIdToVarNameCount,
 } from "../winCheckHelpers";
 
+const getAssignedVariableUsageCount = (compilation: Compilation): number => {
+  const varNameToNodeIdMap = compilation.DAG.getVarNameToNodeIdMap();
+  const assignedNodeIds = new Set(varNameToNodeIdMap.values());
+  return compilation.DAG.getEdgeList().filter((edge) =>
+    assignedNodeIds.has(edge.srcNodeId),
+  ).length;
+};
+
 const assignmentPuzzlets: Puzzlet[] = [
   {
     name: "On Assignment",
@@ -18,9 +26,13 @@ const assignmentPuzzlets: Puzzlet[] = [
     ],
     examples: [fast("// x = f()")],
     clearEditorOnStart: true,
-    successCondition: (compilation: Compilation) => {
-      return compilation.DAG.getVarNameToNodeIdMap().size > 0;
-    },
+    successCriteria: [
+      {
+        description: "Assign a function output to a variable",
+        check: (compilation: Compilation) =>
+          compilation.DAG.getVarNameToNodeIdMap().size > 0,
+      },
+    ],
   },
   {
     name: "Understand the Assignment",
@@ -29,13 +41,18 @@ const assignmentPuzzlets: Puzzlet[] = [
       normal("On a new line, input the variable into another function."),
     ],
     examples: [],
-    successCondition: (compilation: Compilation) => {
-      const varNameToNodeIdMap = compilation.DAG.getVarNameToNodeIdMap();
-      const assignedNodeIds = new Set(varNameToNodeIdMap.values());
-      return compilation.DAG.getEdgeList().some((edge) =>
-        assignedNodeIds.has(edge.srcNodeId),
-      );
-    },
+    successCriteria: [
+      {
+        description: "Input an assigned variable to a function",
+        check: (compilation: Compilation) => {
+          const varNameToNodeIdMap = compilation.DAG.getVarNameToNodeIdMap();
+          const assignedNodeIds = new Set(varNameToNodeIdMap.values());
+          return compilation.DAG.getEdgeList().some((edge) =>
+            assignedNodeIds.has(edge.srcNodeId),
+          );
+        },
+      },
+    ],
   },
   {
     name: "Making a Statement",
@@ -47,15 +64,18 @@ const assignmentPuzzlets: Puzzlet[] = [
       normal("Reorder the lines so the variable is assigned before used."),
     ],
     examples: [fast("g(x); h(x)")],
-    successCondition: (compilation: Compilation) => {
-      const varNameToNodeIdMap = compilation.DAG.getVarNameToNodeIdMap();
-      const assignedNodeIds = new Set(varNameToNodeIdMap.values());
-      return (
-        compilation.DAG.getEdgeList().filter((edge) =>
-          assignedNodeIds.has(edge.srcNodeId),
-        ).length >= 2
-      );
-    },
+    successCriteria: [
+      {
+        description: "Use a single variable as input to at least 1 function",
+        check: (compilation: Compilation) =>
+          getAssignedVariableUsageCount(compilation) >= 1,
+      },
+      {
+        description: "Use a single variable as input to at least 2 functions",
+        check: (compilation: Compilation) =>
+          getAssignedVariableUsageCount(compilation) >= 2,
+      },
+    ],
   },
   {
     name: "Legal Aliases",
@@ -69,31 +89,31 @@ const assignmentPuzzlets: Puzzlet[] = [
       fast("alias = long_variable_name\n"),
       fast("// g(long_variable_name); h(alias)"),
     ],
-    successCondition: (compilation: Compilation) => {
-      // Check AST for variable-to-variable assignment
-      const hasVariableToVariableAssignment = compilation.AST.Statements.some(
-        (stmt) => {
-          if (stmt.Type !== NodeType.Assignment) return false;
-          const assignment = stmt as AssignmentTreeNode;
-          if (assignment.Lhs.length !== 1) return false;
-          if (assignment.Rhs?.Type !== NodeType.QualifiedVariable) {
-            return false;
-          }
-          return true;
+    successCriteria: [
+      {
+        description: "Assign a variable to another variable (an alias)",
+        check: (compilation: Compilation) =>
+          compilation.AST.Statements.some((stmt) => {
+            if (stmt.Type !== NodeType.Assignment) return false;
+            const assignment = stmt as AssignmentTreeNode;
+            if (assignment.Lhs.length !== 1) return false;
+            return assignment.Rhs?.Type === NodeType.QualifiedVariable;
+          }),
+      },
+      {
+        description: "Use the alias as input to a function",
+        check: (compilation: Compilation) => {
+          const varNameToNodeIdMap = compilation.DAG.getVarNameToNodeIdMap();
+          const nodeIdToVarNameCount =
+            createNodeIdToVarNameCount(varNameToNodeIdMap);
+          const edgeList = compilation.DAG.getEdgeList();
+          return Array.from(nodeIdToVarNameCount.entries()).some(
+            ([nodeId, count]) =>
+              count >= 2 && getOutDegree(nodeId, edgeList) >= 2,
+          );
         },
-      );
-
-      // Check DAG for alias usage
-      const varNameToNodeIdMap = compilation.DAG.getVarNameToNodeIdMap();
-      const nodeIdToVarNameCount =
-        createNodeIdToVarNameCount(varNameToNodeIdMap);
-      const edgeList = compilation.DAG.getEdgeList();
-      const hasAliasUsedInDAG = Array.from(nodeIdToVarNameCount.entries()).some(
-        ([nodeId, count]) => count >= 2 && getOutDegree(nodeId, edgeList) >= 2,
-      );
-
-      return hasVariableToVariableAssignment && hasAliasUsedInDAG;
-    },
+      },
+    ],
   },
   {
     name: "Do the Splits",
@@ -106,29 +126,30 @@ const assignmentPuzzlets: Puzzlet[] = [
       fast("// yolk, white = split(egg())\n"),
       fast("whisk(yolk); whip(white)\n"),
     ],
-    successCondition: (compilation: Compilation) => {
-      // Check AST for multi-variable assignment
-      const hasMultiVariableAssignment = compilation.AST.Statements.some(
-        (stmt) => {
-          if (stmt.Type !== NodeType.Assignment) return false;
-          const assignment = stmt as AssignmentTreeNode;
-          return assignment.Lhs.length >= 2;
+    successCriteria: [
+      {
+        description: "Create a multi-variable assignment",
+        check: (compilation: Compilation) =>
+          compilation.AST.Statements.some((stmt) => {
+            if (stmt.Type !== NodeType.Assignment) return false;
+            const assignment = stmt as AssignmentTreeNode;
+            return assignment.Lhs.length >= 2;
+          }),
+      },
+      {
+        description: "Use the parallelly assigned variables as inputs",
+        check: (compilation: Compilation) => {
+          const varNameToNodeIdMap = compilation.DAG.getVarNameToNodeIdMap();
+          const nodeIdToVarNameCount =
+            createNodeIdToVarNameCount(varNameToNodeIdMap);
+          const edgeList = compilation.DAG.getEdgeList();
+          return Array.from(nodeIdToVarNameCount.entries()).some(
+            ([nodeId, count]) =>
+              count >= 2 && getOutDegree(nodeId, edgeList) >= 2,
+          );
         },
-      );
-
-      // Check DAG for multiple variables referencing same node
-      const varNameToNodeIdMap = compilation.DAG.getVarNameToNodeIdMap();
-      const nodeIdToVarNameCount =
-        createNodeIdToVarNameCount(varNameToNodeIdMap);
-      const edgeList = compilation.DAG.getEdgeList();
-      const hasMultipleVarsInDAG = Array.from(
-        nodeIdToVarNameCount.entries(),
-      ).some(
-        ([nodeId, count]) => count >= 2 && getOutDegree(nodeId, edgeList) >= 2,
-      );
-
-      return hasMultiVariableAssignment && hasMultipleVarsInDAG;
-    },
+      },
+    ],
   },
   {
     name: "Ace of Diamonds",
@@ -141,43 +162,59 @@ const assignmentPuzzlets: Puzzlet[] = [
     ],
     examples: [],
     clearEditorOnStart: true,
-    successCondition: (compilation: Compilation) => {
-      const nodeList = compilation.DAG.getNodeList();
-      const edgeList = compilation.DAG.getEdgeList();
-
-      if (nodeList.length < 4 || edgeList.length < 4) return false;
-
-      const topNode = nodeList.find(
-        (node) =>
-          getInDegree(node.id, edgeList) === 0 &&
-          getOutDegree(node.id, edgeList) === 2,
-      );
-      if (!topNode) return false;
-
-      const bottomNode = nodeList.find(
-        (node) =>
-          getInDegree(node.id, edgeList) === 2 &&
-          getOutDegree(node.id, edgeList) === 0,
-      );
-      if (!bottomNode) return false;
-
-      const middleNodes = nodeList.filter(
-        (node) =>
-          getInDegree(node.id, edgeList) === 1 &&
-          getOutDegree(node.id, edgeList) === 1,
-      );
-      if (middleNodes.length < 2) return false;
-
-      return middleNodes.every(
-        (node) =>
-          edgeList.some(
-            (e) => e.srcNodeId === topNode.id && e.destNodeId === node.id,
-          ) &&
-          edgeList.some(
-            (e) => e.srcNodeId === node.id && e.destNodeId === bottomNode.id,
-          ),
-      );
-    },
+    successCriteria: [
+      {
+        description: "Create a top node (0 in, 2 out)",
+        check: (compilation: Compilation) => {
+          const edgeList = compilation.DAG.getEdgeList();
+          return compilation.DAG.getNodeList().some(
+            (node) =>
+              getInDegree(node.id, edgeList) === 0 &&
+              getOutDegree(node.id, edgeList) === 2,
+          );
+        },
+      },
+      {
+        description: "Create a side node (1 in, 1 out)",
+        check: (compilation: Compilation) => {
+          const edgeList = compilation.DAG.getEdgeList();
+          return compilation.DAG.getNodeList().some(
+            (node) =>
+              getInDegree(node.id, edgeList) === 1 &&
+              getOutDegree(node.id, edgeList) === 1,
+          );
+        },
+      },
+      {
+        description: "Create 2 side nodes (1 in, 1 out)",
+        check: (compilation: Compilation) => {
+          const edgeList = compilation.DAG.getEdgeList();
+          const sideNodeCount = compilation.DAG.getNodeList().filter(
+            (node) =>
+              getInDegree(node.id, edgeList) === 1 &&
+              getOutDegree(node.id, edgeList) === 1,
+          ).length;
+          return sideNodeCount === 2;
+        },
+      },
+      {
+        description: "Create a bottom node (2 in, 0 out)",
+        check: (compilation: Compilation) => {
+          const edgeList = compilation.DAG.getEdgeList();
+          return compilation.DAG.getNodeList().some(
+            (node) =>
+              getInDegree(node.id, edgeList) === 2 &&
+              getOutDegree(node.id, edgeList) === 0,
+          );
+        },
+      },
+      {
+        description: "Create exactly 4 nodes and 4 edges",
+        check: (compilation: Compilation) =>
+          compilation.DAG.getNodeList().length === 4 &&
+          compilation.DAG.getEdgeList().length === 4,
+      },
+    ],
   },
 ];
 

--- a/src/tutorial/fiz/functionsModule.ts
+++ b/src/tutorial/fiz/functionsModule.ts
@@ -3,78 +3,78 @@ import { Compilation } from "src/compiler/compilation";
 import { normal } from "../animationHelpers";
 import { getInDegree, getOutDegree } from "../winCheckHelpers";
 
-const functionsPuzzlets: Puzzlet[] = [
-  {
-    name: "Getting Edgy",
-    instructions: [
-      normal("f() is a function.\n"),
-      normal("Functions consist of a word followed by ( ).\n"),
-      normal("Functions are visualized as nodes.\n"),
-      normal("Functions can be input to other functions.\n"),
-      normal("Put another function between the ( )."),
-    ],
-    examples: [],
-    successCriteria: [
-      {
-        description: "Create an edge by inputting a function into a function",
-        check: (compilation: Compilation) =>
-          compilation.DAG.getEdgeList().length > 0,
+const gettingEdgyPuzzlet: Puzzlet = {
+  name: "Getting Edgy",
+  instructions: [
+    normal("f() is a function.\n"),
+    normal("Functions consist of a word followed by ( ).\n"),
+    normal("Functions are visualized as nodes.\n"),
+    normal("Functions can be input to other functions.\n"),
+    normal("Put another function between the ( )."),
+  ],
+  examples: [],
+  successCriteria: [
+    {
+      description: "Create an edge by inputting a function into a function",
+      check: (compilation: Compilation) =>
+        compilation.DAG.getEdgeList().length > 0,
+    },
+  ],
+};
+
+const doubleEdgedPuzzlet: Puzzlet = {
+  name: "Double Edged",
+  instructions: [
+    normal("Arguments to functions are visualized as edges.\n"),
+    normal("Functions can also take multiple comma separated inputs.\n"),
+    normal("Add a ',' and then another function in the outermost ( )."),
+  ],
+  examples: [],
+  successCriteria: [
+    {
+      description: "Create a node with at least 1 input",
+      check: (compilation: Compilation) => {
+        const edgeList = compilation.DAG.getEdgeList();
+        return compilation.DAG.getNodeList().some(
+          (node) => getInDegree(node.id, edgeList) >= 1,
+        );
       },
-    ],
-  },
-  {
-    name: "Double Edged",
-    instructions: [
-      normal("Arguments to functions are visualized as edges.\n"),
-      normal("Functions can also take multiple comma separated inputs.\n"),
-      normal("Add a ',' and then another function in the outermost ( )."),
-    ],
-    examples: [],
-    successCriteria: [
-      {
-        description: "Create a node with at least 1 input",
-        check: (compilation: Compilation) => {
-          const edgeList = compilation.DAG.getEdgeList();
-          return compilation.DAG.getNodeList().some(
-            (node) => getInDegree(node.id, edgeList) >= 1,
-          );
-        },
+    },
+    {
+      description: "Create a node with at least 2 inputs",
+      check: (compilation: Compilation) => {
+        const edgeList = compilation.DAG.getEdgeList();
+        return compilation.DAG.getNodeList().some(
+          (node) => getInDegree(node.id, edgeList) >= 2,
+        );
       },
-      {
-        description: "Create a node with at least 2 inputs",
-        check: (compilation: Compilation) => {
-          const edgeList = compilation.DAG.getEdgeList();
-          return compilation.DAG.getNodeList().some(
-            (node) => getInDegree(node.id, edgeList) >= 2,
-          );
-        },
+    },
+  ],
+};
+
+const composeYourselfPuzzlet: Puzzlet = {
+  name: "Compose Yourself",
+  instructions: [
+    normal("Functions can also be arbitrarily nested.\n"),
+    normal("Add another function inside an innermost ( )."),
+  ],
+  examples: [],
+  successCriteria: [
+    {
+      description: "Create a node with both an input and an output",
+      check: (compilation: Compilation) => {
+        const edgeList = compilation.DAG.getEdgeList();
+        return compilation.DAG.getNodeList().some((node) => {
+          const inDegree = getInDegree(node.id, edgeList);
+          const outDegree = getOutDegree(node.id, edgeList);
+          return inDegree >= 1 && outDegree >= 1;
+        });
       },
-    ],
-  },
-  {
-    name: "Compose Yourself",
-    instructions: [
-      normal("Functions can also be arbitrarily nested.\n"),
-      normal("Add another function inside an innermost ( )."),
-    ],
-    examples: [],
-    successCriteria: [
-      {
-        description: "Create a node with both an input and an output",
-        check: (compilation: Compilation) => {
-          const edgeList = compilation.DAG.getEdgeList();
-          return compilation.DAG.getNodeList().some((node) => {
-            const inDegree = getInDegree(node.id, edgeList);
-            const outDegree = getOutDegree(node.id, edgeList);
-            return inDegree >= 1 && outDegree >= 1;
-          });
-        },
-      },
-    ],
-  },
-];
+    },
+  ],
+};
 
 export const functionsModule = {
   name: "Functions",
-  puzzlets: functionsPuzzlets,
+  puzzlets: [gettingEdgyPuzzlet, doubleEdgedPuzzlet, composeYourselfPuzzlet],
 };

--- a/src/tutorial/fiz/functionsModule.ts
+++ b/src/tutorial/fiz/functionsModule.ts
@@ -14,9 +14,13 @@ const functionsPuzzlets: Puzzlet[] = [
       normal("Put another function between the ( )."),
     ],
     examples: [],
-    successCondition: (compilation: Compilation) => {
-      return compilation.DAG.getEdgeList().length > 0;
-    },
+    successCriteria: [
+      {
+        description: "Create an edge by inputting a function into a function",
+        check: (compilation: Compilation) =>
+          compilation.DAG.getEdgeList().length > 0,
+      },
+    ],
   },
   {
     name: "Double Edged",
@@ -26,12 +30,26 @@ const functionsPuzzlets: Puzzlet[] = [
       normal("Add a ',' and then another function in the outermost ( )."),
     ],
     examples: [],
-    successCondition: (compilation: Compilation) => {
-      const edgeList = compilation.DAG.getEdgeList();
-      return compilation.DAG.getNodeList().some(
-        (node) => getInDegree(node.id, edgeList) >= 2,
-      );
-    },
+    successCriteria: [
+      {
+        description: "Create a node with at least 1 input",
+        check: (compilation: Compilation) => {
+          const edgeList = compilation.DAG.getEdgeList();
+          return compilation.DAG.getNodeList().some(
+            (node) => getInDegree(node.id, edgeList) >= 1,
+          );
+        },
+      },
+      {
+        description: "Create a node with at least 2 inputs",
+        check: (compilation: Compilation) => {
+          const edgeList = compilation.DAG.getEdgeList();
+          return compilation.DAG.getNodeList().some(
+            (node) => getInDegree(node.id, edgeList) >= 2,
+          );
+        },
+      },
+    ],
   },
   {
     name: "Compose Yourself",
@@ -40,14 +58,19 @@ const functionsPuzzlets: Puzzlet[] = [
       normal("Add another function inside an innermost ( )."),
     ],
     examples: [],
-    successCondition: (compilation: Compilation) => {
-      const edgeList = compilation.DAG.getEdgeList();
-      return compilation.DAG.getNodeList().some((node) => {
-        const inDegree = getInDegree(node.id, edgeList);
-        const outDegree = getOutDegree(node.id, edgeList);
-        return inDegree >= 1 && outDegree >= 1;
-      });
-    },
+    successCriteria: [
+      {
+        description: "Create a node with both an input and an output",
+        check: (compilation: Compilation) => {
+          const edgeList = compilation.DAG.getEdgeList();
+          return compilation.DAG.getNodeList().some((node) => {
+            const inDegree = getInDegree(node.id, edgeList);
+            const outDegree = getOutDegree(node.id, edgeList);
+            return inDegree >= 1 && outDegree >= 1;
+          });
+        },
+      },
+    ],
   },
 ];
 

--- a/src/tutorial/fiz/importModule.ts
+++ b/src/tutorial/fiz/importModule.ts
@@ -9,6 +9,58 @@ const byobUrl = `${importBaseUrl}example.fiz`;
 
 type PuzzletCompilation = Parameters<SuccessCriterion["check"]>[0];
 
+const importAntPuzzlet: Puzzlet = {
+  name: "Import Ant",
+  instructions: [
+    normal("Importing allows you to use fiz from other files.\n"),
+    normal('An import statement consists of @ followed by a "url".\n'),
+    normal(`@ "${antUrl}"\n`),
+    normal("is an example import statement.\n"),
+    normal("Imports must end in a .fiz suffix.\n"),
+    normal("Uncomment the import statement below."),
+  ],
+  examples: [fast(`// @ "${antUrl}"`)],
+  clearEditorOnStart: true,
+  successCriteria: [
+    {
+      description: "Import the ant.fiz file",
+      check: (compilation) => compilation.DAG.UsedImports.has(antUrl),
+    },
+  ],
+};
+
+const importAntigravityPuzzlet: Puzzlet = {
+  name: "Import Antigravity",
+  instructions: [
+    normal("Multiple files can be imported.\n"),
+    normal("Imports themselves can import multiple dependencies.\n"),
+    normal("To visually separate import contents, use namespaces.\n"),
+    normal("Put a word at the front of the import statement to put\n"),
+    normal("the imported content in a namespace.\n"),
+    normal('ns @ "url.fiz" is an example of a namespaced import.\n'),
+    normal("Add a namespace to the flying.fiz import below."),
+  ],
+  examples: [fast(`@ "${flyingUrl}"`)],
+  successCriteria: [
+    {
+      description: "Import the flying.fiz file",
+      check: (compilation) => compilation.DAG.UsedImports.has(flyingUrl),
+    },
+    {
+      description: "Import the flying.fiz file into a namespace",
+      check: (compilation) => {
+        const importStmts = compilation.AST.Statements.filter(
+          (stmt) => stmt.Type === NodeType.Import,
+        ) as ImportTreeNode[];
+        return importStmts.some(
+          (stmt) =>
+            stmt.ImportLocation === flyingUrl && stmt.ImportName != null,
+        );
+      },
+    },
+  ],
+};
+
 const createHasFunctionNodeCheck = (functionName: string) => {
   return (compilation: PuzzletCompilation) => {
     const nodeNames = new Set(
@@ -18,94 +70,42 @@ const createHasFunctionNodeCheck = (functionName: string) => {
   };
 };
 
-const importPuzzlets: Puzzlet[] = [
-  {
-    name: "Import Ant",
-    instructions: [
-      normal("Importing allows you to use fiz from other files.\n"),
-      normal('An import statement consists of @ followed by a "url".\n'),
-      normal(`@ "${antUrl}"\n`),
-      normal("is an example import statement.\n"),
-      normal("Imports must end in a .fiz suffix.\n"),
-      normal("Uncomment the import statement below."),
-    ],
-    examples: [fast(`// @ "${antUrl}"`)],
-    clearEditorOnStart: true,
-    successCriteria: [
-      {
-        description: "Import the ant.fiz file",
-        check: (compilation) => compilation.DAG.UsedImports.has(antUrl),
-      },
-    ],
-  },
-  {
-    name: "Import Antigravity",
-    instructions: [
-      normal("Multiple files can be imported.\n"),
-      normal("Imports themselves can import multiple dependencies.\n"),
-      normal("To visually separate import contents, use namespaces.\n"),
-      normal("Put a word at the front of the import statement to put\n"),
-      normal("the imported content in a namespace.\n"),
-      normal('ns @ "url.fiz" is an example of a namespaced import.\n'),
-      normal("Add a namespace to the flying.fiz import below."),
-    ],
-    examples: [fast(`@ "${flyingUrl}"`)],
-    successCriteria: [
-      {
-        description: "Import the flying.fiz file",
-        check: (compilation) => compilation.DAG.UsedImports.has(flyingUrl),
-      },
-      {
-        description: "Import the flying.fiz file into a namespace",
-        check: (compilation) => {
-          const importStmts = compilation.AST.Statements.filter(
-            (stmt) => stmt.Type === NodeType.Import,
-          ) as ImportTreeNode[];
-          return importStmts.some(
-            (stmt) =>
-              stmt.ImportLocation === flyingUrl && stmt.ImportName != null,
-          );
-        },
-      },
-    ],
-  },
-  {
-    name: "BYOB (Bring Your Own Bindings)",
-    instructions: [
-      normal("Some imports only contain styles and keyword bindings.\n"),
-      normal("You can re-use these style definitions by importing them\n"),
-      normal("saving you from redefining them.\n"),
-      normal("Importing is useful for domains with standardized symbols.\n"),
-      normal("Uncomment the function calls below to see them in use."),
-    ],
-    examples: [
-      fast(`@ "${byobUrl}"\n`),
-      fast(`// add()\n`),
-      fast(`// join()\n`),
-      fast(`// freeze()\n`),
-    ],
-    successCriteria: [
-      {
-        description: "Import the example.fiz file",
-        check: (compilation) => compilation.DAG.UsedImports.has(byobUrl),
-      },
-      {
-        description: "Create the add function",
-        check: createHasFunctionNodeCheck("add"),
-      },
-      {
-        description: "Create the join function",
-        check: createHasFunctionNodeCheck("join"),
-      },
-      {
-        description: "Create the freeze function",
-        check: createHasFunctionNodeCheck("freeze"),
-      },
-    ],
-  },
-];
+const byobPuzzlet: Puzzlet = {
+  name: "BYOB (Bring Your Own Bindings)",
+  instructions: [
+    normal("Some imports only contain styles and keyword bindings.\n"),
+    normal("You can re-use these style definitions by importing them\n"),
+    normal("saving you from redefining them.\n"),
+    normal("Importing is useful for domains with standardized symbols.\n"),
+    normal("Uncomment the function calls below to see them in use."),
+  ],
+  examples: [
+    fast(`@ "${byobUrl}"\n`),
+    fast(`// add()\n`),
+    fast(`// join()\n`),
+    fast(`// freeze()\n`),
+  ],
+  successCriteria: [
+    {
+      description: "Import the example.fiz file",
+      check: (compilation) => compilation.DAG.UsedImports.has(byobUrl),
+    },
+    {
+      description: "Create the add function",
+      check: createHasFunctionNodeCheck("add"),
+    },
+    {
+      description: "Create the join function",
+      check: createHasFunctionNodeCheck("join"),
+    },
+    {
+      description: "Create the freeze function",
+      check: createHasFunctionNodeCheck("freeze"),
+    },
+  ],
+};
 
 export const importModule = {
   name: "Imports",
-  puzzlets: importPuzzlets,
+  puzzlets: [importAntPuzzlet, importAntigravityPuzzlet, byobPuzzlet],
 };

--- a/src/tutorial/fiz/importModule.ts
+++ b/src/tutorial/fiz/importModule.ts
@@ -1,4 +1,4 @@
-import { Puzzlet } from "../lesson";
+import { Puzzlet, SuccessCriterion } from "../lesson";
 import { normal, fast } from "../animationHelpers";
 import { NodeType, ImportTreeNode } from "src/compiler/ast";
 
@@ -6,6 +6,17 @@ const importBaseUrl = "https://formulavize.github.io/fiz-tutorial-imports/";
 const antUrl = `${importBaseUrl}ant.fiz`;
 const flyingUrl = `${importBaseUrl}flying.fiz`;
 const byobUrl = `${importBaseUrl}example.fiz`;
+
+type PuzzletCompilation = Parameters<SuccessCriterion["check"]>[0];
+
+const createHasFunctionNodeCheck = (functionName: string) => {
+  return (compilation: PuzzletCompilation) => {
+    const nodeNames = new Set(
+      compilation.DAG.getNodeList().map((node) => node.name),
+    );
+    return nodeNames.has(functionName);
+  };
+};
 
 const importPuzzlets: Puzzlet[] = [
   {
@@ -20,9 +31,12 @@ const importPuzzlets: Puzzlet[] = [
     ],
     examples: [fast(`// @ "${antUrl}"`)],
     clearEditorOnStart: true,
-    successCondition: (compilation) => {
-      return compilation.DAG.UsedImports.has(antUrl);
-    },
+    successCriteria: [
+      {
+        description: "Import the ant.fiz file",
+        check: (compilation) => compilation.DAG.UsedImports.has(antUrl),
+      },
+    ],
   },
   {
     name: "Import Antigravity",
@@ -36,16 +50,24 @@ const importPuzzlets: Puzzlet[] = [
       normal("Add a namespace to the flying.fiz import below."),
     ],
     examples: [fast(`@ "${flyingUrl}"`)],
-    successCondition: (compilation) => {
-      const hasImport = compilation.DAG.UsedImports.has(flyingUrl);
-      const importStmts = compilation.AST.Statements.filter(
-        (stmt) => stmt.Type === NodeType.Import,
-      ) as ImportTreeNode[];
-      const hasNamespacedFlyingImport = importStmts.some(
-        (stmt) => stmt.ImportLocation === flyingUrl && stmt.ImportName != null,
-      );
-      return hasImport && hasNamespacedFlyingImport;
-    },
+    successCriteria: [
+      {
+        description: "Import the flying.fiz file",
+        check: (compilation) => compilation.DAG.UsedImports.has(flyingUrl),
+      },
+      {
+        description: "Import the flying.fiz file into a namespace",
+        check: (compilation) => {
+          const importStmts = compilation.AST.Statements.filter(
+            (stmt) => stmt.Type === NodeType.Import,
+          ) as ImportTreeNode[];
+          return importStmts.some(
+            (stmt) =>
+              stmt.ImportLocation === flyingUrl && stmt.ImportName != null,
+          );
+        },
+      },
+    ],
   },
   {
     name: "BYOB (Bring Your Own Bindings)",
@@ -62,15 +84,24 @@ const importPuzzlets: Puzzlet[] = [
       fast(`// join()\n`),
       fast(`// freeze()\n`),
     ],
-    successCondition: (compilation) => {
-      const hasImport = compilation.DAG.UsedImports.has(byobUrl);
-      const nodeList = compilation.DAG.getNodeList();
-      const nodeNames = new Set(nodeList.map((node) => node.name));
-      return (
-        hasImport &&
-        ["add", "join", "freeze"].every((name) => nodeNames.has(name))
-      );
-    },
+    successCriteria: [
+      {
+        description: "Import the example.fiz file",
+        check: (compilation) => compilation.DAG.UsedImports.has(byobUrl),
+      },
+      {
+        description: "Create the add function",
+        check: createHasFunctionNodeCheck("add"),
+      },
+      {
+        description: "Create the join function",
+        check: createHasFunctionNodeCheck("join"),
+      },
+      {
+        description: "Create the freeze function",
+        check: createHasFunctionNodeCheck("freeze"),
+      },
+    ],
   },
 ];
 

--- a/src/tutorial/fiz/lessonPlan.ts
+++ b/src/tutorial/fiz/lessonPlan.ts
@@ -17,9 +17,13 @@ export function createFizLesson(): Lesson {
       normal("Start by uncommenting the following line (remove the '//'):"),
     ],
     examples: [fast("// f()")],
-    successCondition: (compilation: Compilation) => {
-      return compilation.DAG.getNodeList().length > 0;
-    },
+    successCriteria: [
+      {
+        description: "Create a node",
+        check: (compilation: Compilation) =>
+          compilation.DAG.getNodeList().length > 0,
+      },
+    ],
   };
   const introModule = {
     name: "Intro",
@@ -35,9 +39,13 @@ export function createFizLesson(): Lesson {
       normal("Uncomment the exit() function to exit this tutorial."),
     ],
     examples: [fast("// exit()")],
-    successCondition: (compilation: Compilation) => {
-      return compilation.DAG.getNodeList().some((node) => node.name === "exit");
-    },
+    successCriteria: [
+      {
+        description: "Create an exit() function",
+        check: (compilation: Compilation) =>
+          compilation.DAG.getNodeList().some((node) => node.name === "exit"),
+      },
+    ],
   };
   const outroModule = {
     name: "Outro",

--- a/src/tutorial/fiz/namespacesModule.ts
+++ b/src/tutorial/fiz/namespacesModule.ts
@@ -246,8 +246,7 @@ const solveByPartPuzzlet: Puzzlet = {
 
     return [
       {
-        description:
-          "Connect orangeA to outer, blueA, and blueB with opposite-color inputs",
+        description: "Connect orangeA -> outer, blueA, blueB",
         check: (compilation: Compilation) => {
           const {
             topLevelNodeIds,
@@ -266,7 +265,7 @@ const solveByPartPuzzlet: Puzzlet = {
         },
       },
       {
-        description: "Connect blueA to receive orangeA and pass into orangeB",
+        description: "Connect orangeA -> blueA -> orangeB",
         check: (compilation: Compilation) => {
           const {
             topLevelNodeIds,
@@ -285,7 +284,7 @@ const solveByPartPuzzlet: Puzzlet = {
         },
       },
       {
-        description: "Connect orangeB to receive blueA and pass into blueB",
+        description: "Connect blueA -> orangeB -> blueB",
         check: (compilation: Compilation) => {
           const {
             topLevelNodeIds,
@@ -304,8 +303,7 @@ const solveByPartPuzzlet: Puzzlet = {
         },
       },
       {
-        description:
-          "Connect blueB to receive orangeA, orangeB, and inner namespace output",
+        description: "Connect orangeA, orangeB, inner -> blueB",
         check: (compilation: Compilation) => {
           const {
             topLevelNodeIds,

--- a/src/tutorial/fiz/namespacesModule.ts
+++ b/src/tutorial/fiz/namespacesModule.ts
@@ -16,10 +16,17 @@ const namespacePuzzlets: Puzzlet[] = [
     ],
     examples: [fast("ns[ ]\n")],
     clearEditorOnStart: true,
-    successCondition: (compilation: Compilation) => {
-      const childDags = compilation.DAG.getChildDags();
-      return childDags.some((childDag) => childDag.getNodeList().length > 0);
-    },
+    successCriteria: [
+      {
+        description: "Add a function call inside a namespace",
+        check: (compilation: Compilation) => {
+          const childDags = compilation.DAG.getChildDags();
+          return childDags.some(
+            (childDag) => childDag.getNodeList().length > 0,
+          );
+        },
+      },
+    ],
   },
   {
     name: "Scope It Out",
@@ -34,21 +41,24 @@ const namespacePuzzlets: Puzzlet[] = [
       normal("Pass the variable in the namespace to the outer function."),
     ],
     examples: [fast("ns[ x = f() ]\n"), fast("g()\n")],
-    successCondition: (compilation: Compilation) => {
-      const topLevelNodeIds = getDagNodesIds(compilation.DAG);
-      const childDags = compilation.DAG.getChildDags();
-      const edgeList = compilation.DAG.getEdgeList();
-
-      // Check if there's an edge where source is in a namespace (child DAG)
-      // and destination is in the top-level DAG
-      return edgeList.some((edge) => {
-        const sourceInChildDag = childDags.some((childDag) =>
-          getDagNodesIds(childDag).has(edge.srcNodeId),
-        );
-        const destInTopLevel = topLevelNodeIds.has(edge.destNodeId);
-        return sourceInChildDag && destInTopLevel;
-      });
-    },
+    successCriteria: [
+      {
+        description:
+          "Pass a namespaced variable to a function outside the namespace",
+        check: (compilation: Compilation) => {
+          const topLevelNodeIds = getDagNodesIds(compilation.DAG);
+          const childDags = compilation.DAG.getChildDags();
+          const edgeList = compilation.DAG.getEdgeList();
+          return edgeList.some((edge) => {
+            const sourceInChildDag = childDags.some((childDag) =>
+              getDagNodesIds(childDag).has(edge.srcNodeId),
+            );
+            const destInTopLevel = topLevelNodeIds.has(edge.destNodeId);
+            return sourceInChildDag && destInTopLevel;
+          });
+        },
+      },
+    ],
   },
   {
     name: "The Edge of Space",
@@ -68,26 +78,36 @@ const namespacePuzzlets: Puzzlet[] = [
       fast("]() // pass s here\n"),
       fast("g() // pass n here\n"),
     ],
-    successCondition: (compilation: Compilation) => {
-      const topLevelNodeIds = getDagNodesIds(compilation.DAG);
-      const childDags = compilation.DAG.getChildDags();
-      const edgeList = compilation.DAG.getEdgeList();
-      const childDagIds = new Set(childDags.map((dag) => dag.Id));
-
-      const hasEdgeFromTopLevelToNamespace = edgeList.some(
-        (edge) =>
-          topLevelNodeIds.has(edge.srcNodeId) &&
-          childDagIds.has(edge.destNodeId),
-      );
-
-      const hasEdgeFromNamespaceToTopLevel = edgeList.some(
-        (edge) =>
-          childDagIds.has(edge.srcNodeId) &&
-          topLevelNodeIds.has(edge.destNodeId),
-      );
-
-      return hasEdgeFromTopLevelToNamespace && hasEdgeFromNamespaceToTopLevel;
-    },
+    successCriteria: [
+      {
+        description: "Pass a top-level function to the namespace itself",
+        check: (compilation: Compilation) => {
+          const topLevelNodeIds = getDagNodesIds(compilation.DAG);
+          const childDags = compilation.DAG.getChildDags();
+          const edgeList = compilation.DAG.getEdgeList();
+          const childDagIds = new Set(childDags.map((dag) => dag.Id));
+          return edgeList.some(
+            (edge) =>
+              topLevelNodeIds.has(edge.srcNodeId) &&
+              childDagIds.has(edge.destNodeId),
+          );
+        },
+      },
+      {
+        description: "Use a variable to pass the namespace to a function",
+        check: (compilation: Compilation) => {
+          const topLevelNodeIds = getDagNodesIds(compilation.DAG);
+          const childDags = compilation.DAG.getChildDags();
+          const edgeList = compilation.DAG.getEdgeList();
+          const childDagIds = new Set(childDags.map((dag) => dag.Id));
+          return edgeList.some(
+            (edge) =>
+              childDagIds.has(edge.srcNodeId) &&
+              topLevelNodeIds.has(edge.destNodeId),
+          );
+        },
+      },
+    ],
   },
   {
     name: "Outer Space",
@@ -105,26 +125,28 @@ const namespacePuzzlets: Puzzlet[] = [
       fast("// g(outer.inner.x)\n"),
     ],
     clearEditorOnStart: true,
-    successCondition: (compilation: Compilation) => {
-      const childDags = compilation.DAG.getChildDags();
-      const topLevelNodeIds = getDagNodesIds(compilation.DAG);
-      const edgeList = compilation.DAG.getEdgeList();
-
-      const nestedNodeIds = new Set(
-        childDags.flatMap((outerDag) =>
-          outerDag
-            .getChildDags()
-            .flatMap((innerDag) => Array.from(getDagNodesIds(innerDag))),
-        ),
-      );
-
-      // Check if there's an edge from a nested node to a top-level node
-      return edgeList.some(
-        (edge) =>
-          nestedNodeIds.has(edge.srcNodeId) &&
-          topLevelNodeIds.has(edge.destNodeId),
-      );
-    },
+    successCriteria: [
+      {
+        description: "Pass a doubly nested variable to a top-level function",
+        check: (compilation: Compilation) => {
+          const childDags = compilation.DAG.getChildDags();
+          const topLevelNodeIds = getDagNodesIds(compilation.DAG);
+          const edgeList = compilation.DAG.getEdgeList();
+          const nestedNodeIds = new Set(
+            childDags.flatMap((outerDag) =>
+              outerDag
+                .getChildDags()
+                .flatMap((innerDag) => Array.from(getDagNodesIds(innerDag))),
+            ),
+          );
+          return edgeList.some(
+            (edge) =>
+              nestedNodeIds.has(edge.srcNodeId) &&
+              topLevelNodeIds.has(edge.destNodeId),
+          );
+        },
+      },
+    ],
   },
   {
     name: "Space Decor",
@@ -138,24 +160,23 @@ const namespacePuzzlets: Puzzlet[] = [
       fast("  //#bg\n"),
       fast("}\n"),
     ],
-    successCondition: (compilation: Compilation) => {
-      const childDags = compilation.DAG.getChildDags();
-      const flattenedStyles = compilation.DAG.getFlattenedStyles();
-
-      return childDags.some((childDag) => {
-        // Check if the childDag has direct style properties
-        if (childDag.DagStyleProperties.size > 0) {
-          return true;
-        }
-
-        // Check if the childDag has style tags with properties
-        return childDag.DagStyleTags.some((styleTag) => {
-          const tagName = styleTag.join(".");
-          const properties = flattenedStyles.get(tagName);
-          return (properties?.size ?? 0) > 0;
-        });
-      });
-    },
+    successCriteria: [
+      {
+        description: "Apply at least 1 style to a namespace",
+        check: (compilation: Compilation) => {
+          const childDags = compilation.DAG.getChildDags();
+          const flattenedStyles = compilation.DAG.getFlattenedStyles();
+          return childDags.some((childDag) => {
+            if (childDag.DagStyleProperties.size > 0) return true;
+            return childDag.DagStyleTags.some((styleTag) => {
+              const tagName = styleTag.join(".");
+              const properties = flattenedStyles.get(tagName);
+              return (properties?.size ?? 0) > 0;
+            });
+          });
+        },
+      },
+    ],
   },
   {
     name: "'Solve By Part' Title",
@@ -181,91 +202,129 @@ const namespacePuzzlets: Puzzlet[] = [
       fast("blueB(/* 3 orange inputs */){#b}"),
     ],
     clearEditorOnStart: true,
-    successCondition: (compilation: Compilation) => {
-      const topLevelNodeIds = getDagNodesIds(compilation.DAG);
-      const childDags = compilation.DAG.getChildDags();
-      const childDagIds = new Set(childDags.map((dag) => dag.Id));
+    successCriteria: (() => {
+      // Shared helper to collect all cross-level edge/node data
+      function collectLevelData(compilation: Compilation) {
+        const topLevelNodeIds = getDagNodesIds(compilation.DAG);
+        const childDags = compilation.DAG.getChildDags();
+        const childDagIds = new Set(childDags.map((dag) => dag.Id));
+        const edgeList = [
+          ...compilation.DAG.getEdgeList(),
+          ...childDags.flatMap((dag) => [
+            ...dag.getEdgeList(),
+            ...dag
+              .getChildDags()
+              .flatMap((nestedDag) => nestedDag.getEdgeList()),
+          ]),
+        ];
+        function getNestedNodes(dags: Dag[], level: number): Set<string> {
+          const current = Array.from({ length: level - 1 }).reduce(
+            (dags: Dag[]) => dags.flatMap((dag) => dag.getChildDags()),
+            dags,
+          );
+          return new Set(
+            current.flatMap((dag) => Array.from(getDagNodesIds(dag))),
+          );
+        }
+        const singleNestedNodeIds = getNestedNodes(childDags, 1);
+        const doubleNestedNodeIds = getNestedNodes(childDags, 2);
+        const doubleNestedDagIds = new Set(
+          childDags.flatMap((dag) => dag.getChildDags()).map((dag) => dag.Id),
+        );
+        doubleNestedNodeIds.forEach((nodeId) =>
+          singleNestedNodeIds.delete(nodeId),
+        );
+        return {
+          topLevelNodeIds,
+          childDagIds,
+          singleNestedNodeIds,
+          doubleNestedNodeIds,
+          doubleNestedDagIds,
+          edgeList,
+        };
+      }
 
-      // Collect edges from all levels (top-level, single-nested, and double-nested)
-      const edgeList = [
-        ...compilation.DAG.getEdgeList(),
-        ...childDags.flatMap((dag) => [
-          ...dag.getEdgeList(),
-          ...dag.getChildDags().flatMap((nestedDag) => nestedDag.getEdgeList()),
-        ]),
+      return [
+        {
+          description:
+            "Connect orangeA to outer, blueA, and blueB with opposite-color inputs",
+          check: (compilation: Compilation) => {
+            const {
+              topLevelNodeIds,
+              childDagIds,
+              doubleNestedNodeIds,
+              edgeList,
+            } = collectLevelData(compilation);
+            return Array.from(topLevelNodeIds).some((nodeId) => {
+              const outEdges = getOutEdges(nodeId, edgeList);
+              return (
+                outEdges.some((e) => topLevelNodeIds.has(e.destNodeId)) &&
+                outEdges.some((e) => childDagIds.has(e.destNodeId)) &&
+                outEdges.some((e) => doubleNestedNodeIds.has(e.destNodeId))
+              );
+            });
+          },
+        },
+        {
+          description: "Connect blueA to receive orangeA and pass into orangeB",
+          check: (compilation: Compilation) => {
+            const {
+              topLevelNodeIds,
+              singleNestedNodeIds,
+              doubleNestedNodeIds,
+              edgeList,
+            } = collectLevelData(compilation);
+            return Array.from(doubleNestedNodeIds).some((nodeId) => {
+              const inEdges = getInEdges(nodeId, edgeList);
+              const outEdges = getOutEdges(nodeId, edgeList);
+              return (
+                inEdges.some((e) => topLevelNodeIds.has(e.srcNodeId)) &&
+                outEdges.some((e) => singleNestedNodeIds.has(e.destNodeId))
+              );
+            });
+          },
+        },
+        {
+          description: "Connect orangeB to receive blueA and pass into blueB",
+          check: (compilation: Compilation) => {
+            const {
+              topLevelNodeIds,
+              singleNestedNodeIds,
+              doubleNestedNodeIds,
+              edgeList,
+            } = collectLevelData(compilation);
+            return Array.from(singleNestedNodeIds).some((nodeId) => {
+              const inEdges = getInEdges(nodeId, edgeList);
+              const outEdges = getOutEdges(nodeId, edgeList);
+              return (
+                inEdges.some((e) => doubleNestedNodeIds.has(e.srcNodeId)) &&
+                outEdges.some((e) => topLevelNodeIds.has(e.destNodeId))
+              );
+            });
+          },
+        },
+        {
+          description:
+            "Connect blueB to receive orangeA, orangeB, and inner namespace output",
+          check: (compilation: Compilation) => {
+            const {
+              topLevelNodeIds,
+              singleNestedNodeIds,
+              doubleNestedDagIds,
+              edgeList,
+            } = collectLevelData(compilation);
+            return Array.from(topLevelNodeIds).some((nodeId) => {
+              const inEdges = getInEdges(nodeId, edgeList);
+              return (
+                inEdges.some((e) => topLevelNodeIds.has(e.srcNodeId)) &&
+                inEdges.some((e) => singleNestedNodeIds.has(e.srcNodeId)) &&
+                inEdges.some((e) => doubleNestedDagIds.has(e.srcNodeId))
+              );
+            });
+          },
+        },
       ];
-
-      // Helper to get nodes at a specific nesting level
-      function getNestedNodes(dags: Dag[], level: number): Set<string> {
-        const current = Array.from({ length: level - 1 }).reduce(
-          (dags: Dag[]) => dags.flatMap((dag) => dag.getChildDags()),
-          dags,
-        );
-        return new Set(
-          current.flatMap((dag) => Array.from(getDagNodesIds(dag))),
-        );
-      }
-
-      const singleNestedNodeIds = getNestedNodes(childDags, 1);
-
-      const doubleNestedNodeIds = getNestedNodes(childDags, 2);
-      const doubleNestedDagIds = new Set(
-        childDags.flatMap((dag) => dag.getChildDags()).map((dag) => dag.Id),
-      );
-      doubleNestedNodeIds.forEach((nodeId) =>
-        singleNestedNodeIds.delete(nodeId),
-      );
-
-      function hasNodeWithEdges(
-        nodeIds: Set<string>,
-        edgeChecker: (nodeId: string) => boolean,
-      ): boolean {
-        return Array.from(nodeIds).some(edgeChecker);
-      }
-
-      return (
-        // there is a top-level node with edges to a top-level node,
-        // a single-nested namespace, and a double-nested node
-        hasNodeWithEdges(topLevelNodeIds, (nodeId) => {
-          const outEdges = getOutEdges(nodeId, edgeList);
-          return (
-            outEdges.some((e) => topLevelNodeIds.has(e.destNodeId)) &&
-            outEdges.some((e) => childDagIds.has(e.destNodeId)) &&
-            outEdges.some((e) => doubleNestedNodeIds.has(e.destNodeId))
-          );
-        }) &&
-        // there is a double-nested node with an edge from a top-level node
-        // and an edge to a single-nested node
-        hasNodeWithEdges(doubleNestedNodeIds, (nodeId) => {
-          const inEdges = getInEdges(nodeId, edgeList);
-          const outEdges = getOutEdges(nodeId, edgeList);
-          return (
-            inEdges.some((e) => topLevelNodeIds.has(e.srcNodeId)) &&
-            outEdges.some((e) => singleNestedNodeIds.has(e.destNodeId))
-          );
-        }) &&
-        // there is a single-nested node with edges from a double-nested node
-        // and to a top-level node
-        hasNodeWithEdges(singleNestedNodeIds, (nodeId) => {
-          const inEdges = getInEdges(nodeId, edgeList);
-          const outEdges = getOutEdges(nodeId, edgeList);
-          return (
-            inEdges.some((e) => doubleNestedNodeIds.has(e.srcNodeId)) &&
-            outEdges.some((e) => topLevelNodeIds.has(e.destNodeId))
-          );
-        }) &&
-        // there is a top-level node with edges from a top level node,
-        // a single-nested node, and a double-nested namespace
-        hasNodeWithEdges(topLevelNodeIds, (nodeId) => {
-          const inEdges = getInEdges(nodeId, edgeList);
-          return (
-            inEdges.some((e) => topLevelNodeIds.has(e.srcNodeId)) &&
-            inEdges.some((e) => singleNestedNodeIds.has(e.srcNodeId)) &&
-            inEdges.some((e) => doubleNestedDagIds.has(e.srcNodeId))
-          );
-        })
-      );
-    },
+    })(),
   },
 ];
 

--- a/src/tutorial/fiz/namespacesModule.ts
+++ b/src/tutorial/fiz/namespacesModule.ts
@@ -4,331 +4,337 @@ import { Dag } from "src/compiler/dag";
 import { normal, fast } from "../animationHelpers";
 import { getDagNodesIds, getInEdges, getOutEdges } from "../winCheckHelpers";
 
-const namespacePuzzlets: Puzzlet[] = [
-  {
-    name: "Using Namespace",
-    instructions: [
-      normal("ns[ ] is a namespace.\n"),
-      normal("Namespaces consist of a word followed by [ ].\n"),
-      normal("Namespaces can contain statements inside the [ ].\n"),
-      normal("Namespaces without statements are not visualized.\n"),
-      normal("Add a function call in the namespace below."),
-    ],
-    examples: [fast("ns[ ]\n")],
-    clearEditorOnStart: true,
-    successCriteria: [
-      {
-        description: "Add a function call inside a namespace",
-        check: (compilation: Compilation) => {
-          const childDags = compilation.DAG.getChildDags();
-          return childDags.some(
-            (childDag) => childDag.getNodeList().length > 0,
-          );
-        },
+const usingNamespacePuzzlet: Puzzlet = {
+  name: "Using Namespace",
+  instructions: [
+    normal("ns[ ] is a namespace.\n"),
+    normal("Namespaces consist of a word followed by [ ].\n"),
+    normal("Namespaces can contain statements inside the [ ].\n"),
+    normal("Namespaces without statements are not visualized.\n"),
+    normal("Add a function call in the namespace below."),
+  ],
+  examples: [fast("ns[ ]\n")],
+  clearEditorOnStart: true,
+  successCriteria: [
+    {
+      description: "Add a function call inside a namespace",
+      check: (compilation: Compilation) => {
+        const childDags = compilation.DAG.getChildDags();
+        return childDags.some((childDag) => childDag.getNodeList().length > 0);
       },
-    ],
-  },
-  {
-    name: "Scope It Out",
-    instructions: [
-      normal("Namespaces create a new scope for their statements.\n"),
-      normal("Variables in a namespace cannot be used outside its scope,\n"),
-      normal("unless they are referenced with a qualified name.\n"),
-      normal("ns.x is an example of a qualified name.\n"),
-      normal("A qualified name is a dot '.' separated name path\n"),
-      normal("starting from a namespace in the local scope\n"),
-      normal("and ending in a variable in that namespace.\n"),
-      normal("Pass the variable in the namespace to the outer function."),
-    ],
-    examples: [fast("ns[ x = f() ]\n"), fast("g()\n")],
-    successCriteria: [
-      {
-        description:
-          "Pass a namespaced variable to a function outside the namespace",
-        check: (compilation: Compilation) => {
-          const topLevelNodeIds = getDagNodesIds(compilation.DAG);
-          const childDags = compilation.DAG.getChildDags();
-          const edgeList = compilation.DAG.getEdgeList();
-          return edgeList.some((edge) => {
-            const sourceInChildDag = childDags.some((childDag) =>
-              getDagNodesIds(childDag).has(edge.srcNodeId),
-            );
-            const destInTopLevel = topLevelNodeIds.has(edge.destNodeId);
-            return sourceInChildDag && destInTopLevel;
-          });
-        },
-      },
-    ],
-  },
-  {
-    name: "The Edge of Space",
-    instructions: [
-      normal("Namespaces can take args after the statement list.\n"),
-      normal("Namespaces can also be assigned to variables.\n"),
-      normal("e.g. var = namespace[ ... ](arg1, arg2)\n"),
-      normal("Namespaces themselves cannot be direct arguments to functions\n"),
-      normal("but can be passed as a variable.\n"),
-      normal("Pass a top-level function to the namespace itself\n"),
-      normal("and use a variable to pass the namespace itself to a function."),
-    ],
-    examples: [
-      fast("s = start()\n"),
-      fast("n = m[\n"),
-      fast("  f()\n"),
-      fast("]() // pass s here\n"),
-      fast("g() // pass n here\n"),
-    ],
-    successCriteria: [
-      {
-        description: "Pass a top-level function to the namespace itself",
-        check: (compilation: Compilation) => {
-          const topLevelNodeIds = getDagNodesIds(compilation.DAG);
-          const childDags = compilation.DAG.getChildDags();
-          const edgeList = compilation.DAG.getEdgeList();
-          const childDagIds = new Set(childDags.map((dag) => dag.Id));
-          return edgeList.some(
-            (edge) =>
-              topLevelNodeIds.has(edge.srcNodeId) &&
-              childDagIds.has(edge.destNodeId),
-          );
-        },
-      },
-      {
-        description: "Use a variable to pass the namespace to a function",
-        check: (compilation: Compilation) => {
-          const topLevelNodeIds = getDagNodesIds(compilation.DAG);
-          const childDags = compilation.DAG.getChildDags();
-          const edgeList = compilation.DAG.getEdgeList();
-          const childDagIds = new Set(childDags.map((dag) => dag.Id));
-          return edgeList.some(
-            (edge) =>
-              childDagIds.has(edge.srcNodeId) &&
-              topLevelNodeIds.has(edge.destNodeId),
-          );
-        },
-      },
-    ],
-  },
-  {
-    name: "Outer Space",
-    instructions: [
-      normal("Namespaces can be nested inside other namespaces.\n"),
-      normal("Reference nested values with a deeper qualified name.\n"),
-      normal("Uncomment the assignment and function call below."),
-    ],
-    examples: [
-      fast("outer[\n"),
-      fast("  inner[\n"),
-      fast("    // x = f()\n"),
-      fast("  ]\n"),
-      fast("]\n"),
-      fast("// g(outer.inner.x)\n"),
-    ],
-    clearEditorOnStart: true,
-    successCriteria: [
-      {
-        description: "Pass a doubly nested variable to a top-level function",
-        check: (compilation: Compilation) => {
-          const childDags = compilation.DAG.getChildDags();
-          const topLevelNodeIds = getDagNodesIds(compilation.DAG);
-          const edgeList = compilation.DAG.getEdgeList();
-          const nestedNodeIds = new Set(
-            childDags.flatMap((outerDag) =>
-              outerDag
-                .getChildDags()
-                .flatMap((innerDag) => Array.from(getDagNodesIds(innerDag))),
-            ),
-          );
-          return edgeList.some(
-            (edge) =>
-              nestedNodeIds.has(edge.srcNodeId) &&
-              topLevelNodeIds.has(edge.destNodeId),
-          );
-        },
-      },
-    ],
-  },
-  {
-    name: "Space Decor",
-    instructions: [
-      normal("Namespaces can also have styles in { }.\n"),
-      normal("Add a style tag or property to the namespace."),
-    ],
-    examples: [
-      fast('#bg { background-color: "orange" }\n'),
-      fast("colored[ f() ](){\n"),
-      fast("  //#bg\n"),
-      fast("}\n"),
-    ],
-    successCriteria: [
-      {
-        description: "Apply at least 1 style to a namespace",
-        check: (compilation: Compilation) => {
-          const childDags = compilation.DAG.getChildDags();
-          const flattenedStyles = compilation.DAG.getFlattenedStyles();
-          return childDags.some((childDag) => {
-            if (childDag.DagStyleProperties.size > 0) return true;
-            return childDag.DagStyleTags.some((styleTag) => {
-              const tagName = styleTag.join(".");
-              const properties = flattenedStyles.get(tagName);
-              return (properties?.size ?? 0) > 0;
-            });
-          });
-        },
-      },
-    ],
-  },
-  {
-    name: "'Solve By Part' Title",
-    instructions: [
-      normal("Now you're thinking with namespaces!\n"),
-      normal("Let's connect the dots with the code below.\n"),
-      normal("Pass each variable to all subsequent functions/namespaces\n"),
-      normal("of the opposite color without modifying declaration order."),
-    ],
-    examples: [
-      fast('#o{background-color: "orange"}\n'),
-      fast('#b{background-color: "dodgerblue"}\n'),
-      fast('#curvy{curve-style: "unbundled-bezier"; line-style: "dotted"}\n'),
-      fast("%oA{#curvy}; %bA{#curvy}; %oB{#curvy}; %oN{#curvy}\n"),
-      fast("\n"),
-      fast("oA = orangeA(){#o}\n"),
-      fast("outer[\n"),
-      fast("  oN = inner[\n"),
-      fast("    bA = blueA(/* 1 orange input */){#b}\n"),
-      fast("  ]{#o}\n"),
-      fast("  oB = orangeB(/* 1 blue input */){#o}\n"),
-      fast("](/* 1 orange input */){#b}\n"),
-      fast("blueB(/* 3 orange inputs */){#b}"),
-    ],
-    clearEditorOnStart: true,
-    successCriteria: (() => {
-      // Shared helper to collect all cross-level edge/node data
-      function collectLevelData(compilation: Compilation) {
+    },
+  ],
+};
+
+const scopeItOutPuzzlet: Puzzlet = {
+  name: "Scope It Out",
+  instructions: [
+    normal("Namespaces create a new scope for their statements.\n"),
+    normal("Variables in a namespace cannot be used outside its scope,\n"),
+    normal("unless they are referenced with a qualified name.\n"),
+    normal("ns.x is an example of a qualified name.\n"),
+    normal("A qualified name is a dot '.' separated name path\n"),
+    normal("starting from a namespace in the local scope\n"),
+    normal("and ending in a variable in that namespace.\n"),
+    normal("Pass the variable in the namespace to the outer function."),
+  ],
+  examples: [fast("ns[ x = f() ]\n"), fast("g()\n")],
+  successCriteria: [
+    {
+      description:
+        "Pass a namespaced variable to a function outside the namespace",
+      check: (compilation: Compilation) => {
         const topLevelNodeIds = getDagNodesIds(compilation.DAG);
         const childDags = compilation.DAG.getChildDags();
-        const childDagIds = new Set(childDags.map((dag) => dag.Id));
-        const edgeList = [
-          ...compilation.DAG.getEdgeList(),
-          ...childDags.flatMap((dag) => [
-            ...dag.getEdgeList(),
-            ...dag
-              .getChildDags()
-              .flatMap((nestedDag) => nestedDag.getEdgeList()),
-          ]),
-        ];
-        function getNestedNodes(dags: Dag[], level: number): Set<string> {
-          const current = Array.from({ length: level - 1 }).reduce(
-            (dags: Dag[]) => dags.flatMap((dag) => dag.getChildDags()),
-            dags,
+        const edgeList = compilation.DAG.getEdgeList();
+        return edgeList.some((edge) => {
+          const sourceInChildDag = childDags.some((childDag) =>
+            getDagNodesIds(childDag).has(edge.srcNodeId),
           );
-          return new Set(
-            current.flatMap((dag) => Array.from(getDagNodesIds(dag))),
-          );
-        }
-        const singleNestedNodeIds = getNestedNodes(childDags, 1);
-        const doubleNestedNodeIds = getNestedNodes(childDags, 2);
-        const doubleNestedDagIds = new Set(
-          childDags.flatMap((dag) => dag.getChildDags()).map((dag) => dag.Id),
-        );
-        doubleNestedNodeIds.forEach((nodeId) =>
-          singleNestedNodeIds.delete(nodeId),
-        );
-        return {
-          topLevelNodeIds,
-          childDagIds,
-          singleNestedNodeIds,
-          doubleNestedNodeIds,
-          doubleNestedDagIds,
-          edgeList,
-        };
-      }
+          const destInTopLevel = topLevelNodeIds.has(edge.destNodeId);
+          return sourceInChildDag && destInTopLevel;
+        });
+      },
+    },
+  ],
+};
 
-      return [
-        {
-          description:
-            "Connect orangeA to outer, blueA, and blueB with opposite-color inputs",
-          check: (compilation: Compilation) => {
-            const {
-              topLevelNodeIds,
-              childDagIds,
-              doubleNestedNodeIds,
-              edgeList,
-            } = collectLevelData(compilation);
-            return Array.from(topLevelNodeIds).some((nodeId) => {
-              const outEdges = getOutEdges(nodeId, edgeList);
-              return (
-                outEdges.some((e) => topLevelNodeIds.has(e.destNodeId)) &&
-                outEdges.some((e) => childDagIds.has(e.destNodeId)) &&
-                outEdges.some((e) => doubleNestedNodeIds.has(e.destNodeId))
-              );
-            });
-          },
-        },
-        {
-          description: "Connect blueA to receive orangeA and pass into orangeB",
-          check: (compilation: Compilation) => {
-            const {
-              topLevelNodeIds,
-              singleNestedNodeIds,
-              doubleNestedNodeIds,
-              edgeList,
-            } = collectLevelData(compilation);
-            return Array.from(doubleNestedNodeIds).some((nodeId) => {
-              const inEdges = getInEdges(nodeId, edgeList);
-              const outEdges = getOutEdges(nodeId, edgeList);
-              return (
-                inEdges.some((e) => topLevelNodeIds.has(e.srcNodeId)) &&
-                outEdges.some((e) => singleNestedNodeIds.has(e.destNodeId))
-              );
-            });
-          },
-        },
-        {
-          description: "Connect orangeB to receive blueA and pass into blueB",
-          check: (compilation: Compilation) => {
-            const {
-              topLevelNodeIds,
-              singleNestedNodeIds,
-              doubleNestedNodeIds,
-              edgeList,
-            } = collectLevelData(compilation);
-            return Array.from(singleNestedNodeIds).some((nodeId) => {
-              const inEdges = getInEdges(nodeId, edgeList);
-              const outEdges = getOutEdges(nodeId, edgeList);
-              return (
-                inEdges.some((e) => doubleNestedNodeIds.has(e.srcNodeId)) &&
-                outEdges.some((e) => topLevelNodeIds.has(e.destNodeId))
-              );
-            });
-          },
-        },
-        {
-          description:
-            "Connect blueB to receive orangeA, orangeB, and inner namespace output",
-          check: (compilation: Compilation) => {
-            const {
-              topLevelNodeIds,
-              singleNestedNodeIds,
-              doubleNestedDagIds,
-              edgeList,
-            } = collectLevelData(compilation);
-            return Array.from(topLevelNodeIds).some((nodeId) => {
-              const inEdges = getInEdges(nodeId, edgeList);
-              return (
-                inEdges.some((e) => topLevelNodeIds.has(e.srcNodeId)) &&
-                inEdges.some((e) => singleNestedNodeIds.has(e.srcNodeId)) &&
-                inEdges.some((e) => doubleNestedDagIds.has(e.srcNodeId))
-              );
-            });
-          },
-        },
+const theEdgeOfSpacePuzzlet: Puzzlet = {
+  name: "The Edge of Space",
+  instructions: [
+    normal("Namespaces can take args after the statement list.\n"),
+    normal("Namespaces can also be assigned to variables.\n"),
+    normal("e.g. var = namespace[ ... ](arg1, arg2)\n"),
+    normal("Namespaces themselves cannot be direct arguments to functions\n"),
+    normal("but can be passed as a variable.\n"),
+    normal("Pass a top-level function to the namespace itself\n"),
+    normal("and use a variable to pass the namespace itself to a function."),
+  ],
+  examples: [
+    fast("s = start()\n"),
+    fast("n = m[\n"),
+    fast("  f()\n"),
+    fast("]() // pass s here\n"),
+    fast("g() // pass n here\n"),
+  ],
+  successCriteria: [
+    {
+      description: "Pass a top-level function to the namespace itself",
+      check: (compilation: Compilation) => {
+        const topLevelNodeIds = getDagNodesIds(compilation.DAG);
+        const childDags = compilation.DAG.getChildDags();
+        const edgeList = compilation.DAG.getEdgeList();
+        const childDagIds = new Set(childDags.map((dag) => dag.Id));
+        return edgeList.some(
+          (edge) =>
+            topLevelNodeIds.has(edge.srcNodeId) &&
+            childDagIds.has(edge.destNodeId),
+        );
+      },
+    },
+    {
+      description: "Use a variable to pass the namespace to a function",
+      check: (compilation: Compilation) => {
+        const topLevelNodeIds = getDagNodesIds(compilation.DAG);
+        const childDags = compilation.DAG.getChildDags();
+        const edgeList = compilation.DAG.getEdgeList();
+        const childDagIds = new Set(childDags.map((dag) => dag.Id));
+        return edgeList.some(
+          (edge) =>
+            childDagIds.has(edge.srcNodeId) &&
+            topLevelNodeIds.has(edge.destNodeId),
+        );
+      },
+    },
+  ],
+};
+
+const outerSpacePuzzlet: Puzzlet = {
+  name: "Outer Space",
+  instructions: [
+    normal("Namespaces can be nested inside other namespaces.\n"),
+    normal("Reference nested values with a deeper qualified name.\n"),
+    normal("Uncomment the assignment and function call below."),
+  ],
+  examples: [
+    fast("outer[\n"),
+    fast("  inner[\n"),
+    fast("    // x = f()\n"),
+    fast("  ]\n"),
+    fast("]\n"),
+    fast("// g(outer.inner.x)\n"),
+  ],
+  clearEditorOnStart: true,
+  successCriteria: [
+    {
+      description: "Pass a doubly nested variable to a top-level function",
+      check: (compilation: Compilation) => {
+        const childDags = compilation.DAG.getChildDags();
+        const topLevelNodeIds = getDagNodesIds(compilation.DAG);
+        const edgeList = compilation.DAG.getEdgeList();
+        const nestedNodeIds = new Set(
+          childDags.flatMap((outerDag) =>
+            outerDag
+              .getChildDags()
+              .flatMap((innerDag) => Array.from(getDagNodesIds(innerDag))),
+          ),
+        );
+        return edgeList.some(
+          (edge) =>
+            nestedNodeIds.has(edge.srcNodeId) &&
+            topLevelNodeIds.has(edge.destNodeId),
+        );
+      },
+    },
+  ],
+};
+
+const spaceDecorPuzzlet: Puzzlet = {
+  name: "Space Decor",
+  instructions: [
+    normal("Namespaces can also have styles in { }.\n"),
+    normal("Add a style tag or property to the namespace."),
+  ],
+  examples: [
+    fast('#bg { background-color: "orange" }\n'),
+    fast("colored[ f() ](){\n"),
+    fast("  //#bg\n"),
+    fast("}\n"),
+  ],
+  successCriteria: [
+    {
+      description: "Apply at least 1 style to a namespace",
+      check: (compilation: Compilation) => {
+        const childDags = compilation.DAG.getChildDags();
+        const flattenedStyles = compilation.DAG.getFlattenedStyles();
+        return childDags.some((childDag) => {
+          if (childDag.DagStyleProperties.size > 0) return true;
+          return childDag.DagStyleTags.some((styleTag) => {
+            const tagName = styleTag.join(".");
+            const properties = flattenedStyles.get(tagName);
+            return (properties?.size ?? 0) > 0;
+          });
+        });
+      },
+    },
+  ],
+};
+
+const solveByPartPuzzlet: Puzzlet = {
+  name: "'Solve By Part' Title",
+  instructions: [
+    normal("Now you're thinking with namespaces!\n"),
+    normal("Let's connect the dots with the code below.\n"),
+    normal("Pass each variable to all subsequent functions/namespaces\n"),
+    normal("of the opposite color without modifying declaration order."),
+  ],
+  examples: [
+    fast('#o{background-color: "orange"}\n'),
+    fast('#b{background-color: "dodgerblue"}\n'),
+    fast('#curvy{curve-style: "unbundled-bezier"; line-style: "dotted"}\n'),
+    fast("%oA{#curvy}; %bA{#curvy}; %oB{#curvy}; %oN{#curvy}\n"),
+    fast("\n"),
+    fast("oA = orangeA(){#o}\n"),
+    fast("outer[\n"),
+    fast("  oN = inner[\n"),
+    fast("    bA = blueA(/* 1 orange input */){#b}\n"),
+    fast("  ]{#o}\n"),
+    fast("  oB = orangeB(/* 1 blue input */){#o}\n"),
+    fast("](/* 1 orange input */){#b}\n"),
+    fast("blueB(/* 3 orange inputs */){#b}"),
+  ],
+  clearEditorOnStart: true,
+  successCriteria: (() => {
+    // Shared helper to collect all cross-level edge/node data
+    function collectLevelData(compilation: Compilation) {
+      const topLevelNodeIds = getDagNodesIds(compilation.DAG);
+      const childDags = compilation.DAG.getChildDags();
+      const childDagIds = new Set(childDags.map((dag) => dag.Id));
+      const edgeList = [
+        ...compilation.DAG.getEdgeList(),
+        ...childDags.flatMap((dag) => [
+          ...dag.getEdgeList(),
+          ...dag.getChildDags().flatMap((nestedDag) => nestedDag.getEdgeList()),
+        ]),
       ];
-    })(),
-  },
-];
+      function getNestedNodes(dags: Dag[], level: number): Set<string> {
+        const current = Array.from({ length: level - 1 }).reduce(
+          (dags: Dag[]) => dags.flatMap((dag) => dag.getChildDags()),
+          dags,
+        );
+        return new Set(
+          current.flatMap((dag) => Array.from(getDagNodesIds(dag))),
+        );
+      }
+      const singleNestedNodeIds = getNestedNodes(childDags, 1);
+      const doubleNestedNodeIds = getNestedNodes(childDags, 2);
+      const doubleNestedDagIds = new Set(
+        childDags.flatMap((dag) => dag.getChildDags()).map((dag) => dag.Id),
+      );
+      doubleNestedNodeIds.forEach((nodeId) =>
+        singleNestedNodeIds.delete(nodeId),
+      );
+      return {
+        topLevelNodeIds,
+        childDagIds,
+        singleNestedNodeIds,
+        doubleNestedNodeIds,
+        doubleNestedDagIds,
+        edgeList,
+      };
+    }
+
+    return [
+      {
+        description:
+          "Connect orangeA to outer, blueA, and blueB with opposite-color inputs",
+        check: (compilation: Compilation) => {
+          const {
+            topLevelNodeIds,
+            childDagIds,
+            doubleNestedNodeIds,
+            edgeList,
+          } = collectLevelData(compilation);
+          return Array.from(topLevelNodeIds).some((nodeId) => {
+            const outEdges = getOutEdges(nodeId, edgeList);
+            return (
+              outEdges.some((e) => topLevelNodeIds.has(e.destNodeId)) &&
+              outEdges.some((e) => childDagIds.has(e.destNodeId)) &&
+              outEdges.some((e) => doubleNestedNodeIds.has(e.destNodeId))
+            );
+          });
+        },
+      },
+      {
+        description: "Connect blueA to receive orangeA and pass into orangeB",
+        check: (compilation: Compilation) => {
+          const {
+            topLevelNodeIds,
+            singleNestedNodeIds,
+            doubleNestedNodeIds,
+            edgeList,
+          } = collectLevelData(compilation);
+          return Array.from(doubleNestedNodeIds).some((nodeId) => {
+            const inEdges = getInEdges(nodeId, edgeList);
+            const outEdges = getOutEdges(nodeId, edgeList);
+            return (
+              inEdges.some((e) => topLevelNodeIds.has(e.srcNodeId)) &&
+              outEdges.some((e) => singleNestedNodeIds.has(e.destNodeId))
+            );
+          });
+        },
+      },
+      {
+        description: "Connect orangeB to receive blueA and pass into blueB",
+        check: (compilation: Compilation) => {
+          const {
+            topLevelNodeIds,
+            singleNestedNodeIds,
+            doubleNestedNodeIds,
+            edgeList,
+          } = collectLevelData(compilation);
+          return Array.from(singleNestedNodeIds).some((nodeId) => {
+            const inEdges = getInEdges(nodeId, edgeList);
+            const outEdges = getOutEdges(nodeId, edgeList);
+            return (
+              inEdges.some((e) => doubleNestedNodeIds.has(e.srcNodeId)) &&
+              outEdges.some((e) => topLevelNodeIds.has(e.destNodeId))
+            );
+          });
+        },
+      },
+      {
+        description:
+          "Connect blueB to receive orangeA, orangeB, and inner namespace output",
+        check: (compilation: Compilation) => {
+          const {
+            topLevelNodeIds,
+            singleNestedNodeIds,
+            doubleNestedDagIds,
+            edgeList,
+          } = collectLevelData(compilation);
+          return Array.from(topLevelNodeIds).some((nodeId) => {
+            const inEdges = getInEdges(nodeId, edgeList);
+            return (
+              inEdges.some((e) => topLevelNodeIds.has(e.srcNodeId)) &&
+              inEdges.some((e) => singleNestedNodeIds.has(e.srcNodeId)) &&
+              inEdges.some((e) => doubleNestedDagIds.has(e.srcNodeId))
+            );
+          });
+        },
+      },
+    ];
+  })(),
+};
 
 export const namespacesModule = {
   name: "Namespaces",
-  puzzlets: namespacePuzzlets,
+  puzzlets: [
+    usingNamespacePuzzlet,
+    scopeItOutPuzzlet,
+    theEdgeOfSpacePuzzlet,
+    outerSpacePuzzlet,
+    spaceDecorPuzzlet,
+    solveByPartPuzzlet,
+  ],
 };

--- a/src/tutorial/fiz/styleModule.ts
+++ b/src/tutorial/fiz/styleModule.ts
@@ -5,25 +5,133 @@ import { DESCRIPTION_PROPERTY } from "src/compiler/constants";
 import { normal, fast } from "../animationHelpers";
 import { getStyleTaggedNodes } from "../winCheckHelpers";
 
-function checkBindingHasProperties(
-  compilation: Compilation,
-  keyword: string,
-  expectedProps: string[],
-): boolean {
-  const bindings = compilation.DAG.getStyleBindings();
-  const flattenedStyles = compilation.DAG.getFlattenedStyles();
-  const dagStyle = bindings.get(keyword);
-  if (!dagStyle?.styleTags.length && !dagStyle?.styleProperties.size)
-    return false;
-  const collectedProperties = new Set([
-    ...Array.from(dagStyle.styleProperties.keys()),
-    ...dagStyle.styleTags.flatMap((styleTag) => {
-      const properties = flattenedStyles.get(styleTag.join("."));
-      return properties ? Array.from(properties.keys()) : [];
-    }),
-  ]);
-  return expectedProps.every((p) => collectedProperties.has(p));
-}
+const seeingRedPuzzlet: Puzzlet = {
+  name: "Seeing Red",
+  instructions: [
+    normal("Functions can have styles to change node appearance.\n"),
+    normal("Styles are defined in the { } to the right of a function.\n"),
+    normal("Styles are denoted using 'key:value' pairs.\n"),
+    normal("Keep to one 'key:value' pair per line unless ';' separated.\n"),
+    normal("key is a (cytoscape.js) style property.\n"),
+    normal("value is the (string|number|hex) value for that property.\n"),
+    normal("Uncomment the styles to see node change."),
+  ],
+  examples: [
+    fast("first() {\n"),
+    fast("  //background-color: #FF0000\n"),
+    fast('  //shape: "octagon"\n'),
+    fast("  //outline-width: 1\n"),
+    fast("}"),
+  ],
+  clearEditorOnStart: true,
+  successCriteria: [
+    {
+      description: "Apply at least 1 style property to a node",
+      check: (compilation: Compilation) =>
+        compilation.DAG.getNodeList().some(
+          (node) => node.styleProperties.size >= 1,
+        ),
+    },
+    {
+      description: "Apply at least 2 style properties to a node",
+      check: (compilation: Compilation) =>
+        compilation.DAG.getNodeList().some(
+          (node) => node.styleProperties.size >= 2,
+        ),
+    },
+    {
+      description: "Apply at least 3 style properties to a node",
+      check: (compilation: Compilation) =>
+        compilation.DAG.getNodeList().some(
+          (node) => node.styleProperties.size >= 3,
+        ),
+    },
+  ],
+};
+
+const gettingTaggedPuzzlet: Puzzlet = {
+  name: "Getting Tagged",
+  instructions: [
+    normal("Styles can be defined using #tags.\n"),
+    normal("Define style tags with a hashtag '#', tag name, and { }.\n"),
+    normal("e.g. #my_tag { }\n"),
+    normal("Uncomment the tag to apply its styles to the function."),
+  ],
+  examples: [
+    fast("#easy {\n"),
+    fast('  background-color: "green"\n'),
+    fast('  shape: "ellipse"\n'),
+    fast("}\n"),
+    fast("second() {\n"),
+    fast("  //#easy\n"),
+    fast("}\n"),
+  ],
+  successCriteria: [
+    {
+      description: "Apply a style tag with properties to a node",
+      check: (compilation: Compilation) => {
+        const flattenedStyles = compilation.DAG.getFlattenedStyles();
+        const nodes = compilation.DAG.getNodeList();
+        return getStyleTaggedNodes(flattenedStyles, nodes).length > 0;
+      },
+    },
+  ],
+};
+
+const mixAndMatchPuzzlet: Puzzlet = {
+  name: "Mix and Match",
+  instructions: [
+    normal("Multiple tags can be specified in { }.\n"),
+    normal("Tags should be separated by spaces ' '.\n"),
+    normal("The styles from all tags in { } will be applied together.\n"),
+    normal("Uncomment both style tags to apply their styles."),
+  ],
+  examples: [
+    fast("#mix {\n"),
+    fast('  background-color: "blue"\n'),
+    fast("}\n"),
+    fast("#match {\n"),
+    fast('  shape: "rectangle"\n'),
+    fast("}\n"),
+    fast("third() {\n"),
+    fast("  //#mix #match\n"),
+    fast("}\n"),
+  ],
+  successCriteria: [
+    {
+      description: "Define at least 1 style tag with properties",
+      check: (compilation: Compilation) => {
+        const flattenedStyles = compilation.DAG.getFlattenedStyles();
+        return (
+          Array.from(flattenedStyles.values()).filter(
+            (properties) => properties.size > 0,
+          ).length >= 1
+        );
+      },
+    },
+    {
+      description: "Define at least 2 style tags with properties",
+      check: (compilation: Compilation) => {
+        const flattenedStyles = compilation.DAG.getFlattenedStyles();
+        return (
+          Array.from(flattenedStyles.values()).filter(
+            (properties) => properties.size > 0,
+          ).length >= 2
+        );
+      },
+    },
+    {
+      description: "Apply both style tags to a single node",
+      check: (compilation: Compilation) => {
+        const flattenedStyles = compilation.DAG.getFlattenedStyles();
+        const nodes = compilation.DAG.getNodeList();
+        return getStyleTaggedNodes(flattenedStyles, nodes).some(
+          (node) => node.styleTags.length >= 2,
+        );
+      },
+    },
+  ],
+};
 
 function getFlattenedMultiTagStyleNames(
   compilation: Compilation,
@@ -60,6 +168,45 @@ function hasCombinedStyleAppliedToMinimumNodes(
   });
 }
 
+const inStylePuzzlet: Puzzlet = {
+  name: "In Style",
+  instructions: [
+    normal("Styles tags can also be put in another style tag's { }.\n"),
+    normal("Uncomment the nested style tag to apply its styles."),
+  ],
+  examples: [
+    fast('#black { background-color: "black" }\n'),
+    fast('#diamond { shape: "diamond" }\n'),
+    fast("#hard {\n"),
+    fast("  #black // #diamond\n"),
+    fast("}\n"),
+    fast("fourth() { #hard }\n"),
+    fast("fourth_too() { #hard }\n"),
+  ],
+  successCriteria: [
+    {
+      description: "Create a style tag containing 1 other style tag",
+      check: (compilation: Compilation) =>
+        getFlattenedMultiTagStyleNames(compilation, 1).length > 0,
+    },
+    {
+      description: "Create a style tag containing 2 other style tags",
+      check: (compilation: Compilation) =>
+        getFlattenedMultiTagStyleNames(compilation, 2).length > 0,
+    },
+    {
+      description: "Apply the combined style tag to at least 1 node",
+      check: (compilation: Compilation) =>
+        hasCombinedStyleAppliedToMinimumNodes(compilation, 1, 1),
+    },
+    {
+      description: "Apply the combined style tag to at least 2 nodes",
+      check: (compilation: Compilation) =>
+        hasCombinedStyleAppliedToMinimumNodes(compilation, 2, 2),
+    },
+  ],
+};
+
 function hasEdgeTagWithMinimumProperties(
   compilation: Compilation,
   minimumPropertyCount: number,
@@ -74,402 +221,270 @@ function hasEdgeTagWithMinimumProperties(
   );
 }
 
-const stylePuzzlets: Puzzlet[] = [
-  {
-    name: "Seeing Red",
-    instructions: [
-      normal("Functions can have styles to change node appearance.\n"),
-      normal("Styles are defined in the { } to the right of a function.\n"),
-      normal("Styles are denoted using 'key:value' pairs.\n"),
-      normal("Keep to one 'key:value' pair per line unless ';' separated.\n"),
-      normal("key is a (cytoscape.js) style property.\n"),
-      normal("value is the (string|number|hex) value for that property.\n"),
-      normal("Uncomment the styles to see node change."),
-    ],
-    examples: [
-      fast("first() {\n"),
-      fast("  //background-color: #FF0000\n"),
-      fast('  //shape: "octagon"\n'),
-      fast("  //outline-width: 1\n"),
-      fast("}"),
-    ],
-    clearEditorOnStart: true,
-    successCriteria: [
-      {
-        description: "Apply at least 1 style property to a node",
-        check: (compilation: Compilation) =>
-          compilation.DAG.getNodeList().some(
-            (node) => node.styleProperties.size >= 1,
-          ),
-      },
-      {
-        description: "Apply at least 2 style properties to a node",
-        check: (compilation: Compilation) =>
-          compilation.DAG.getNodeList().some(
-            (node) => node.styleProperties.size >= 2,
-          ),
-      },
-      {
-        description: "Apply at least 3 style properties to a node",
-        check: (compilation: Compilation) =>
-          compilation.DAG.getNodeList().some(
-            (node) => node.styleProperties.size >= 3,
-          ),
-      },
-    ],
-  },
-  {
-    name: "Getting Tagged",
-    instructions: [
-      normal("Styles can be defined using #tags.\n"),
-      normal("Define style tags with a hashtag '#', tag name, and { }.\n"),
-      normal("e.g. #my_tag { }\n"),
-      normal("Uncomment the tag to apply its styles to the function."),
-    ],
-    examples: [
-      fast("#easy {\n"),
-      fast('  background-color: "green"\n'),
-      fast('  shape: "ellipse"\n'),
-      fast("}\n"),
-      fast("second() {\n"),
-      fast("  //#easy\n"),
-      fast("}\n"),
-    ],
-    successCriteria: [
-      {
-        description: "Apply a style tag with properties to a node",
-        check: (compilation: Compilation) => {
-          const flattenedStyles = compilation.DAG.getFlattenedStyles();
-          const nodes = compilation.DAG.getNodeList();
-          return getStyleTaggedNodes(flattenedStyles, nodes).length > 0;
-        },
-      },
-    ],
-  },
-  {
-    name: "Mix and Match",
-    instructions: [
-      normal("Multiple tags can be specified in { }.\n"),
-      normal("Tags should be separated by spaces ' '.\n"),
-      normal("The styles from all tags in { } will be applied together.\n"),
-      normal("Uncomment both style tags to apply their styles."),
-    ],
-    examples: [
-      fast("#mix {\n"),
-      fast('  background-color: "blue"\n'),
-      fast("}\n"),
-      fast("#match {\n"),
-      fast('  shape: "rectangle"\n'),
-      fast("}\n"),
-      fast("third() {\n"),
-      fast("  //#mix #match\n"),
-      fast("}\n"),
-    ],
-    successCriteria: [
-      {
-        description: "Define at least 1 style tag with properties",
-        check: (compilation: Compilation) => {
-          const flattenedStyles = compilation.DAG.getFlattenedStyles();
-          return (
-            Array.from(flattenedStyles.values()).filter(
-              (properties) => properties.size > 0,
-            ).length >= 1
-          );
-        },
-      },
-      {
-        description: "Define at least 2 style tags with properties",
-        check: (compilation: Compilation) => {
-          const flattenedStyles = compilation.DAG.getFlattenedStyles();
-          return (
-            Array.from(flattenedStyles.values()).filter(
-              (properties) => properties.size > 0,
-            ).length >= 2
-          );
-        },
-      },
-      {
-        description: "Apply both style tags to a single node",
-        check: (compilation: Compilation) => {
-          const flattenedStyles = compilation.DAG.getFlattenedStyles();
-          const nodes = compilation.DAG.getNodeList();
-          return getStyleTaggedNodes(flattenedStyles, nodes).some(
-            (node) => node.styleTags.length >= 2,
-          );
-        },
-      },
-    ],
-  },
-  {
-    name: "In Style",
-    instructions: [
-      normal("Styles tags can also be put in another style tag's { }.\n"),
-      normal("Uncomment the nested style tag to apply its styles."),
-    ],
-    examples: [
-      fast('#black { background-color: "black" }\n'),
-      fast('#diamond { shape: "diamond" }\n'),
-      fast("#hard {\n"),
-      fast("  #black // #diamond\n"),
-      fast("}\n"),
-      fast("fourth() { #hard }\n"),
-      fast("fourth_too() { #hard }\n"),
-    ],
-    successCriteria: [
-      {
-        description: "Create a style tag containing 1 other style tag",
-        check: (compilation: Compilation) =>
-          getFlattenedMultiTagStyleNames(compilation, 1).length > 0,
-      },
-      {
-        description: "Create a style tag containing 2 other style tags",
-        check: (compilation: Compilation) =>
-          getFlattenedMultiTagStyleNames(compilation, 2).length > 0,
-      },
-      {
-        description: "Apply the combined style tag to at least 1 node",
-        check: (compilation: Compilation) =>
-          hasCombinedStyleAppliedToMinimumNodes(compilation, 1, 1),
-      },
-      {
-        description: "Apply the combined style tag to at least 2 nodes",
-        check: (compilation: Compilation) =>
-          hasCombinedStyleAppliedToMinimumNodes(compilation, 2, 2),
-      },
-    ],
-  },
-  {
-    name: "Silver Lining",
-    instructions: [
-      normal("Styles can be applied to edges too.\n"),
-      normal("Edge styles are defined in a variable's { }.\n"),
-      normal("Uncomment the variables styles to see the changes."),
-    ],
-    examples: [
-      fast("#s {\n"),
-      fast("  //width: 4\n"),
-      fast('  //line-color: "silver"\n'),
-      fast('  //line-style: "dashed"\n'),
-      fast("}\n"),
-      fast("x{ #s } = fifth()\n"),
-      fast("fifth_too(x)\n"),
-    ],
-    successCriteria: [
-      {
-        description: "Apply at least 1 style property to an edge via tags",
-        check: (compilation: Compilation) =>
-          hasEdgeTagWithMinimumProperties(compilation, 1),
-      },
-      {
-        description: "Apply at least 2 style properties to an edge via tags",
-        check: (compilation: Compilation) =>
-          hasEdgeTagWithMinimumProperties(compilation, 2),
-      },
-      {
-        description: "Apply at least 3 style properties to an edge via tags",
-        check: (compilation: Compilation) =>
-          hasEdgeTagWithMinimumProperties(compilation, 3),
-      },
-    ],
-  },
-  {
-    name: "In a Bind",
-    instructions: [
-      normal("Style bindings associate styles with keywords.\n"),
-      normal("Define a binding with a percent sign '%', keyword, and { }.\n"),
-      normal("e.g. %my_keyword{ }\n"),
-      normal("Functions and variables with the keyword as its name\n"),
-      normal("will receive the keyword's bound styles.\n"),
-      normal("Uncomment the function call to see the binding in action."),
-    ],
-    examples: [
-      fast('#starry { background-color: "gold"; shape: "star" }\n'),
-      fast("%star { #starry }\n\n"),
-      fast("// star()\n"),
-    ],
-    clearEditorOnStart: true,
-    successCriteria: [
-      {
-        description: "Define a keyword binding with styles",
-        check: (compilation: Compilation) => {
-          const bindings = compilation.DAG.getStyleBindings();
-          const flattenedStyles = compilation.DAG.getFlattenedStyles();
-          return Array.from(bindings.values()).some(
-            (dagStyle) =>
-              dagStyle.styleProperties.size > 0 ||
-              dagStyle.styleTags.some((styleTag) => {
-                const properties = flattenedStyles.get(styleTag.join("."));
-                return (properties?.size ?? 0) > 0;
-              }),
-          );
-        },
-      },
-      {
-        description: "Create a function matching the defined keyword",
-        check: (compilation: Compilation) => {
-          const bindings = compilation.DAG.getStyleBindings();
-          const nodes = compilation.DAG.getNodeList();
-          return Array.from(bindings.keys()).some((keyword) =>
-            nodes.some((node) => node.name === keyword),
-          );
-        },
-      },
-    ],
-  },
-  {
-    name: "The All-Stars",
-    instructions: [
-      normal("Global style bindings apply styles to a graph element type.\n"),
-      normal("node, edge, and subgraph are graph element types.\n"),
-      normal("Define this binding with an asterisk '*', keyword, and { }\n"),
-      normal("where keyword is the graph element type.\n"),
-      normal("Uncomment the global style binding to see the changes."),
-    ],
-    examples: [
-      fast('//*node{ text-valign: "center" }\n'),
-      fast('//*edge{ line-style: "dotted" }\n'),
-      fast('//*subgraph{ border-style: "dashed" }\n'),
-      fast("y[seventh(sixth())]"),
-    ],
-    successCriteria: [
-      {
-        description: "Define a *node global binding",
-        check: (compilation: Compilation) => {
-          const bindings = compilation.DAG.getGlobalStyleBindings();
-          const flattenedStyles = compilation.DAG.getFlattenedStyles();
-          const binding = bindings.get("node");
-          if (!binding) return false;
-          return (
-            binding.styleProperties.size > 0 ||
-            binding.styleTags.some((styleTag) => {
+const silverLiningPuzzlet: Puzzlet = {
+  name: "Silver Lining",
+  instructions: [
+    normal("Styles can be applied to edges too.\n"),
+    normal("Edge styles are defined in a variable's { }.\n"),
+    normal("Uncomment the variables styles to see the changes."),
+  ],
+  examples: [
+    fast("#s {\n"),
+    fast("  //width: 4\n"),
+    fast('  //line-color: "silver"\n'),
+    fast('  //line-style: "dashed"\n'),
+    fast("}\n"),
+    fast("x{ #s } = fifth()\n"),
+    fast("fifth_too(x)\n"),
+  ],
+  successCriteria: [
+    {
+      description: "Apply at least 1 style property to an edge via tags",
+      check: (compilation: Compilation) =>
+        hasEdgeTagWithMinimumProperties(compilation, 1),
+    },
+    {
+      description: "Apply at least 2 style properties to an edge via tags",
+      check: (compilation: Compilation) =>
+        hasEdgeTagWithMinimumProperties(compilation, 2),
+    },
+    {
+      description: "Apply at least 3 style properties to an edge via tags",
+      check: (compilation: Compilation) =>
+        hasEdgeTagWithMinimumProperties(compilation, 3),
+    },
+  ],
+};
+
+const inABindPuzzlet: Puzzlet = {
+  name: "In a Bind",
+  instructions: [
+    normal("Style bindings associate styles with keywords.\n"),
+    normal("Define a binding with a percent sign '%', keyword, and { }.\n"),
+    normal("e.g. %my_keyword{ }\n"),
+    normal("Functions and variables with the keyword as its name\n"),
+    normal("will receive the keyword's bound styles.\n"),
+    normal("Uncomment the function call to see the binding in action."),
+  ],
+  examples: [
+    fast('#starry { background-color: "gold"; shape: "star" }\n'),
+    fast("%star { #starry }\n\n"),
+    fast("// star()\n"),
+  ],
+  clearEditorOnStart: true,
+  successCriteria: [
+    {
+      description: "Define a keyword binding with styles",
+      check: (compilation: Compilation) => {
+        const bindings = compilation.DAG.getStyleBindings();
+        const flattenedStyles = compilation.DAG.getFlattenedStyles();
+        return Array.from(bindings.values()).some(
+          (dagStyle) =>
+            dagStyle.styleProperties.size > 0 ||
+            dagStyle.styleTags.some((styleTag) => {
               const properties = flattenedStyles.get(styleTag.join("."));
               return (properties?.size ?? 0) > 0;
-            })
-          );
-        },
+            }),
+        );
       },
-      {
-        description: "Define an *edge global binding",
-        check: (compilation: Compilation) => {
-          const bindings = compilation.DAG.getGlobalStyleBindings();
-          const flattenedStyles = compilation.DAG.getFlattenedStyles();
-          const binding = bindings.get("edge");
-          if (!binding) return false;
-          return (
-            binding.styleProperties.size > 0 ||
-            binding.styleTags.some((styleTag) => {
-              const properties = flattenedStyles.get(styleTag.join("."));
-              return (properties?.size ?? 0) > 0;
-            })
-          );
-        },
+    },
+    {
+      description: "Create a function matching the defined keyword",
+      check: (compilation: Compilation) => {
+        const bindings = compilation.DAG.getStyleBindings();
+        const nodes = compilation.DAG.getNodeList();
+        return Array.from(bindings.keys()).some((keyword) =>
+          nodes.some((node) => node.name === keyword),
+        );
       },
-      {
-        description: "Define a *subgraph global binding",
-        check: (compilation: Compilation) => {
-          const bindings = compilation.DAG.getGlobalStyleBindings();
-          const flattenedStyles = compilation.DAG.getFlattenedStyles();
-          const binding = bindings.get("subgraph");
-          if (!binding) return false;
-          return (
-            binding.styleProperties.size > 0 ||
-            binding.styleTags.some((styleTag) => {
-              const properties = flattenedStyles.get(styleTag.join("."));
-              return (properties?.size ?? 0) > 0;
-            })
-          );
-        },
+    },
+  ],
+};
+
+const theAllStarsPuzzlet: Puzzlet = {
+  name: "The All-Stars",
+  instructions: [
+    normal("Global style bindings apply styles to a graph element type.\n"),
+    normal("node, edge, and subgraph are graph element types.\n"),
+    normal("Define this binding with an asterisk '*', keyword, and { }\n"),
+    normal("where keyword is the graph element type.\n"),
+    normal("Uncomment the global style binding to see the changes."),
+  ],
+  examples: [
+    fast('//*node{ text-valign: "center" }\n'),
+    fast('//*edge{ line-style: "dotted" }\n'),
+    fast('//*subgraph{ border-style: "dashed" }\n'),
+    fast("y[seventh(sixth())]"),
+  ],
+  successCriteria: [
+    {
+      description: "Define a *node global binding",
+      check: (compilation: Compilation) => {
+        const bindings = compilation.DAG.getGlobalStyleBindings();
+        const flattenedStyles = compilation.DAG.getFlattenedStyles();
+        const binding = bindings.get("node");
+        if (!binding) return false;
+        return (
+          binding.styleProperties.size > 0 ||
+          binding.styleTags.some((styleTag) => {
+            const properties = flattenedStyles.get(styleTag.join("."));
+            return (properties?.size ?? 0) > 0;
+          })
+        );
       },
-    ],
-  },
-  {
-    name: "Put a Label on it",
-    instructions: [
-      normal("The 'label' style property will override the current name.\n"),
-      normal("Extra labels can be shown by adding strings to a { }\n"),
-      normal("or by adding a 'description' property.\n"),
-      normal("Descriptions are styled with description-* prefixed CSS.\n"),
-      normal("Uncomment the strings in { } to see the changes."),
-    ],
-    examples: [
-      fast("main_label() {\n"),
-      fast("  description-font-size: 6px\n"),
-      fast('  //"this extra label"\n'),
-      fast('  //"spans two lines"\n'),
-      fast("}\n"),
-    ],
-    successCriteria: [
-      {
-        description: "Add a multi-line description to a node",
-        check: (compilation: Compilation) =>
-          compilation.DAG.getNodeList().some((node) => {
-            const descriptionValue =
-              node.styleProperties.get(DESCRIPTION_PROPERTY);
-            return descriptionValue?.includes("\n") ?? false;
-          }),
+    },
+    {
+      description: "Define an *edge global binding",
+      check: (compilation: Compilation) => {
+        const bindings = compilation.DAG.getGlobalStyleBindings();
+        const flattenedStyles = compilation.DAG.getFlattenedStyles();
+        const binding = bindings.get("edge");
+        if (!binding) return false;
+        return (
+          binding.styleProperties.size > 0 ||
+          binding.styleTags.some((styleTag) => {
+            const properties = flattenedStyles.get(styleTag.join("."));
+            return (properties?.size ?? 0) > 0;
+          })
+        );
       },
-    ],
-  },
-  {
-    name: "FizBuzz",
-    instructions: [
-      normal("It's time to mix things up!\n"),
-      normal("Show that you've got style by refactoring the recipe below.\n"),
-      normal("Make keyword bindings for water, seltzer, and serve.\n"),
-      normal("Apply all existing style properties through these bindings."),
-    ],
-    examples: [
-      fast('#temperature{ shape: "round-diamond" }\n'),
-      fast('#hot{ background-color: "red" }\n'),
-      fast('#cold{ background-color: "blue" }\n'),
-      fast('#watery{ background-color: "lightblue" }\n'),
-      fast('#can{ shape: "barrel" }\n'),
-      fast("\n"),
-      fast("%heat{ #temperature #hot }\n"),
-      fast("%cool{ #temperature #cold }\n"),
-      fast('%honey{ shape: "hexagon"; background-color: "gold" }\n'),
-      fast("\n"),
-      fast("w = water(){ #watery }\n"),
-      fast("hot_water = heat(w)\n"),
-      fast("h = honey()\n"),
-      fast("honey_syrup = mix(hot_water, h)\n"),
-      fast("buzz = cool(honey_syrup)\n"),
-      fast("fizz = seltzer() { #watery #can }\n"),
-      fast("drink = mix(fizz, buzz)\n"),
-      fast("serve(drink) {\n"),
-      fast('  shape: "bottom-round-rectangle"\n'),
-      fast('  background-color: "silver"\n'),
-      fast("}\n"),
-    ],
-    clearEditorOnStart: true,
-    successCriteria: [
-      {
-        description: "Create a %water binding with background-color",
-        check: (compilation: Compilation) =>
-          checkBindingHasProperties(compilation, "water", ["background-color"]),
+    },
+    {
+      description: "Define a *subgraph global binding",
+      check: (compilation: Compilation) => {
+        const bindings = compilation.DAG.getGlobalStyleBindings();
+        const flattenedStyles = compilation.DAG.getFlattenedStyles();
+        const binding = bindings.get("subgraph");
+        if (!binding) return false;
+        return (
+          binding.styleProperties.size > 0 ||
+          binding.styleTags.some((styleTag) => {
+            const properties = flattenedStyles.get(styleTag.join("."));
+            return (properties?.size ?? 0) > 0;
+          })
+        );
       },
-      {
-        description:
-          "Create a %seltzer binding with background-color and shape",
-        check: (compilation: Compilation) =>
-          checkBindingHasProperties(compilation, "seltzer", [
-            "background-color",
-            "shape",
-          ]),
-      },
-      {
-        description: "Create a %serve binding with shape and background-color",
-        check: (compilation: Compilation) =>
-          checkBindingHasProperties(compilation, "serve", [
-            "shape",
-            "background-color",
-          ]),
-      },
-    ],
-  },
-];
+    },
+  ],
+};
+
+const putALabelOnItPuzzlet: Puzzlet = {
+  name: "Put a Label on it",
+  instructions: [
+    normal("The 'label' style property will override the current name.\n"),
+    normal("Extra labels can be shown by adding strings to a { }\n"),
+    normal("or by adding a 'description' property.\n"),
+    normal("Descriptions are styled with description-* prefixed CSS.\n"),
+    normal("Uncomment the strings in { } to see the changes."),
+  ],
+  examples: [
+    fast("main_label() {\n"),
+    fast("  description-font-size: 6px\n"),
+    fast('  //"this extra label"\n'),
+    fast('  //"spans two lines"\n'),
+    fast("}\n"),
+  ],
+  successCriteria: [
+    {
+      description: "Add a multi-line description to a node",
+      check: (compilation: Compilation) =>
+        compilation.DAG.getNodeList().some((node) => {
+          const descriptionValue =
+            node.styleProperties.get(DESCRIPTION_PROPERTY);
+          return descriptionValue?.includes("\n") ?? false;
+        }),
+    },
+  ],
+};
+
+function checkBindingHasProperties(
+  compilation: Compilation,
+  keyword: string,
+  expectedProps: string[],
+): boolean {
+  const bindings = compilation.DAG.getStyleBindings();
+  const flattenedStyles = compilation.DAG.getFlattenedStyles();
+  const dagStyle = bindings.get(keyword);
+  if (!dagStyle?.styleTags.length && !dagStyle?.styleProperties.size)
+    return false;
+  const collectedProperties = new Set([
+    ...Array.from(dagStyle.styleProperties.keys()),
+    ...dagStyle.styleTags.flatMap((styleTag) => {
+      const properties = flattenedStyles.get(styleTag.join("."));
+      return properties ? Array.from(properties.keys()) : [];
+    }),
+  ]);
+  return expectedProps.every((p) => collectedProperties.has(p));
+}
+
+const fizBuzzPuzzlet: Puzzlet = {
+  name: "FizBuzz",
+  instructions: [
+    normal("It's time to mix things up!\n"),
+    normal("Show that you've got style by refactoring the recipe below.\n"),
+    normal("Make keyword bindings for water, seltzer, and serve.\n"),
+    normal("Apply all existing style properties through these bindings."),
+  ],
+  examples: [
+    fast('#temperature{ shape: "round-diamond" }\n'),
+    fast('#hot{ background-color: "red" }\n'),
+    fast('#cold{ background-color: "blue" }\n'),
+    fast('#watery{ background-color: "lightblue" }\n'),
+    fast('#can{ shape: "barrel" }\n'),
+    fast("\n"),
+    fast("%heat{ #temperature #hot }\n"),
+    fast("%cool{ #temperature #cold }\n"),
+    fast('%honey{ shape: "hexagon"; background-color: "gold" }\n'),
+    fast("\n"),
+    fast("w = water(){ #watery }\n"),
+    fast("hot_water = heat(w)\n"),
+    fast("h = honey()\n"),
+    fast("honey_syrup = mix(hot_water, h)\n"),
+    fast("buzz = cool(honey_syrup)\n"),
+    fast("fizz = seltzer() { #watery #can }\n"),
+    fast("drink = mix(fizz, buzz)\n"),
+    fast("serve(drink) {\n"),
+    fast('  shape: "bottom-round-rectangle"\n'),
+    fast('  background-color: "silver"\n'),
+    fast("}\n"),
+  ],
+  clearEditorOnStart: true,
+  successCriteria: [
+    {
+      description: "Create a %water binding with background-color",
+      check: (compilation: Compilation) =>
+        checkBindingHasProperties(compilation, "water", ["background-color"]),
+    },
+    {
+      description: "Create a %seltzer binding with background-color and shape",
+      check: (compilation: Compilation) =>
+        checkBindingHasProperties(compilation, "seltzer", [
+          "background-color",
+          "shape",
+        ]),
+    },
+    {
+      description: "Create a %serve binding with shape and background-color",
+      check: (compilation: Compilation) =>
+        checkBindingHasProperties(compilation, "serve", [
+          "shape",
+          "background-color",
+        ]),
+    },
+  ],
+};
 
 export const styleModule = {
   name: "Style",
-  puzzlets: stylePuzzlets,
+  puzzlets: [
+    seeingRedPuzzlet,
+    gettingTaggedPuzzlet,
+    mixAndMatchPuzzlet,
+    inStylePuzzlet,
+    silverLiningPuzzlet,
+    inABindPuzzlet,
+    theAllStarsPuzzlet,
+    putALabelOnItPuzzlet,
+    fizBuzzPuzzlet,
+  ],
 };

--- a/src/tutorial/fiz/styleModule.ts
+++ b/src/tutorial/fiz/styleModule.ts
@@ -5,6 +5,75 @@ import { DESCRIPTION_PROPERTY } from "src/compiler/constants";
 import { normal, fast } from "../animationHelpers";
 import { getStyleTaggedNodes } from "../winCheckHelpers";
 
+function checkBindingHasProperties(
+  compilation: Compilation,
+  keyword: string,
+  expectedProps: string[],
+): boolean {
+  const bindings = compilation.DAG.getStyleBindings();
+  const flattenedStyles = compilation.DAG.getFlattenedStyles();
+  const dagStyle = bindings.get(keyword);
+  if (!dagStyle?.styleTags.length && !dagStyle?.styleProperties.size)
+    return false;
+  const collectedProperties = new Set([
+    ...Array.from(dagStyle.styleProperties.keys()),
+    ...dagStyle.styleTags.flatMap((styleTag) => {
+      const properties = flattenedStyles.get(styleTag.join("."));
+      return properties ? Array.from(properties.keys()) : [];
+    }),
+  ]);
+  return expectedProps.every((p) => collectedProperties.has(p));
+}
+
+function getFlattenedMultiTagStyleNames(
+  compilation: Compilation,
+  minimumTagCount: number,
+): string[] {
+  const namedStyles = compilation.AST.Statements.filter(
+    (stmt) => stmt.Type === NodeType.NamedStyle,
+  ) as NamedStyleTreeNode[];
+  const flattenedStyles = compilation.DAG.getFlattenedStyles();
+  return namedStyles
+    .filter((style) => style.StyleNode.StyleTags.length >= minimumTagCount)
+    .map((style) => style.StyleName)
+    .filter((styleName) => {
+      const properties = flattenedStyles.get(styleName);
+      return (properties?.size ?? 0) > 0;
+    });
+}
+
+function hasCombinedStyleAppliedToMinimumNodes(
+  compilation: Compilation,
+  minimumTagCount: number,
+  minimumNodeCount: number,
+): boolean {
+  const styleNames = getFlattenedMultiTagStyleNames(
+    compilation,
+    minimumTagCount,
+  );
+  const nodes = compilation.DAG.getNodeList();
+  return styleNames.some((styleName) => {
+    const styledUsers = nodes.filter((node) =>
+      node.styleTags.some((tag) => tag.join(".") === styleName),
+    );
+    return styledUsers.length >= minimumNodeCount;
+  });
+}
+
+function hasEdgeTagWithMinimumProperties(
+  compilation: Compilation,
+  minimumPropertyCount: number,
+): boolean {
+  const flattenedStyles = compilation.DAG.getFlattenedStyles();
+  return compilation.DAG.getEdgeList().some((edge) =>
+    edge.styleTags.some((tag) => {
+      const tagKey = tag.join(".");
+      const properties = flattenedStyles.get(tagKey);
+      return (properties?.size ?? 0) >= minimumPropertyCount;
+    }),
+  );
+}
+
 const stylePuzzlets: Puzzlet[] = [
   {
     name: "Seeing Red",
@@ -25,11 +94,29 @@ const stylePuzzlets: Puzzlet[] = [
       fast("}"),
     ],
     clearEditorOnStart: true,
-    successCondition: (compilation: Compilation) => {
-      return compilation.DAG.getNodeList().some(
-        (node) => node.styleProperties.size >= 3,
-      );
-    },
+    successCriteria: [
+      {
+        description: "Apply at least 1 style property to a node",
+        check: (compilation: Compilation) =>
+          compilation.DAG.getNodeList().some(
+            (node) => node.styleProperties.size >= 1,
+          ),
+      },
+      {
+        description: "Apply at least 2 style properties to a node",
+        check: (compilation: Compilation) =>
+          compilation.DAG.getNodeList().some(
+            (node) => node.styleProperties.size >= 2,
+          ),
+      },
+      {
+        description: "Apply at least 3 style properties to a node",
+        check: (compilation: Compilation) =>
+          compilation.DAG.getNodeList().some(
+            (node) => node.styleProperties.size >= 3,
+          ),
+      },
+    ],
   },
   {
     name: "Getting Tagged",
@@ -48,11 +135,16 @@ const stylePuzzlets: Puzzlet[] = [
       fast("  //#easy\n"),
       fast("}\n"),
     ],
-    successCondition: (compilation: Compilation) => {
-      const flattenedStyles = compilation.DAG.getFlattenedStyles();
-      const nodes = compilation.DAG.getNodeList();
-      return getStyleTaggedNodes(flattenedStyles, nodes).length > 0;
-    },
+    successCriteria: [
+      {
+        description: "Apply a style tag with properties to a node",
+        check: (compilation: Compilation) => {
+          const flattenedStyles = compilation.DAG.getFlattenedStyles();
+          const nodes = compilation.DAG.getNodeList();
+          return getStyleTaggedNodes(flattenedStyles, nodes).length > 0;
+        },
+      },
+    ],
   },
   {
     name: "Mix and Match",
@@ -73,17 +165,40 @@ const stylePuzzlets: Puzzlet[] = [
       fast("  //#mix #match\n"),
       fast("}\n"),
     ],
-    successCondition: (compilation: Compilation) => {
-      const flattenedStyles = compilation.DAG.getFlattenedStyles();
-      const nodes = compilation.DAG.getNodeList();
-      const nonEmptyTagCount = Array.from(flattenedStyles.values()).filter(
-        (properties) => properties.size > 0,
-      ).length;
-      if (nonEmptyTagCount < 2) return false;
-      return getStyleTaggedNodes(flattenedStyles, nodes).some(
-        (node) => node.styleTags.length >= 2,
-      );
-    },
+    successCriteria: [
+      {
+        description: "Define at least 1 style tag with properties",
+        check: (compilation: Compilation) => {
+          const flattenedStyles = compilation.DAG.getFlattenedStyles();
+          return (
+            Array.from(flattenedStyles.values()).filter(
+              (properties) => properties.size > 0,
+            ).length >= 1
+          );
+        },
+      },
+      {
+        description: "Define at least 2 style tags with properties",
+        check: (compilation: Compilation) => {
+          const flattenedStyles = compilation.DAG.getFlattenedStyles();
+          return (
+            Array.from(flattenedStyles.values()).filter(
+              (properties) => properties.size > 0,
+            ).length >= 2
+          );
+        },
+      },
+      {
+        description: "Apply both style tags to a single node",
+        check: (compilation: Compilation) => {
+          const flattenedStyles = compilation.DAG.getFlattenedStyles();
+          const nodes = compilation.DAG.getNodeList();
+          return getStyleTaggedNodes(flattenedStyles, nodes).some(
+            (node) => node.styleTags.length >= 2,
+          );
+        },
+      },
+    ],
   },
   {
     name: "In Style",
@@ -100,33 +215,28 @@ const stylePuzzlets: Puzzlet[] = [
       fast("fourth() { #hard }\n"),
       fast("fourth_too() { #hard }\n"),
     ],
-    successCondition: (compilation: Compilation) => {
-      const flattenedStyles = compilation.DAG.getFlattenedStyles();
-      const nonEmptyTagCount = Array.from(flattenedStyles.values()).filter(
-        (properties) => properties.size > 0,
-      ).length;
-      if (nonEmptyTagCount < 3) return false;
-
-      const namedStyles = compilation.AST.Statements.filter(
-        (stmt) => stmt.Type === NodeType.NamedStyle,
-      ) as NamedStyleTreeNode[];
-
-      const multiTagStyleNames = namedStyles
-        .filter((style) => style.StyleNode.StyleTags.length >= 2)
-        .map((style) => style.StyleName)
-        .filter((styleName) => {
-          const properties = flattenedStyles.get(styleName);
-          return (properties?.size ?? 0) > 0;
-        });
-
-      const nodes = compilation.DAG.getNodeList();
-      return multiTagStyleNames.some((styleName) => {
-        const styledUsers = nodes.filter((node) =>
-          node.styleTags.some((tag) => tag.join(".") === styleName),
-        );
-        return styledUsers.length >= 2;
-      });
-    },
+    successCriteria: [
+      {
+        description: "Create a style tag containing 1 other style tag",
+        check: (compilation: Compilation) =>
+          getFlattenedMultiTagStyleNames(compilation, 1).length > 0,
+      },
+      {
+        description: "Create a style tag containing 2 other style tags",
+        check: (compilation: Compilation) =>
+          getFlattenedMultiTagStyleNames(compilation, 2).length > 0,
+      },
+      {
+        description: "Apply the combined style tag to at least 1 node",
+        check: (compilation: Compilation) =>
+          hasCombinedStyleAppliedToMinimumNodes(compilation, 1, 1),
+      },
+      {
+        description: "Apply the combined style tag to at least 2 nodes",
+        check: (compilation: Compilation) =>
+          hasCombinedStyleAppliedToMinimumNodes(compilation, 2, 2),
+      },
+    ],
   },
   {
     name: "Silver Lining",
@@ -144,16 +254,23 @@ const stylePuzzlets: Puzzlet[] = [
       fast("x{ #s } = fifth()\n"),
       fast("fifth_too(x)\n"),
     ],
-    successCondition: (compilation: Compilation) => {
-      const flattenedStyles = compilation.DAG.getFlattenedStyles();
-      return compilation.DAG.getEdgeList().some((edge) => {
-        return edge.styleTags.some((tag) => {
-          const tagKey = tag.join(".");
-          const properties = flattenedStyles.get(tagKey);
-          return (properties?.size ?? 0) >= 3;
-        });
-      });
-    },
+    successCriteria: [
+      {
+        description: "Apply at least 1 style property to an edge via tags",
+        check: (compilation: Compilation) =>
+          hasEdgeTagWithMinimumProperties(compilation, 1),
+      },
+      {
+        description: "Apply at least 2 style properties to an edge via tags",
+        check: (compilation: Compilation) =>
+          hasEdgeTagWithMinimumProperties(compilation, 2),
+      },
+      {
+        description: "Apply at least 3 style properties to an edge via tags",
+        check: (compilation: Compilation) =>
+          hasEdgeTagWithMinimumProperties(compilation, 3),
+      },
+    ],
   },
   {
     name: "In a Bind",
@@ -171,26 +288,33 @@ const stylePuzzlets: Puzzlet[] = [
       fast("// star()\n"),
     ],
     clearEditorOnStart: true,
-    successCondition: (compilation: Compilation) => {
-      const bindings = compilation.DAG.getStyleBindings();
-      const flattenedStyles = compilation.DAG.getFlattenedStyles();
-      const nodes = compilation.DAG.getNodeList();
-
-      // Find bindings that have style tags or inline properties
-      return Array.from(bindings.entries()).some(([keyword, dagStyle]) => {
-        const bindingHasProperties =
-          dagStyle.styleProperties.size > 0 ||
-          dagStyle.styleTags.some((styleTag) => {
-            const tagName = styleTag.join(".");
-            const properties = flattenedStyles.get(tagName);
-            return (properties?.size ?? 0) > 0;
-          });
-        if (!bindingHasProperties) return false;
-
-        // Check if any node uses this binding
-        return nodes.some((node) => node.name === keyword);
-      });
-    },
+    successCriteria: [
+      {
+        description: "Define a keyword binding with styles",
+        check: (compilation: Compilation) => {
+          const bindings = compilation.DAG.getStyleBindings();
+          const flattenedStyles = compilation.DAG.getFlattenedStyles();
+          return Array.from(bindings.values()).some(
+            (dagStyle) =>
+              dagStyle.styleProperties.size > 0 ||
+              dagStyle.styleTags.some((styleTag) => {
+                const properties = flattenedStyles.get(styleTag.join("."));
+                return (properties?.size ?? 0) > 0;
+              }),
+          );
+        },
+      },
+      {
+        description: "Create a function matching the defined keyword",
+        check: (compilation: Compilation) => {
+          const bindings = compilation.DAG.getStyleBindings();
+          const nodes = compilation.DAG.getNodeList();
+          return Array.from(bindings.keys()).some((keyword) =>
+            nodes.some((node) => node.name === keyword),
+          );
+        },
+      },
+    ],
   },
   {
     name: "The All-Stars",
@@ -207,24 +331,56 @@ const stylePuzzlets: Puzzlet[] = [
       fast('//*subgraph{ border-style: "dashed" }\n'),
       fast("y[seventh(sixth())]"),
     ],
-    successCondition: (compilation: Compilation) => {
-      const bindings = compilation.DAG.getGlobalStyleBindings();
-      const flattenedStyles = compilation.DAG.getFlattenedStyles();
-
-      // Check that node, edge, and subgraph bindings exist and have properties
-      return ["node", "edge", "subgraph"].every((elementType) => {
-        const binding = bindings.get(elementType);
-        if (!binding) return false;
-
-        return (
-          binding.styleProperties.size > 0 ||
-          binding.styleTags.some((styleTag) => {
-            const properties = flattenedStyles.get(styleTag.join("."));
-            return (properties?.size ?? 0) > 0;
-          })
-        );
-      });
-    },
+    successCriteria: [
+      {
+        description: "Define a *node global binding",
+        check: (compilation: Compilation) => {
+          const bindings = compilation.DAG.getGlobalStyleBindings();
+          const flattenedStyles = compilation.DAG.getFlattenedStyles();
+          const binding = bindings.get("node");
+          if (!binding) return false;
+          return (
+            binding.styleProperties.size > 0 ||
+            binding.styleTags.some((styleTag) => {
+              const properties = flattenedStyles.get(styleTag.join("."));
+              return (properties?.size ?? 0) > 0;
+            })
+          );
+        },
+      },
+      {
+        description: "Define an *edge global binding",
+        check: (compilation: Compilation) => {
+          const bindings = compilation.DAG.getGlobalStyleBindings();
+          const flattenedStyles = compilation.DAG.getFlattenedStyles();
+          const binding = bindings.get("edge");
+          if (!binding) return false;
+          return (
+            binding.styleProperties.size > 0 ||
+            binding.styleTags.some((styleTag) => {
+              const properties = flattenedStyles.get(styleTag.join("."));
+              return (properties?.size ?? 0) > 0;
+            })
+          );
+        },
+      },
+      {
+        description: "Define a *subgraph global binding",
+        check: (compilation: Compilation) => {
+          const bindings = compilation.DAG.getGlobalStyleBindings();
+          const flattenedStyles = compilation.DAG.getFlattenedStyles();
+          const binding = bindings.get("subgraph");
+          if (!binding) return false;
+          return (
+            binding.styleProperties.size > 0 ||
+            binding.styleTags.some((styleTag) => {
+              const properties = flattenedStyles.get(styleTag.join("."));
+              return (properties?.size ?? 0) > 0;
+            })
+          );
+        },
+      },
+    ],
   },
   {
     name: "Put a Label on it",
@@ -242,12 +398,17 @@ const stylePuzzlets: Puzzlet[] = [
       fast('  //"spans two lines"\n'),
       fast("}\n"),
     ],
-    successCondition: (compilation: Compilation) => {
-      return compilation.DAG.getNodeList().some((node) => {
-        const descriptionValue = node.styleProperties.get(DESCRIPTION_PROPERTY);
-        return descriptionValue?.includes("\n") ?? false;
-      });
-    },
+    successCriteria: [
+      {
+        description: "Add a multi-line description to a node",
+        check: (compilation: Compilation) =>
+          compilation.DAG.getNodeList().some((node) => {
+            const descriptionValue =
+              node.styleProperties.get(DESCRIPTION_PROPERTY);
+            return descriptionValue?.includes("\n") ?? false;
+          }),
+      },
+    ],
   },
   {
     name: "FizBuzz",
@@ -281,37 +442,30 @@ const stylePuzzlets: Puzzlet[] = [
       fast("}\n"),
     ],
     clearEditorOnStart: true,
-    successCondition: (compilation: Compilation) => {
-      const expectedProperties = new Map([
-        ["water", new Set(["background-color"])],
-        ["seltzer", new Set(["background-color", "shape"])],
-        ["serve", new Set(["shape", "background-color"])],
-      ]);
-
-      const bindings = compilation.DAG.getStyleBindings();
-      const flattenedStyles = compilation.DAG.getFlattenedStyles();
-
-      // Check that each required keyword has all expected properties
-      return Array.from(expectedProperties.entries()).every(
-        ([keyword, expectedProps]) => {
-          const dagStyle = bindings.get(keyword);
-          if (!dagStyle?.styleTags.length && !dagStyle?.styleProperties.size)
-            return false;
-
-          // Collect all properties from this keyword's style tags and inline properties
-          const collectedProperties = new Set([
-            ...Array.from(dagStyle.styleProperties.keys()),
-            ...dagStyle.styleTags.flatMap((styleTag) => {
-              const properties = flattenedStyles.get(styleTag.join("."));
-              return properties ? Array.from(properties.keys()) : [];
-            }),
-          ]);
-
-          // Check if all expected properties are present
-          return expectedProps.isSubsetOf(collectedProperties);
-        },
-      );
-    },
+    successCriteria: [
+      {
+        description: "Create a %water binding with background-color",
+        check: (compilation: Compilation) =>
+          checkBindingHasProperties(compilation, "water", ["background-color"]),
+      },
+      {
+        description:
+          "Create a %seltzer binding with background-color and shape",
+        check: (compilation: Compilation) =>
+          checkBindingHasProperties(compilation, "seltzer", [
+            "background-color",
+            "shape",
+          ]),
+      },
+      {
+        description: "Create a %serve binding with shape and background-color",
+        check: (compilation: Compilation) =>
+          checkBindingHasProperties(compilation, "serve", [
+            "shape",
+            "background-color",
+          ]),
+      },
+    ],
   },
 ];
 

--- a/src/tutorial/lesson.ts
+++ b/src/tutorial/lesson.ts
@@ -5,13 +5,18 @@ export interface AnimationStep {
   typingSpeedDelayMs: number;
 }
 
+export interface SuccessCriterion {
+  description: string;
+  check: (compilation: Compilation) => boolean;
+}
+
 // Teach each grammar rule as a ludeme
 export interface Puzzlet {
   name: string;
   instructions: AnimationStep[];
   examples: AnimationStep[];
   clearEditorOnStart?: boolean;
-  successCondition: (compilation: Compilation) => boolean;
+  successCriteria: SuccessCriterion[];
 }
 
 export interface LudicModule {
@@ -62,9 +67,16 @@ export class Lesson {
     return this.currentPuzzletIndex >= this.flattenedPuzzlets.length;
   }
 
+  public evaluateCriteria(compilation: Compilation): boolean[] {
+    if (this.isComplete()) return [];
+    return this.getCurrentPuzzlet().successCriteria.map((c) =>
+      c.check(compilation),
+    );
+  }
+
   public canAdvance(compilation: Compilation): boolean {
     if (this.isComplete()) return false;
-    return this.getCurrentPuzzlet().successCondition(compilation);
+    return this.evaluateCriteria(compilation).every(Boolean);
   }
 
   public advance(): boolean {

--- a/src/tutorial/tutorialManager.ts
+++ b/src/tutorial/tutorialManager.ts
@@ -1,7 +1,8 @@
-import { Lesson, Puzzlet } from "./lesson";
+import { Lesson, Puzzlet, SuccessCriterion } from "./lesson";
 import { createFizLesson } from "./fiz/lessonPlan";
 import { Compilation } from "../compiler/compilation";
 import { TutorialProgressStore } from "./tutorialProgressStore";
+import { TypingSpeed } from "./animationHelpers";
 
 export class TutorialManager {
   private callbacks: {
@@ -26,6 +27,8 @@ export class TutorialManager {
   private disableAnimations: boolean = false;
   private progressStore: TutorialProgressStore = new TutorialProgressStore();
   public cachedHighestCompleted: number;
+  private staticHeaderText: string = "";
+  private latestCriteriaResults: boolean[] = [];
 
   constructor() {
     this.cachedHighestCompleted = this.progressStore.getHighestCompletedIndex();
@@ -83,8 +86,43 @@ export class TutorialManager {
     this.cancelAnimation();
   }
 
+  private formatChecklist(
+    criteria: SuccessCriterion[],
+    results: boolean[],
+  ): string {
+    if (criteria.length === 0) return "";
+    return (
+      "\n" +
+      criteria
+        .map((c, i) => {
+          const mark = results[i] ? "\u2713" : " ";
+          return `[${mark}] ${c.description}`;
+        })
+        .join("\n")
+    );
+  }
+
+  private updateChecklistDisplay(): void {
+    const puzzlet = this.currentLesson.getCurrentPuzzlet();
+    const checklist = this.formatChecklist(
+      puzzlet.successCriteria,
+      this.latestCriteriaResults,
+    );
+    this.setTutorialHeaderText(
+      "/* " + this.staticHeaderText + checklist + " */\n",
+    );
+  }
+
   public async onCompilation(compilation: Compilation): Promise<void> {
     if (!this.tutorialActive || this.isAdvancing) return;
+
+    // Update criteria results and checklist display
+    if (!this.isAnimating) {
+      this.latestCriteriaResults =
+        this.currentLesson.evaluateCriteria(compilation);
+      this.updateChecklistDisplay();
+    }
+
     if (!this.currentLesson.canAdvance(compilation)) return;
     this.isAdvancing = true;
     try {
@@ -134,11 +172,15 @@ export class TutorialManager {
     }
 
     let headerText = this.getProgressString();
+    this.latestCriteriaResults = new Array(puzzlet.successCriteria.length).fill(
+      false,
+    );
 
     // If animations are disabled, show all text immediately
     if (this.disableAnimations) {
       headerText += puzzlet.instructions.map((step) => step.text).join("");
-      this.setTutorialHeaderText("/* " + headerText + " */\n");
+      this.staticHeaderText = headerText;
+      this.updateChecklistDisplay();
 
       const examplesText = puzzlet.examples.map((step) => step.text).join("");
       this.setExamplesText(examplesText + "\n");
@@ -156,6 +198,22 @@ export class TutorialManager {
         this.setTutorialHeaderText("/* " + headerText + " */\n");
         await this.delay(step.typingSpeedDelayMs);
       }
+    }
+
+    // Store static header and animate the initial checklist
+    this.staticHeaderText = headerText;
+    const checklistText = this.formatChecklist(
+      puzzlet.successCriteria,
+      this.latestCriteriaResults,
+    );
+    let animatedChecklist = "";
+    for (const char of checklistText) {
+      if (!this.isAnimating) break;
+      animatedChecklist += char;
+      this.setTutorialHeaderText(
+        "/* " + this.staticHeaderText + animatedChecklist + " */\n",
+      );
+      await this.delay(TypingSpeed.Fast);
     }
 
     // Animate all examples at the header boundary (all are editable)

--- a/src/tutorial/tutorialManager.ts
+++ b/src/tutorial/tutorialManager.ts
@@ -5,6 +5,9 @@ import { TutorialProgressStore } from "./tutorialProgressStore";
 import { TypingSpeed } from "./animationHelpers";
 
 export class TutorialManager {
+  private static readonly CHECKLIST_SEPARATOR = "--------------------";
+  private static readonly EXAMPLES_SEPARATOR = "====================";
+
   private callbacks: {
     setEditorText: ((text: string) => void) | null;
     setTutorialHeaderText: ((text: string) => void) | null;
@@ -93,6 +96,8 @@ export class TutorialManager {
     if (criteria.length === 0) return "";
     return (
       "\n" +
+      TutorialManager.CHECKLIST_SEPARATOR +
+      "\n" +
       criteria
         .map((c, i) => {
           const mark = results[i] ? "\u2713" : " ";
@@ -108,8 +113,17 @@ export class TutorialManager {
       puzzlet.successCriteria,
       this.latestCriteriaResults,
     );
-    this.setTutorialHeaderText(
-      "/* " + this.staticHeaderText + checklist + " */\n",
+    this.setTutorialHeaderText(this.formatTutorialHeaderText(checklist));
+  }
+
+  private formatTutorialHeaderText(checklist: string): string {
+    return (
+      "/* " +
+      this.staticHeaderText +
+      checklist +
+      "\n" +
+      TutorialManager.EXAMPLES_SEPARATOR +
+      " */\n"
     );
   }
 
@@ -211,7 +225,7 @@ export class TutorialManager {
       if (!this.isAnimating) break;
       animatedChecklist += char;
       this.setTutorialHeaderText(
-        "/* " + this.staticHeaderText + animatedChecklist + " */\n",
+        this.formatTutorialHeaderText(animatedChecklist),
       );
       await this.delay(TypingSpeed.Fast);
     }

--- a/tests/unit/tutorial/lesson.test.ts
+++ b/tests/unit/tutorial/lesson.test.ts
@@ -7,7 +7,9 @@ function makePuzzlet(name: string, isSuccessful = false): Puzzlet {
     name,
     instructions: [{ text: "do something", typingSpeedDelayMs: 0 }],
     examples: [{ text: "example", typingSpeedDelayMs: 0 }],
-    successCondition: () => isSuccessful,
+    successCriteria: [
+      { description: "test criterion", check: () => isSuccessful },
+    ],
   };
 }
 
@@ -138,12 +140,12 @@ describe("Lesson", () => {
       expect(lesson.canAdvance(compilation)).toBe(false);
     });
 
-    test("returns true when success condition passes", () => {
+    test("returns true when all criteria pass", () => {
       const alwaysPass: Puzzlet = {
         name: "pass",
         instructions: [],
         examples: [],
-        successCondition: () => true,
+        successCriteria: [{ description: "always", check: () => true }],
       };
       const lesson = new Lesson("L", [{ name: "M", puzzlets: [alwaysPass] }]);
       const compilation = {} as Compilation;
@@ -155,11 +157,54 @@ describe("Lesson", () => {
         name: "pass",
         instructions: [],
         examples: [],
-        successCondition: () => true,
+        successCriteria: [{ description: "always", check: () => true }],
       };
       const lesson = new Lesson("L", [{ name: "M", puzzlets: [alwaysPass] }]);
       lesson.advance();
       expect(lesson.canAdvance({} as Compilation)).toBe(false);
+    });
+  });
+
+  describe("evaluateCriteria", () => {
+    test("returns mixed results for partial pass", () => {
+      const partial: Puzzlet = {
+        name: "partial",
+        instructions: [],
+        examples: [],
+        successCriteria: [
+          { description: "passes", check: () => true },
+          { description: "fails", check: () => false },
+          { description: "passes too", check: () => true },
+        ],
+      };
+      const lesson = new Lesson("L", [{ name: "M", puzzlets: [partial] }]);
+      expect(lesson.evaluateCriteria({} as Compilation)).toEqual([
+        true,
+        false,
+        true,
+      ]);
+    });
+
+    test("returns all true when all pass", () => {
+      const allPass: Puzzlet = {
+        name: "all",
+        instructions: [],
+        examples: [],
+        successCriteria: [
+          { description: "a", check: () => true },
+          { description: "b", check: () => true },
+        ],
+      };
+      const lesson = new Lesson("L", [{ name: "M", puzzlets: [allPass] }]);
+      expect(lesson.evaluateCriteria({} as Compilation)).toEqual([true, true]);
+    });
+
+    test("returns empty array when lesson is complete", () => {
+      const lesson = new Lesson("L", [
+        { name: "M", puzzlets: [makePuzzlet("p")] },
+      ]);
+      lesson.advance();
+      expect(lesson.evaluateCriteria({} as Compilation)).toEqual([]);
     });
   });
 

--- a/tests/unit/tutorial/tutorialManager.test.ts
+++ b/tests/unit/tutorial/tutorialManager.test.ts
@@ -105,4 +105,37 @@ describe("TutorialManager", () => {
       manager.startTutorialAt(0);
     });
   });
+
+  describe("checklist display", () => {
+    test("header includes checklist after startTutorialAt", () => {
+      const { manager, headerText } = setupManager();
+      manager.startTutorialAt(0);
+      expect(headerText.value).toContain("[ ]");
+    });
+
+    test("onCompilation updates checkmarks in header text", async () => {
+      vi.stubGlobal("window", { setTimeout: globalThis.setTimeout });
+      vi.useFakeTimers();
+      const { manager, headerText } = setupManager();
+      manager.startTutorialAt(0);
+      // Initially all unchecked
+      expect(headerText.value).toContain("[ ]");
+      expect(headerText.value).not.toContain("[\u2713]");
+
+      // Simulate a compilation that satisfies the first puzzlet's criteria
+      const mockCompilation = {
+        DAG: {
+          getNodeList: () => [{ id: "1", name: "f" }],
+        },
+      } as unknown as Parameters<typeof manager.onCompilation>[0];
+      // Don't await — just trigger the update (will start the advance delay)
+      const promise = manager.onCompilation(mockCompilation);
+      // After onCompilation, the header should show checked criteria
+      expect(headerText.value).toContain("[\u2713]");
+      expect(headerText.value).not.toContain("[ ]");
+      await vi.advanceTimersByTimeAsync(1000);
+      await promise;
+      vi.useRealTimers();
+    });
+  });
 });


### PR DESCRIPTION
This pull request refactors all tutorial modules (`assignmentModule.ts`, `functionsModule.ts`, `importModule.ts`, `lessonPlan.ts`, `namespacesModule.ts`) to support multiple success criteria for each puzzlet, replacing the previous single `successCondition` with a new `successCriteria` array. This change allows for more granular and descriptive win conditions, improves code organization, and introduces helper functions for common checks.

The most important changes are:

**Refactor to support multiple success criteria:**

* Replaces the `successCondition` property with a `successCriteria` array in all puzzlet definitions, enabling each puzzlet to specify multiple win conditions, each with a description and a check function. (`[[1]](diffhunk://#diff-3010dc67427ab7a392a44951c5f0c17eff3749f4297cdd2a8fe54ca617f83bc4L21-R58)`, `[[2]](diffhunk://#diff-e0f21dae0c3e00aca9ad459396d35e4efe8c703f065717edb2facb863a7900dcL17-R65)`, `[[3]](diffhunk://#diff-fe7f5fcc77e697a6c0a78ed78cf3a68e52b8a3784b3763bc205ad4d5f20424b3L23-R32)`, `[[4]](diffhunk://#diff-010f99a11b3abb8e02595ec11cb8ebe192019961c2c2d824d73413c9709bae60L20-R26)`, `[[5]](diffhunk://#diff-e12d7e57f173ad77c26c3491672fa5ef9f8df7838ac8ef873f367ee43a3e5892L19-R29)`)

**Code organization and maintainability:**

* Refactors puzzlet definitions from array literals to individually named constants (e.g., `onAssignmentPuzzlet`, `importAntPuzzlet`, etc.), then aggregates them in the exported module, improving readability and maintainability. (`[[1]](diffhunk://#diff-3010dc67427ab7a392a44951c5f0c17eff3749f4297cdd2a8fe54ca617f83bc4L11-R11)`, `[[2]](diffhunk://#diff-e0f21dae0c3e00aca9ad459396d35e4efe8c703f065717edb2facb863a7900dcL6-R6)`, `[[3]](diffhunk://#diff-fe7f5fcc77e697a6c0a78ed78cf3a68e52b8a3784b3763bc205ad4d5f20424b3L10-R12)`, `[[4]](diffhunk://#diff-e12d7e57f173ad77c26c3491672fa5ef9f8df7838ac8ef873f367ee43a3e5892L7-R7)`)
* Extracts repeated logic into helper functions such as `getAssignedVariableUsageCount` and `createHasFunctionNodeCheck` to avoid code duplication and clarify intent. (`[[1]](diffhunk://#diff-3010dc67427ab7a392a44951c5f0c17eff3749f4297cdd2a8fe54ca617f83bc4L21-R58)`, `[[2]](diffhunk://#diff-fe7f5fcc77e697a6c0a78ed78cf3a68e52b8a3784b3763bc205ad4d5f20424b3L39-R73)`)

**Enhancements to win condition expressiveness:**

* Adds descriptive `description` fields to each success criterion, providing clearer guidance to users about what is required to complete each puzzlet. (`[[1]](diffhunk://#diff-3010dc67427ab7a392a44951c5f0c17eff3749f4297cdd2a8fe54ca617f83bc4L21-R58)`, `[[2]](diffhunk://#diff-e0f21dae0c3e00aca9ad459396d35e4efe8c703f065717edb2facb863a7900dcL17-R65)`, `[[3]](diffhunk://#diff-fe7f5fcc77e697a6c0a78ed78cf3a68e52b8a3784b3763bc205ad4d5f20424b3L23-R32)`, `[[4]](diffhunk://#diff-010f99a11b3abb8e02595ec11cb8ebe192019961c2c2d824d73413c9709bae60L20-R26)`, `[[5]](diffhunk://#diff-e12d7e57f173ad77c26c3491672fa5ef9f8df7838ac8ef873f367ee43a3e5892L19-R29)`)

**No functional changes to lesson logic:**

* The core logic for checking win conditions remains the same; the refactor is structural and does not alter the behavior of the tutorials. (`[[1]](diffhunk://#diff-3010dc67427ab7a392a44951c5f0c17eff3749f4297cdd2a8fe54ca617f83bc4L21-R58)`, `[[2]](diffhunk://#diff-e0f21dae0c3e00aca9ad459396d35e4efe8c703f065717edb2facb863a7900dcL17-R65)`, `[[3]](diffhunk://#diff-fe7f5fcc77e697a6c0a78ed78cf3a68e52b8a3784b3763bc205ad4d5f20424b3L23-R32)`, `[[4]](diffhunk://#diff-010f99a11b3abb8e02595ec11cb8ebe192019961c2c2d824d73413c9709bae60L20-R26)`, `[[5]](diffhunk://#diff-e12d7e57f173ad77c26c3491672fa5ef9f8df7838ac8ef873f367ee43a3e5892L19-R29)`)

**Improved tutorial maintainability and extensibility:**

* The new structure makes it easier to add, update, or remove individual win conditions for puzzlets in the future. (`[[1]](diffhunk://#diff-3010dc67427ab7a392a44951c5f0c17eff3749f4297cdd2a8fe54ca617f83bc4L21-R58)`, `[[2]](diffhunk://#diff-e0f21dae0c3e00aca9ad459396d35e4efe8c703f065717edb2facb863a7900dcL17-R65)`, `[[3]](diffhunk://#diff-fe7f5fcc77e697a6c0a78ed78cf3a68e52b8a3784b3763bc205ad4d5f20424b3L23-R32)`, `[[4]](diffhunk://#diff-010f99a11b3abb8e02595ec11cb8ebe192019961c2c2d824d73413c9709bae60L20-R26)`, `[[5]](diffhunk://#diff-e12d7e57f173ad77c26c3491672fa5ef9f8df7838ac8ef873f367ee43a3e5892L19-R29)`)