### PR TITLE
fix(confetti): restore missing confetti blast

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -82,7 +82,7 @@ importers:
         version: 1.4.0(vue@3.5.41(typescript@6.0.3))
       vuetify:
         specifier: ^4.1.7
-        version: 4.1.7(typescript@6.0.3)(vue@3.5.41(typescript@6.0.3))
+        version: 4.1.8(typescript@6.0.3)(vue@3.5.41(typescript@6.0.3))
     devDependencies:
       '@babel/types':
         specifier: ^7.29.8
@@ -2434,12 +2434,12 @@ packages:
       typescript:
         optional: true
 
-  vuetify@4.1.7:
-    resolution: {integrity: sha512-07qxu0S1oxPjmknP/Yn5276PtIhlCvHnpcp7HuOKEHni89/6BGiM2aVdKlEGeyM5RfytDkiv0SNieabGT2D8qQ==}
+  vuetify@4.1.8:
+    resolution: {integrity: sha512-003D/8b5462uZCD5CMRTZF3smADmOn47mzthNY0aP/xkslovR5yIc1qXjPdFN0LHcu+p3GEAVmMQabldaIQ5pg==}
     peerDependencies:
       typescript: '>=4.7'
       vite-plugin-vuetify: '>=2.1.0'
-      vue: ^3.5.0
+      vue: ^3.5.0 || ^3.6.0-0
       webpack-plugin-vuetify: '>=3.1.0'
     peerDependenciesMeta:
       typescript:
@@ -4745,7 +4745,7 @@ snapshots:
     optionalDependencies:
       typescript: 6.0.3
 
-  vuetify@4.1.7(typescript@6.0.3)(vue@3.5.41(typescript@6.0.3)):
+  vuetify@4.1.8(typescript@6.0.3)(vue@3.5.41(typescript@6.0.3)):
     dependencies:
       vue: 3.5.41(typescript@6.0.3)
     optionalDependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,7 +1,7 @@
 allowBuilds:
   "@formulavize/lang-fiz": true
   "@formulavize/lezer-fiz": true
-  "@tsparticles/engine": false
+  "@tsparticles/engine": true
 minimumReleaseAgeExclude:
   - "@formulavize/lang-fiz"
   - "@formulavize/lezer-fiz"

--- a/tests/unit/tutorial/tutorialManager.test.ts
+++ b/tests/unit/tutorial/tutorialManager.test.ts
@@ -4,6 +4,12 @@ import { createMockLocalStorage } from "../versionedStoreTestHelpers";
 
 const STORAGE_KEY = "formulavize-tutorial-progress";
 
+function setupTutorialTimers(): void {
+  // Ensure window.setTimeout is bound to fake timers, not real timers.
+  vi.useFakeTimers();
+  vi.stubGlobal("window", { setTimeout: globalThis.setTimeout });
+}
+
 function setupManager(): {
   manager: TutorialManager;
   editorText: { value: string };
@@ -35,6 +41,7 @@ describe("TutorialManager", () => {
   });
 
   afterEach(() => {
+    vi.useRealTimers();
     vi.unstubAllGlobals();
   });
 
@@ -114,8 +121,7 @@ describe("TutorialManager", () => {
     });
 
     test("onCompilation updates checkmarks in header text", async () => {
-      vi.stubGlobal("window", { setTimeout: globalThis.setTimeout });
-      vi.useFakeTimers();
+      setupTutorialTimers();
       const { manager, headerText } = setupManager();
       manager.startTutorialAt(0);
       // Initially all unchecked
@@ -133,9 +139,8 @@ describe("TutorialManager", () => {
       // After onCompilation, the header should show checked criteria
       expect(headerText.value).toContain("[\u2713]");
       expect(headerText.value).not.toContain("[ ]");
-      await vi.advanceTimersByTimeAsync(1000);
+      await vi.advanceTimersByTimeAsync(500);
       await promise;
-      vi.useRealTimers();
     });
   });
 });


### PR DESCRIPTION
This pull request enables builds for `@tsparticles/engine` because it is required to properly draw confetti, and refactoring the tutorial manager tests to better handle timers.

**Dependency Updates:**
* Enabled builds for `@tsparticles/engine` in `pnpm-workspace.yaml`.

**Test Improvements:**
* Refactored tutorial manager tests in `tutorialManager.test.ts` to use a new `setupTutorialTimers` helper, ensuring consistent use of fake timers and proper global stubbing. [[1]](diffhunk://#diff-5f0f2f4062535ed5911b7b205bb6fd000584a87119840ea1c95b1e0eff5da9f1R7-R12) [[2]](diffhunk://#diff-5f0f2f4062535ed5911b7b205bb6fd000584a87119840ea1c95b1e0eff5da9f1L117-R124)
* Adjusted the timer advancement in a test from 1000ms to 500ms to match the expected behavior.