### PR TITLE
chore: update theme assignment call and confetti duration settings

### DIFF
--- a/src/components/ConfettiEffect.vue
+++ b/src/components/ConfettiEffect.vue
@@ -12,7 +12,7 @@ const triggerConfetti = async () => {
     startVelocity: 60,
     shapes: ["circle"],
     colors: ["#80ebff", "#33acff"],
-    ticks: 50,
+    ticks: 2000,
     gravity: 1,
     scalar: 1,
   };

--- a/src/composables/useAppTheme.ts
+++ b/src/composables/useAppTheme.ts
@@ -15,7 +15,7 @@ export function useAppTheme(initialThemeMode: ThemeMode = "system") {
   });
 
   function applyTheme(theme: "light" | "dark") {
-    vuetifyTheme.global.name.value = theme;
+    vuetifyTheme.change(theme);
     document.documentElement.classList.toggle("dark", theme === "dark");
   }
 

--- a/tests/integration/composables/useAppTheme.test.ts
+++ b/tests/integration/composables/useAppTheme.test.ts
@@ -4,8 +4,12 @@ import { useAppTheme } from "src/composables/useAppTheme";
 
 // Mock Vuetify's useTheme
 const mockVuetifyThemeName = { value: "light" };
+const mockVuetifyThemeChange = vi.fn((theme: "light" | "dark") => {
+  mockVuetifyThemeName.value = theme;
+});
 vi.mock("vuetify", () => ({
   useTheme: () => ({
+    change: mockVuetifyThemeChange,
     global: {
       name: mockVuetifyThemeName,
     },
@@ -19,6 +23,7 @@ describe("useAppTheme", () => {
 
   beforeEach(() => {
     mockVuetifyThemeName.value = "light";
+    mockVuetifyThemeChange.mockClear();
     mediaQueryHandler = null;
 
     mockMatchMedia = vi.fn().mockReturnValue({

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -6,7 +6,7 @@ export default defineConfig({
   plugins: [Vue()],
   resolve: {
     alias: {
-      src: path.resolve(__dirname, "./src"),
+      src: path.resolve(import.meta.dirname, "./src"),
     },
   },
   test: {


### PR DESCRIPTION
This pull request introduces several improvements and fixes related to theming and configuration.

**Theming System Updates:**

* Updated the `applyTheme` method in `useAppTheme` to use Vuetify's `change` method instead of directly setting the theme name, ensuring better compatibility with Vuetify's API.

**Build and Configuration:**

* Changed the Vite alias resolution in `vite.config.ts` to use `import.meta.dirname` instead of `__dirname`, improving compatibility with ESM environments.

**Visual Effects:**

* Increased the confetti effect duration by changing `ticks` from 50 to 2000 in `ConfettiEffect.vue` so that the last confetti clears the screen before fading.