### PR TITLE
feat: add RendererDirective support

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "@codemirror/theme-one-dark": "^6.1.3",
     "@codemirror/view": "^6.43.7",
     "@floating-ui/dom": "^1.8.0",
-    "@formulavize/lang-fiz": "^2.1.2",
+    "@formulavize/lang-fiz": "^2.2.0",
     "@lezer/common": "^1.5.2",
     "@napi-rs/canvas": "^0.1.60",
     "@tsparticles/confetti": "^4.3.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -36,8 +36,8 @@ importers:
         specifier: ^1.8.0
         version: 1.8.0
       '@formulavize/lang-fiz':
-        specifier: ^2.1.2
-        version: 2.1.2
+        specifier: ^2.2.0
+        version: 2.2.0
       '@lezer/common':
         specifier: ^1.5.2
         version: 1.5.2
@@ -52,16 +52,16 @@ importers:
         version: 15.0.0
       cytoscape:
         specifier: ^3.34.0
-        version: 3.34.0
+        version: 3.34.1
       cytoscape-dagre:
         specifier: ^4.0.0
-        version: 4.0.0(cytoscape@3.34.0)
+        version: 4.0.0(cytoscape@3.34.1)
       cytoscape-popper:
         specifier: ^4.0.1
-        version: 4.0.1(cytoscape@3.34.0)
+        version: 4.0.1(cytoscape@3.34.1)
       cytoscape-svg:
         specifier: ^0.4.0
-        version: 0.4.0(cytoscape@3.34.0)
+        version: 0.4.0(cytoscape@3.34.1)
       file-saver:
         specifier: ^2.0.5
         version: 2.0.5
@@ -85,26 +85,26 @@ importers:
         version: 3.5.41(typescript@6.0.3)
       vue-router:
         specifier: ^5.2.0
-        version: 5.2.0(@vue/compiler-sfc@3.5.41)(esbuild@0.28.1)(rolldown@1.2.3)(vite@8.2.1(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.6.1)(tsx@4.23.10)(yaml@2.9.0))(vue@3.5.41(typescript@6.0.3))
+        version: 5.2.0(@vue/compiler-sfc@3.5.41)(esbuild@0.28.2)(rolldown@1.2.4)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.6.1)(tsx@4.23.12)(yaml@2.9.0))(vue@3.5.41(typescript@6.0.3))
       vue3-tabs-component:
         specifier: ^1.4.0
         version: 1.4.0(vue@3.5.41(typescript@6.0.3))
       vuetify:
         specifier: ^4.1.7
-        version: 4.1.8(typescript@6.0.3)(vue@3.5.41(typescript@6.0.3))
+        version: 4.1.9(typescript@6.0.3)(vue@3.5.41(typescript@6.0.3))
     devDependencies:
       '@babel/types':
         specifier: ^7.29.8
         version: 7.29.8
       '@commitlint/cli':
         specifier: ^21.2.1
-        version: 21.2.1(@types/node@26.1.2)(conventional-commits-parser@7.1.2)(typescript@6.0.3)
+        version: 21.2.2(@types/node@26.2.0)(conventional-commits-parser@7.1.2)(typescript@6.0.3)
       '@commitlint/config-conventional':
         specifier: ^21.2.0
-        version: 21.2.0
+        version: 21.2.2
       '@eslint/js':
         specifier: ^10.0.1
-        version: 10.0.1(eslint@10.8.0(jiti@2.6.1)(supports-color@7.2.0))
+        version: 10.0.1(eslint@10.8.1(jiti@2.6.1)(supports-color@7.2.0))
       '@mdi/js':
         specifier: ^7.4.47
         version: 7.4.47
@@ -122,10 +122,10 @@ importers:
         version: 4.17.25
       '@types/node':
         specifier: ^26.1.2
-        version: 26.1.2
+        version: 26.2.0
       '@vitejs/plugin-vue':
         specifier: ^6.0.8
-        version: 6.0.8(vite@8.2.1(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.6.1)(tsx@4.23.10)(yaml@2.9.0))(vue@3.5.41(typescript@6.0.3))
+        version: 6.0.8(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.6.1)(tsx@4.23.12)(yaml@2.9.0))(vue@3.5.41(typescript@6.0.3))
       '@vitest/coverage-v8':
         specifier: ^4.1.10
         version: 4.1.10(vitest@4.1.10)
@@ -134,7 +134,7 @@ importers:
         version: 3.5.41
       '@vue/eslint-config-typescript':
         specifier: ^14.9.0
-        version: 14.9.0(eslint-plugin-vue@10.10.0(@typescript-eslint/parser@8.66.0(eslint@10.8.0(jiti@2.6.1)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@6.0.3))(eslint@10.8.0(jiti@2.6.1)(supports-color@7.2.0))(vue-eslint-parser@10.4.1(eslint@10.8.0(jiti@2.6.1)(supports-color@7.2.0))(supports-color@7.2.0)))(eslint@10.8.0(jiti@2.6.1)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@6.0.3)
+        version: 14.9.0(eslint-plugin-vue@10.10.0(@typescript-eslint/parser@8.67.0(eslint@10.8.1(jiti@2.6.1)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@6.0.3))(eslint@10.8.1(jiti@2.6.1)(supports-color@7.2.0))(vue-eslint-parser@10.4.1(eslint@10.8.1(jiti@2.6.1)(supports-color@7.2.0))(supports-color@7.2.0)))(eslint@10.8.1(jiti@2.6.1)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@6.0.3)
       '@vue/test-utils':
         specifier: ^2.4.11
         version: 2.4.11(@vue/compiler-dom@3.5.41)(@vue/server-renderer@3.5.41)(vue@3.5.41(typescript@6.0.3))
@@ -143,25 +143,25 @@ importers:
         version: 12.0.0
       commitizen:
         specifier: ^4.3.2
-        version: 4.3.2(@types/node@26.1.2)(typescript@6.0.3)
+        version: 4.3.2(@types/node@26.2.0)(typescript@6.0.3)
       cz-conventional-changelog:
         specifier: ^3.3.0
-        version: 3.3.0(@types/node@26.1.2)(typescript@6.0.3)
+        version: 3.3.0(@types/node@26.2.0)(typescript@6.0.3)
       eslint:
         specifier: ^10.8.0
-        version: 10.8.0(jiti@2.6.1)(supports-color@7.2.0)
+        version: 10.8.1(jiti@2.6.1)(supports-color@7.2.0)
       eslint-config-prettier:
         specifier: ^10.1.8
-        version: 10.1.8(eslint@10.8.0(jiti@2.6.1)(supports-color@7.2.0))
+        version: 10.1.8(eslint@10.8.1(jiti@2.6.1)(supports-color@7.2.0))
       eslint-plugin-prettier:
         specifier: ^5.5.6
-        version: 5.5.6(eslint-config-prettier@10.1.8(eslint@10.8.0(jiti@2.6.1)(supports-color@7.2.0)))(eslint@10.8.0(jiti@2.6.1)(supports-color@7.2.0))(prettier@3.9.6)
+        version: 5.5.6(eslint-config-prettier@10.1.8(eslint@10.8.1(jiti@2.6.1)(supports-color@7.2.0)))(eslint@10.8.1(jiti@2.6.1)(supports-color@7.2.0))(prettier@3.9.6)
       eslint-plugin-vue:
         specifier: ^10.10.0
-        version: 10.10.0(@typescript-eslint/parser@8.66.0(eslint@10.8.0(jiti@2.6.1)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@6.0.3))(eslint@10.8.0(jiti@2.6.1)(supports-color@7.2.0))(vue-eslint-parser@10.4.1(eslint@10.8.0(jiti@2.6.1)(supports-color@7.2.0))(supports-color@7.2.0))
+        version: 10.10.0(@typescript-eslint/parser@8.67.0(eslint@10.8.1(jiti@2.6.1)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@6.0.3))(eslint@10.8.1(jiti@2.6.1)(supports-color@7.2.0))(vue-eslint-parser@10.4.1(eslint@10.8.1(jiti@2.6.1)(supports-color@7.2.0))(supports-color@7.2.0))
       globals:
         specifier: ^17.9.0
-        version: 17.9.0
+        version: 17.11.0
       husky:
         specifier: ^9.1.7
         version: 9.1.7
@@ -176,19 +176,19 @@ importers:
         version: 3.9.6
       tsx:
         specifier: ^4.20.0
-        version: 4.23.10
+        version: 4.23.12
       typescript:
         specifier: ^6.0.3
         version: 6.0.3
       typescript-eslint:
         specifier: ^8.65.0
-        version: 8.66.0(eslint@10.8.0(jiti@2.6.1)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@6.0.3)
+        version: 8.67.0(eslint@10.8.1(jiti@2.6.1)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@6.0.3)
       vite:
         specifier: ^8.2.0
-        version: 8.2.1(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.6.1)(tsx@4.23.10)(yaml@2.9.0)
+        version: 8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.6.1)(tsx@4.23.12)(yaml@2.9.0)
       vitest:
         specifier: ^4.1.10
-        version: 4.1.10(@types/node@26.1.2)(@vitest/coverage-v8@4.1.10)(jsdom@27.4.0(supports-color@7.2.0))(vite@8.2.1(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.6.1)(tsx@4.23.10)(yaml@2.9.0))
+        version: 4.1.10(@types/node@26.2.0)(@vitest/coverage-v8@4.1.10)(jsdom@27.4.0(supports-color@7.2.0))(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.6.1)(tsx@4.23.12)(yaml@2.9.0))
       vue-tsc:
         specifier: ^3.3.9
         version: 3.3.9(typescript@6.0.3)
@@ -281,13 +281,13 @@ packages:
   '@codemirror/view@6.43.8':
     resolution: {integrity: sha512-qtItTDssZ/5GFfi94hrILu9j/VUeFPDPkhovEfmWFj2ipTxnzPB8DdHgfbb8HYTzLTYhrndKmyQxXUz/PDLenw==}
 
-  '@commitlint/cli@21.2.1':
-    resolution: {integrity: sha512-blsZGe29hJ72VGEFVl72IVYX+1vsfINpjA9yWQA6i7OKD/McGEOXg08sKIRKjFk4JvzhV/9n0l3i6NooPLTNfg==}
+  '@commitlint/cli@21.2.2':
+    resolution: {integrity: sha512-a+6hQxIxnpdvSvS2apvttPNbEliYsVC3PqFYDiiB2kjbwIsQsj1urvQ4Tkf70pKYozPalKAuRQmm/GHwndduqA==}
     engines: {node: '>=22.12.0'}
     hasBin: true
 
-  '@commitlint/config-conventional@21.2.0':
-    resolution: {integrity: sha512-Qf8WRDVcyVd14if6VTWenebxFbKnVnbzPUJjlzjkyJGeHK2xCGd63Dr1XZzj0plXKQb9P0BfOxoc1HVeCo2BWQ==}
+  '@commitlint/config-conventional@21.2.2':
+    resolution: {integrity: sha512-NxA37SZviusFUEYOQZ5hNnZ1h7O/KiemPkxjOlpzKJNnWxThiwc6/SaZhaPa8fyLvfRBAywhQhJJk8XESHWlpQ==}
     engines: {node: '>=22.12.0'}
 
   '@commitlint/config-validator@21.2.0':
@@ -302,40 +302,40 @@ packages:
     resolution: {integrity: sha512-RifH+FmImozKBE6mozhF4K3r2RRKP7SMi/Q/zLCmExtp5e05lhHOUYqGBlFBAGNHaZxU/WYw1XuugYK9jQzqnA==}
     engines: {node: '>=22.12.0'}
 
-  '@commitlint/format@21.2.0':
-    resolution: {integrity: sha512-c4q64xaav2U83t7k7RyzJerBZurPer7FxUOY0RL5L/6CZijZ7K+s6HIBGIghj0ey1P2+seRX0J9XQYtDued6tg==}
+  '@commitlint/format@21.2.2':
+    resolution: {integrity: sha512-v6fvxZSc/AvVMROlr3H34+1766bZSYApRUSCAMjWamStPjKMvZ8GdvVA5YW/VQNgbFTmcMz6OYmSTJEvIjPrfA==}
     engines: {node: '>=22.12.0'}
 
-  '@commitlint/is-ignored@21.2.0':
-    resolution: {integrity: sha512-4/eB0vBN7L88O/oC4ajAEqi7j2ZfNgxl/+11RfAV9YosejZgDXhY2C9VcHnHJhOzPLoSy5P3Mg/46kqeyJfXKw==}
+  '@commitlint/is-ignored@21.2.2':
+    resolution: {integrity: sha512-9UoKNgfFE3LU7FrzierCvk3CdDfMDeVGC86qZiT/n0TIjfq/dmZ9MHuXd45OTNRa26ZanmJRxEtmiXk/lEJihg==}
     engines: {node: '>=22.12.0'}
 
-  '@commitlint/lint@21.2.0':
-    resolution: {integrity: sha512-ceO5dp9pLjEZ6y6qbq/uXWXDPykqqlTsyzoQ0NzecpisSJhK3kTy9qzQoPeJuWG/IMNdV1lO0RgmzqoAlSi1uw==}
+  '@commitlint/lint@21.2.2':
+    resolution: {integrity: sha512-Fy8JxEBzdmsYWFude/61GxXu5O+wEymwiRK2z9GL9R8mCsXphCoGxAFc5iHn5mjlfcSrhiiONE+ksf4KOjnaPg==}
     engines: {node: '>=22.12.0'}
 
-  '@commitlint/load@21.2.0':
-    resolution: {integrity: sha512-RjlzWQqruRwIenJEfZtq7kG97co97nKoHpflE5YnF61tDLXxHPrdWImgzw6VL6MlFyaOcVlk74eBV8ZQmc3oIA==}
+  '@commitlint/load@21.2.2':
+    resolution: {integrity: sha512-0Tt6wDPX167cjKC5D4zhm0+20wJJG+TN/TKovMOspfSe78rOnKX+MNzlVNiu6HyQPZChPJ8QBH31MVt6Bb8fCg==}
     engines: {node: '>=22.12.0'}
 
   '@commitlint/message@21.2.0':
     resolution: {integrity: sha512-YxGoiXD/HXNXLJPrQwE5poXa+XH0CBEm+mdvbHQP0g6MV/dmJyUFCzPNzZbxL93GvZ70TmtTK0Z0/IBpAqHv8g==}
     engines: {node: '>=22.12.0'}
 
-  '@commitlint/parse@21.2.0':
-    resolution: {integrity: sha512-QHWxG4d0PLTF634/AdyZ0MQS+CLn5YOuJlCFhMMlSGKFxzYGUetkHBj18xgBD+6fVzUrA2lrCdi/vlS2f/oYXg==}
+  '@commitlint/parse@21.2.2':
+    resolution: {integrity: sha512-MEkobPfvRp+z06Wro8HMG1BDGHzZmj82A1LH1nWeG3ipHpg/x4m6v3wEDvMBIKjRFUnfR3nBeFs3MVCr7UdAmg==}
     engines: {node: '>=22.12.0'}
 
   '@commitlint/read@21.2.1':
     resolution: {integrity: sha512-hUW7EJQnNTL0vPOmVMNK4CrnrNBN0nN+JJHReFkdHO5y4iyHeEmTBwuC15OCqUTjxWo7idnH1LftfpWVIaPWIA==}
     engines: {node: '>=22.12.0'}
 
-  '@commitlint/resolve-extends@21.2.0':
-    resolution: {integrity: sha512-4O/1j51+79Wth9s/MGxt/5gs0XYLDgNlYpltQfhAvLE0itusLKs9zruxbiNg1oOkmkb9L9L4USYGjEj7n87NxA==}
+  '@commitlint/resolve-extends@21.2.2':
+    resolution: {integrity: sha512-RPkJ/IFi7sMUUVbZLqwWFtWw/zRDcfFsmrPSiTMrt5wb7AdxOr86EGQFvmGzef5QKV5IPBWWCujqVTw1RWX44A==}
     engines: {node: '>=22.12.0'}
 
-  '@commitlint/rules@21.2.0':
-    resolution: {integrity: sha512-C2yXMNpiB8ETZKfx5JD8+ExgF8vTU1VQMKPSUUYwqKpw9oJWQBrlXBpdU038mj2WPjof7o9UzFpmTyBeGMZwZg==}
+  '@commitlint/rules@21.2.2':
+    resolution: {integrity: sha512-eplQzyYkBjYB1HyyRj8hkcK11Y9DU9nuBz7uOKEd6NpE9NGDytLFCAnlRE+OoiK/5sHEJsaz2RGhuWBvYzIbNA==}
     engines: {node: '>=22.12.0'}
 
   '@commitlint/to-lines@21.0.1':
@@ -350,20 +350,20 @@ packages:
     resolution: {integrity: sha512-7zVFCDB2reMvJH5dmbKnOQPjZEvjdJTH8jc0U/PIPU1r3/+vf5pD1HlfitV2MWsWXrvu7u39iY1lyLUPOaN0Gw==}
     engines: {node: '>=22.12.0'}
 
-  '@conventional-changelog/git-client@3.1.0':
-    resolution: {integrity: sha512-Tqa/gHco2WJWa740NRjOrfKVvzIqxkZpecb8bemaQ8sKM5PXb1UK4uTyTb/1wIqNuOVaDOFxyBdhTIQZn6gdjQ==}
+  '@conventional-changelog/git-client@3.1.2':
+    resolution: {integrity: sha512-jZqwnJwf7nboIlAcw/mkOjVa6DexCcUOgT2oOQgkoi3z9vR8tGFkcMy2BFcYwjhL9sYcDDXkRQDayiDieCoW7A==}
     engines: {node: '>=22'}
     peerDependencies:
       conventional-commits-filter: ^6.0.1
-      conventional-commits-parser: ^7.0.1
+      conventional-commits-parser: ^7.1.2
     peerDependenciesMeta:
       conventional-commits-filter:
         optional: true
       conventional-commits-parser:
         optional: true
 
-  '@conventional-changelog/template@1.2.1':
-    resolution: {integrity: sha512-TzlTVpKPjaqW6qOYjQcYUDuGsLCNsvFHVBXkYGTAnf5V37jCWrE5haKNXzz0WZUtVHjrpV76L1buANjwXMfT8w==}
+  '@conventional-changelog/template@1.3.0':
+    resolution: {integrity: sha512-GsCw/qu92GI0EX6s7fxUi/SG1lmFjG9XZivxxEDZXqztuQKCn5o5wKdz4v005zci0Md7EZzgAwmQLoIEDZoaow==}
     engines: {node: '>=22'}
 
   '@csstools/color-helpers@6.1.0':
@@ -402,158 +402,158 @@ packages:
     resolution: {integrity: sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==}
     engines: {node: '>=20.19.0'}
 
-  '@esbuild/aix-ppc64@0.28.1':
-    resolution: {integrity: sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==}
+  '@esbuild/aix-ppc64@0.28.2':
+    resolution: {integrity: sha512-XExcO+dvLKvVtNTibSTBej1NCAbaGhWn9Ww1ZPx80qsahhPFe/8jgWP0IchNe0F3HwkU7n8ejhH8bjonqht8mQ==}
     engines: {node: '>=18'}
     cpu: [ppc64]
     os: [aix]
 
-  '@esbuild/android-arm64@0.28.1':
-    resolution: {integrity: sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==}
+  '@esbuild/android-arm64@0.28.2':
+    resolution: {integrity: sha512-5YfKeeI8qWfBZIX+u2xZC3Zlb3Os/gLS2sbEKM+I4ZOcsWmHS2WLysCcQZDAFRslDUU5Oiq44gf6PYN1vGwG5A==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [android]
 
-  '@esbuild/android-arm@0.28.1':
-    resolution: {integrity: sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==}
+  '@esbuild/android-arm@0.28.2':
+    resolution: {integrity: sha512-kXXoiPVVGQcnIYGOeaovwOURpniDBpSq4A03qkQ+BMQqtGG6HYap3xne9C1O1yo4TR3qxlCX5IqqmX6fFo2Lqg==}
     engines: {node: '>=18'}
     cpu: [arm]
     os: [android]
 
-  '@esbuild/android-x64@0.28.1':
-    resolution: {integrity: sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==}
+  '@esbuild/android-x64@0.28.2':
+    resolution: {integrity: sha512-O387ite7SzUyCcy3JQX4P4bLtEA7bLLkx+esve5JHnyYfNTxcVpXZo9jhdB0lTKN44gztELTdU7nS8Nr16Fs1Q==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [android]
 
-  '@esbuild/darwin-arm64@0.28.1':
-    resolution: {integrity: sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==}
+  '@esbuild/darwin-arm64@0.28.2':
+    resolution: {integrity: sha512-n4KqkOQrraxHJcgjM1RvwbigfQKIKJVpM7xp+KsxiyUSrRdIXnt73VhrPAx0fV44hgfmIVKjxMN9J1t5jySVkw==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [darwin]
 
-  '@esbuild/darwin-x64@0.28.1':
-    resolution: {integrity: sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==}
+  '@esbuild/darwin-x64@0.28.2':
+    resolution: {integrity: sha512-uq6suIWYP37qzGddBKPw5QEQPi6HiLGsO7UmkpfyaYNQ3D+rN6w6WfwH+nuqcGXWvawGwxOEroO4YGnFh95azw==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [darwin]
 
-  '@esbuild/freebsd-arm64@0.28.1':
-    resolution: {integrity: sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==}
+  '@esbuild/freebsd-arm64@0.28.2':
+    resolution: {integrity: sha512-n+I0BTSRIoy+d6RPKnEVwql5UwBJolytvY4mAOIEJorKlqgPII8ix6slVVrfZ5Tnj7glIZvloylbB/EJPMWEXw==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [freebsd]
 
-  '@esbuild/freebsd-x64@0.28.1':
-    resolution: {integrity: sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==}
+  '@esbuild/freebsd-x64@0.28.2':
+    resolution: {integrity: sha512-78XJTJkvPs0kz2w61301PJjXl4g7q3JqiYMZ/M/yVI73EHBrCRTgkhu9oqG7vPqq+a/yadEW8aD+agKlk5xrmg==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [freebsd]
 
-  '@esbuild/linux-arm64@0.28.1':
-    resolution: {integrity: sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==}
+  '@esbuild/linux-arm64@0.28.2':
+    resolution: {integrity: sha512-pW4AC0P3it8c7do9MVM4p51FzHzdM/TZrerurgRcHJ2WTa1VQ1CIq18xncfpBJw4ojkiZZrKW2yIBWBP92j6Ug==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [linux]
 
-  '@esbuild/linux-arm@0.28.1':
-    resolution: {integrity: sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==}
+  '@esbuild/linux-arm@0.28.2':
+    resolution: {integrity: sha512-XlDnu2q5yoqems+xay6wSAcg9DDD7K9RLKZEBOMZm3ckNpJBvOX20tSfby8KfrrhINDyv9V2YVZKY/SpoGJI8w==}
     engines: {node: '>=18'}
     cpu: [arm]
     os: [linux]
 
-  '@esbuild/linux-ia32@0.28.1':
-    resolution: {integrity: sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==}
+  '@esbuild/linux-ia32@0.28.2':
+    resolution: {integrity: sha512-CYbnj78HsIeA+DhgUKgFCfvNsTHFhMMrinUrMZpDXJXKN8T3XViTZ/+wtHeVxEWY8ewSzTFN+nRmSwO2tZaLUQ==}
     engines: {node: '>=18'}
     cpu: [ia32]
     os: [linux]
 
-  '@esbuild/linux-loong64@0.28.1':
-    resolution: {integrity: sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==}
+  '@esbuild/linux-loong64@0.28.2':
+    resolution: {integrity: sha512-buwkd8nsph4R+ajRvw0qM5Hja/TXQow3ptzWO2EbG/cqcIkHloRrdlBtQlshyYGTNFvfkfJ5tpPLVkY4DtsPfQ==}
     engines: {node: '>=18'}
     cpu: [loong64]
     os: [linux]
 
-  '@esbuild/linux-mips64el@0.28.1':
-    resolution: {integrity: sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==}
+  '@esbuild/linux-mips64el@0.28.2':
+    resolution: {integrity: sha512-ZVykbDyk7519VwiNb9Lcj9m8XM6v5V9uKPvrEMkkEedVewf+0itkhahp4HDpgERXhwLRpWFypsGbG/J8s0QjJA==}
     engines: {node: '>=18'}
     cpu: [mips64el]
     os: [linux]
 
-  '@esbuild/linux-ppc64@0.28.1':
-    resolution: {integrity: sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==}
+  '@esbuild/linux-ppc64@0.28.2':
+    resolution: {integrity: sha512-CAXl+Dtd9UUuJd8pKKdwh6MLm3MUMiqMPmhZ3tTSXPqfyQ3vDl6R5hZdZ/kYojK4ofXtdfSv1tFq8XzWx3heNQ==}
     engines: {node: '>=18'}
     cpu: [ppc64]
     os: [linux]
 
-  '@esbuild/linux-riscv64@0.28.1':
-    resolution: {integrity: sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==}
+  '@esbuild/linux-riscv64@0.28.2':
+    resolution: {integrity: sha512-GeXCej4IQtU1B+QlDV8W/RRvbzI3O/Stss+/bCXv4lZls5WGRtu2a+3JkA3i4qIUlMXpcHebWpF8AkJhATowuA==}
     engines: {node: '>=18'}
     cpu: [riscv64]
     os: [linux]
 
-  '@esbuild/linux-s390x@0.28.1':
-    resolution: {integrity: sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==}
+  '@esbuild/linux-s390x@0.28.2':
+    resolution: {integrity: sha512-3H1weTYZPxt/WOhByszQZybS9w5lKzUn1FDMsgEChbHWQwHYQQRfBxgCcZvPhjHfKyJjIievvMmEUawJrdY9Dg==}
     engines: {node: '>=18'}
     cpu: [s390x]
     os: [linux]
 
-  '@esbuild/linux-x64@0.28.1':
-    resolution: {integrity: sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==}
+  '@esbuild/linux-x64@0.28.2':
+    resolution: {integrity: sha512-4xTZr1FUmSoQW4XIWmit3tzQrUTZM+N3P0XV8xROKYF50XfI7xeO90+1bZvNwxIufQ9hDQVRJH5YhgPVF8A/HQ==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [linux]
 
-  '@esbuild/netbsd-arm64@0.28.1':
-    resolution: {integrity: sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==}
+  '@esbuild/netbsd-arm64@0.28.2':
+    resolution: {integrity: sha512-sSATRjPeDBg3pdgHoQfoYBob11Kk1FGa9lui5RIHZCoCkJa9QKlvl3/vKz2usCmYYjs7ymJR/2Nnsqe+Hjt5nw==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [netbsd]
 
-  '@esbuild/netbsd-x64@0.28.1':
-    resolution: {integrity: sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==}
+  '@esbuild/netbsd-x64@0.28.2':
+    resolution: {integrity: sha512-lqnzCV+mM0gIADaKihiCg6ifgfU2L3h5E33rNQBN1Y4MaVGnzryzmvvf7UHxprpQdE8hpqLolJ9Rl+SkIRDpyw==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [netbsd]
 
-  '@esbuild/openbsd-arm64@0.28.1':
-    resolution: {integrity: sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==}
+  '@esbuild/openbsd-arm64@0.28.2':
+    resolution: {integrity: sha512-AL2qJILH7lNjrDmCQDvdxMfAUIv8KMNZOvrwAQ8i8//ntL9FflhOyMJ8OZSMBb8/AWXe3/5v5S20y3zCoZWKoQ==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openbsd]
 
-  '@esbuild/openbsd-x64@0.28.1':
-    resolution: {integrity: sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==}
+  '@esbuild/openbsd-x64@0.28.2':
+    resolution: {integrity: sha512-QtiuPytchRyC4rwUKhexJdQKvDuZ6hWloi3igqPQNUJCS1/v9EiO3UTOXR6A3FoMo4fnAKbWJdqaIwhOzh8qEw==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [openbsd]
 
-  '@esbuild/openharmony-arm64@0.28.1':
-    resolution: {integrity: sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==}
+  '@esbuild/openharmony-arm64@0.28.2':
+    resolution: {integrity: sha512-WkhYDmpTjLvGlScA1rwjRUmhl4k8oXR3cIbtqWmELgU/dFeHHlEllxDvdWcNJV9rbzCexB5vz8gtNewWLgCT7Q==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openharmony]
 
-  '@esbuild/sunos-x64@0.28.1':
-    resolution: {integrity: sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==}
+  '@esbuild/sunos-x64@0.28.2':
+    resolution: {integrity: sha512-GPMSkTOtMnv2U2F8gxe4Io6qmVs+YKyp832Etqqxr0hFngmXQ3rzwytelm3GIn7T4VviRUlf3sOgBOiTdvaf7g==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [sunos]
 
-  '@esbuild/win32-arm64@0.28.1':
-    resolution: {integrity: sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==}
+  '@esbuild/win32-arm64@0.28.2':
+    resolution: {integrity: sha512-PIhhEkE9uPBleRBrQEJpUn7MBnibZzbGzYWPmY3x+YoVg/95zbjB4CxPPOQ8l5tYYM4mMaCthF8/1DIfBQQyWQ==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [win32]
 
-  '@esbuild/win32-ia32@0.28.1':
-    resolution: {integrity: sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==}
+  '@esbuild/win32-ia32@0.28.2':
+    resolution: {integrity: sha512-YmJbfTlvU7Sdn9BB+4PRES4oB6pxgS37MAONj+hBr/cpXS1aBPKXxNnDbu+QCWPj0o9dgyxeq79g6c5P8KeuYA==}
     engines: {node: '>=18'}
     cpu: [ia32]
     os: [win32]
 
-  '@esbuild/win32-x64@0.28.1':
-    resolution: {integrity: sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==}
+  '@esbuild/win32-x64@0.28.2':
+    resolution: {integrity: sha512-5ebpxr3nWMzrL/rnUI755Jkuee0bHL/Gq0WTF9lvcpv73wAp5eu8MfBUgWK9bhWvZjj7yX8etf/8tI8Ney695g==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
@@ -615,12 +615,12 @@ packages:
   '@floating-ui/utils@0.2.12':
     resolution: {integrity: sha512-HpCo8tmWzLVad5s2d19EhAz5zqrrQ6s69qd6moPMQvkOuSwDT1YgRfWSVuc4ennqrgv3OHppiOGMQ7oC13yIww==}
 
-  '@formulavize/lang-fiz@2.1.2':
-    resolution: {integrity: sha512-k1Gd3ldSan0823Mw6a9AodoT+Bds1N0HgFBAqyEo//Q0aLrP87aiZ6Ky9NKeqVRRuGM8SuLNHR/+JLA0Y3edRg==}
+  '@formulavize/lang-fiz@2.2.0':
+    resolution: {integrity: sha512-4Ir9IoQSXM1z+zTINCCHPFqvYrrWK+nXmBvTvfenBS184VS7XP9P00YspYkXHuh86OEhRsdZGdZ9D3nKXlQNew==}
     engines: {node: '>=26', pnpm: '>=11'}
 
-  '@formulavize/lezer-fiz@2.1.1':
-    resolution: {integrity: sha512-0z4xFgXvAKQ4YCupaCuHJZywVppzOyEy0V8KvHHcB7oEo88zFT092CZQsO/PBsK5A/NGFSPEc7OxZEhgMpvGeA==}
+  '@formulavize/lezer-fiz@2.2.0':
+    resolution: {integrity: sha512-qHSGpfWfBOO/xeSCagDc7DNkaBUIRV1AI3p3IRYQ0cj4nJ1Nbj2704slUtVMkXJQgmX7OvA7E4FFx3MxRWGYyw==}
     engines: {node: '>=26.0', pnpm: '>=11'}
 
   '@humanfs/core@0.19.2':
@@ -781,8 +781,8 @@ packages:
   '@one-ini/wasm@0.1.1':
     resolution: {integrity: sha512-XuySG1E38YScSJoMlqovLru4KTUNSjgVTIjyh7qMX6aNN5HY5Ct5LhRJdxO79JtTzKfzV/bnWpz+zquYrISsvw==}
 
-  '@oxc-project/types@0.143.0':
-    resolution: {integrity: sha512-u6JZdLBTLotrNC9Vd6vPssINdzcCzleKAH6EJKImQb7GtYvX5keN2dxkoK44stCc4tffE6QQRtZTXVSzsLUlWA==}
+  '@oxc-project/types@0.144.0':
+    resolution: {integrity: sha512-nuhZIOLuI6TFQ32I/WnUx+SCPY7SdSKwgnFHydAuoS1+Z4BRcaP+RRJmGzl9lw+0OFF7UmaESf7KQRXaNLHypg==}
 
   '@pkgjs/parseargs@0.11.0':
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
@@ -792,92 +792,92 @@ packages:
     resolution: {integrity: sha512-SEeaJLb3qBNF/OaXnaR1NmmBbFYk1zC0ZH/52fATcRPLFg/p791YrcyFFy44Bo9sLaGuSuLp5Q6axbb/O+v/RA==}
     engines: {node: ^14.18.0 || >=16.0.0}
 
-  '@rolldown/binding-android-arm64@1.2.3':
-    resolution: {integrity: sha512-zrJtHDcaZJ1Fp7xf4hNl+7seH9Cn/N5TwLYkhgXREtBwAd/jaqW3uqeHxpDugJLVICWg4eW44kOQEGJ1r6jCGw==}
+  '@rolldown/binding-android-arm64@1.2.4':
+    resolution: {integrity: sha512-jHC2cnyKz5xU2fhECtFl8OZ83cYNt13GZQD+0uMJ/X3o+ijmd56okHhTUwxVSHPx1IRVIJEZ1/1pPzeLCU6XKA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [android]
 
-  '@rolldown/binding-darwin-arm64@1.2.3':
-    resolution: {integrity: sha512-ieIiibVCp0tX7TLu2cafoNPv8wJyYi01ekXpbf8q2j7F4rGAhhXb/eQh7ge9DRBY78GwmRQtvjZDux7EDbA8kA==}
+  '@rolldown/binding-darwin-arm64@1.2.4':
+    resolution: {integrity: sha512-Dc5mPD8F5F/FS8i01syd7FTF6yB2fVthH/TRkjwJkzUK6EpoxHtqvZQP5Zwq80/5z19TWYHIg1KOHboCgVx/aQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [darwin]
 
-  '@rolldown/binding-darwin-x64@1.2.3':
-    resolution: {integrity: sha512-Zh9tCon19eDXJoihx0rqKhMUlMYqzwj3aPsSuHmI4RWZh62dWUL+DJN4C5YQya5TcQBJU/Fe8+rY0jhXTQITqA==}
+  '@rolldown/binding-darwin-x64@1.2.4':
+    resolution: {integrity: sha512-fpDm4oBo6SqLvWUYCmFhdde3U9KH2fRNNMeAnAPAIwxRL345xutL0EtEUcuoxsoazdJGv/MuDBQHlCDrtbvqOg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [darwin]
 
-  '@rolldown/binding-freebsd-x64@1.2.3':
-    resolution: {integrity: sha512-nGbJWewA1wrXXZiQhjAT5rhibGfns5ZNkDVqxsO6zJ3f3YvpoDNNmGMSbbhLuXKjNScaBJVOAboztAWVespQMg==}
+  '@rolldown/binding-freebsd-x64@1.2.4':
+    resolution: {integrity: sha512-rSJoreDE/HoIzoaib6MTp5jQtCTdMHKIvItAKT/ImS6Y6Ww76oUaeMyp4Vc/fAgd/ehji068IxetHXAnqUwN9A==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [freebsd]
 
-  '@rolldown/binding-linux-arm-gnueabihf@1.2.3':
-    resolution: {integrity: sha512-QNniJr5Kml0kDEB98jiDOJjXNroxIIi0IXIbdYzY26Xt1pVbeP62+KnoIZLwirOymX/0jDk/2gI/bNUv7A7OIw==}
+  '@rolldown/binding-linux-arm-gnueabihf@1.2.4':
+    resolution: {integrity: sha512-/jm8OGHgn7oGaJu3i/qZI9spUGcJ+y/lk43ttQ/iO1tOd9NissG6o97bighBCiL+BKRngmcDuR6ikfwYdJmVuQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm]
     os: [linux]
 
-  '@rolldown/binding-linux-arm64-gnu@1.2.3':
-    resolution: {integrity: sha512-TkqEAcmmvH3I/q4114NB4RVt6241Dao48pF45uLcFGrwAaIn0iITgTAKP/dLjbN0R4buJjGb91+UHSoFmpgIWw==}
+  '@rolldown/binding-linux-arm64-gnu@1.2.4':
+    resolution: {integrity: sha512-tIP06BeD9EqvECBrPZ+sqdPlYrT+aYaAiu1wYziVx5elRK/ftm33JxVDy2bXGbr6J0CrtirCkR87/X5a2euEng==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  '@rolldown/binding-linux-arm64-musl@1.2.3':
-    resolution: {integrity: sha512-NHqjnxpsndf4MPymxteFAWHHfkTL8HjWh1KB7z23ofZ6QO2euONuxDXjat69dKZRALnGypg8k8SsK8vZJoXv1Q==}
+  '@rolldown/binding-linux-arm64-musl@1.2.4':
+    resolution: {integrity: sha512-Ql1Q0EQqVThvn9VAVlwNzsUvbSFtCMGjLpRRi4pk5i7NZZ4n5ISiLMjHYtus4VQ2PvkSw24zyaCVsiS+sXPj1w==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  '@rolldown/binding-linux-ppc64-gnu@1.2.3':
-    resolution: {integrity: sha512-6tbrbwfz5GB9DQ4Jwo6hy9v+vR31xZlvzZ6n5Xut6Hhx5PvrA9q/HsK8KMaYQp063iqZGXwNvZtYNLD7EM/x0w==}
+  '@rolldown/binding-linux-ppc64-gnu@1.2.4':
+    resolution: {integrity: sha512-GjbjXD4XXfN19D0LZNbmiCBUoDiRACsYHr0yaIbbn8aFsXjHZifcYqu/W5Er5X2X990WjHXFrxarn5chzItorQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
     libc: [glibc]
 
-  '@rolldown/binding-linux-s390x-gnu@1.2.3':
-    resolution: {integrity: sha512-oyuXxXmoZHjXC917IAPFAAv4wWAa0cM9afk8nx1+9/jNNOX1uPf8yDA6p7G0RypOfw/X0PQt5IfoquY1um+zSg==}
+  '@rolldown/binding-linux-s390x-gnu@1.2.4':
+    resolution: {integrity: sha512-p5WR0NOwaRmJ/B1b6IjEFLLivwEsf3PrdBIhRbhTCQisbo2SvHHpG4ELB/+FgQNnB88LTOF86upmJmbvZdQ2lw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
     libc: [glibc]
 
-  '@rolldown/binding-linux-x64-gnu@1.2.3':
-    resolution: {integrity: sha512-TytMwF2KVGqP2tgd0I1OY0PAv78dZRAYcF5ssDzjM34SUXCED3uXvSd5+lHoC0bTD6eEdFz7LdQNCO1y0oVk9w==}
+  '@rolldown/binding-linux-x64-gnu@1.2.4':
+    resolution: {integrity: sha512-4/GyVjmhR+Tc6HLJvwc1sOhPqAZtySiSMesOZyX6JQ5XBxoTDEMKQzvo07NIK6nTon/SivlZqvhzvuVBNQhObQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  '@rolldown/binding-linux-x64-musl@1.2.3':
-    resolution: {integrity: sha512-/E9m3qstrJFVPoULV25mVQblSNExY2+kBsYe4sy0Tn0yOOgJ8wZbZt3KnRbF/XeU2Gl1STKUQnDNTqhIE5MD4A==}
+  '@rolldown/binding-linux-x64-musl@1.2.4':
+    resolution: {integrity: sha512-l9eeLsCNvPpmSXUej0etw/J1eqV0Jj1D5G/xG6YTijmE6dkv6E2QezgWbTfQk63v952DPqrjOCoiqxq7Bw0YUQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  '@rolldown/binding-openharmony-arm64@1.2.3':
-    resolution: {integrity: sha512-Kr0OcsoQI816i6HOl3vFHpd1K0eZyh76zgfj4c1nTyaTsd5r2Mj1lwM4R90y/qaCfmTn9eHy0SKwi98eitRxug==}
+  '@rolldown/binding-openharmony-arm64@1.2.4':
+    resolution: {integrity: sha512-e0F355MSTMm3+UOqtV3L24gFUp2N5m1f8L/7d56deik6va+AXdrt9F8LbzGpeWGWRbZEDq4m8NVnJDeBtf9DZg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [openharmony]
 
-  '@rolldown/binding-win32-arm64-msvc@1.2.3':
-    resolution: {integrity: sha512-hOtMwTqnME+/gJcH/PCZ0wn0zPUjiWOgkHpxbSJpfGKMezHltx1S7/k1SitzVa7Ww2cqrDDaFbZEhcJZO8o+Jw==}
+  '@rolldown/binding-win32-arm64-msvc@1.2.4':
+    resolution: {integrity: sha512-AWLi0uBRYh6QlE7OKhiz+phZC0qwtij2QZmhmOdsLdFn64m7oMpooE9ICE3lhm9xMb4SpDo2WbHcxX1iFLFtqw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [win32]
 
-  '@rolldown/binding-win32-x64-msvc@1.2.3':
-    resolution: {integrity: sha512-ekcqMMkI2PlhYnfzQnB/cEdYUVVJViWvoUyLrbzgDoi3Snfc1mVBwdnc306ufA5ejy8JSPjT2RlW1nQSjW7efg==}
+  '@rolldown/binding-win32-x64-msvc@1.2.4':
+    resolution: {integrity: sha512-UwSDJOg3dqCAejWdxclJjCsh3Qq4vLYMDxmyHqo1btz3stK2VqgwNd3mm5tuIwzSlGIQ/1H9Hr+Zn09mrezNqQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [win32]
@@ -1083,69 +1083,69 @@ packages:
   '@types/lodash@4.17.25':
     resolution: {integrity: sha512-+K1NIO8I+F9/wNulfVvu23QYd0Pe9/OCqRrim4NoYIf1VoEDL90Ve4ClzpyqBLc7NpGGWRvYNCKZ1BE/Jpf8dQ==}
 
-  '@types/node@26.1.2':
-    resolution: {integrity: sha512-Vu4a5UFA9rIIFJ7rB/Vaafh9lrCQszopTCx6KjFboXTGQbPNasehVR5TEiithSDGyd1DEiUByggTZsg8jukeIg==}
+  '@types/node@26.2.0':
+    resolution: {integrity: sha512-5IviulTZeRNp2vAJ514cc/HUlY5nZ9fCbq9DMyC52BrhFZACo3nI0R7qBxhQmo/d27NFe96ur/b7Wwxklda+kg==}
 
   '@types/tough-cookie@4.0.5':
     resolution: {integrity: sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==}
 
-  '@typescript-eslint/eslint-plugin@8.66.0':
-    resolution: {integrity: sha512-p088eaGrzYz1s+7cov0aMOCkNGTJlVxF4jgubf28c8L0Cv9Rloj8YBHnv4hXLq6IIEE1AsjNWavO+k+8kP2Y0A==}
+  '@typescript-eslint/eslint-plugin@8.67.0':
+    resolution: {integrity: sha512-Un7Heoyj65NREbKAyIrFxeM143NZpExWmy1Nep4DLeQOeLlTeumPjoNKnBrU5D5moWXbPJgRa5Uwcdu0faVNGQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
-      '@typescript-eslint/parser': ^8.66.0
+      '@typescript-eslint/parser': ^8.67.0
       eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
       typescript: '>=4.8.4 <6.1.0'
 
-  '@typescript-eslint/parser@8.66.0':
-    resolution: {integrity: sha512-X6ypGChaWYk6PBtUg2BwuTZEFFcHJAtGTVJ9/lCTOufhZ4i9fNolQNnktq+kkMCwMj7V8Svsq7+TxSDslmhE0g==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-    peerDependencies:
-      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
-      typescript: '>=4.8.4 <6.1.0'
-
-  '@typescript-eslint/project-service@8.66.0':
-    resolution: {integrity: sha512-7MthGPTt4BP69lSryqpqq8HQqxuzynssckL/jyDyk3+TNMQ3y2jFWkptCrktWvBrP+EH787Nl5N5Qpw7WZg+5g==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-    peerDependencies:
-      typescript: '>=4.8.4 <6.1.0'
-
-  '@typescript-eslint/scope-manager@8.66.0':
-    resolution: {integrity: sha512-8TGcH25j9zqJ/IULB/ppyhRvxA8QYfFEZ7nfbg6/BN9spDgb8fPWQXlE5l8TWBL50EtUx007uZ1o9VOwrq2/9g==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-
-  '@typescript-eslint/tsconfig-utils@8.66.0':
-    resolution: {integrity: sha512-9D5gLYZG4rOjcoag8MQ/fWI8WqA9wcPDyOGyWtWFhvM1lHRbliqUSPIY5J3zqCU1tvSwzXxnnjhQhz5Ne7mJ4g==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-    peerDependencies:
-      typescript: '>=4.8.4 <6.1.0'
-
-  '@typescript-eslint/type-utils@8.66.0':
-    resolution: {integrity: sha512-LG2dWfjZQQp0ADtAu/EWJVayefGL2UEZ3CDeI44D9v3rXB/WYUqE/jpO28KrEKul5AySrmI+Zh1v6v+xW2U9+g==}
+  '@typescript-eslint/parser@8.67.0':
+    resolution: {integrity: sha512-fUBfTuuEulWqX6V8+O3PtScV01tzYYRUDTAirHFKoRAt7nOzoGiPt0M/bB47wWNy0coOOcgEwAMUtBpykMxl6w==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
       typescript: '>=4.8.4 <6.1.0'
 
-  '@typescript-eslint/types@8.66.0':
-    resolution: {integrity: sha512-H6gcYaSDOyvL3AD/jHUtUFo2jqGgn/F6nuyuZSu0QTesxL+cP4dQoIMrODRofuJC09g64+WgZ6tE19Y1N2YIFQ==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-
-  '@typescript-eslint/typescript-estree@8.66.0':
-    resolution: {integrity: sha512-8/x4INiiQb10jGgXYD7116/zQ+OL84ZIFn0za68wwFHCanT/VLbBEroWht8RV8fn0/ZCAoazHLQgwUC0UQcDfg==}
+  '@typescript-eslint/project-service@8.67.0':
+    resolution: {integrity: sha512-cvE8c7ulYeXN9fYuszhCeCsbzyVEXuhrRCybnBre7TUmqb5nRmBfQAwCj0O3WJFDeyAZt4VYv51vMCC9LHSdYw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       typescript: '>=4.8.4 <6.1.0'
 
-  '@typescript-eslint/utils@8.66.0':
-    resolution: {integrity: sha512-jasearZPolBw5NJNYGMwxzHMF83niVWmMU1VdHzG1CyfI2VS7f7nZltnKtHcg20hW+7Uo5GfK4MeDPoU3qI8EA==}
+  '@typescript-eslint/scope-manager@8.67.0':
+    resolution: {integrity: sha512-EgvsleTwS4E+WzzSvem8fAUubLwatMNF1B5hHSLQxcvs7q2dtRhGyujHwLJSYlG41niJ7GP24Aha2+0mb1b2kg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@typescript-eslint/tsconfig-utils@8.67.0':
+    resolution: {integrity: sha512-vV+LUSv5njUWsknE71fqKTlXUva+R76SaeORd6Zojcunk/6DvKFXONU3BrAs2H49mbygUXt6gbYunzwqNwlhdg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: '>=4.8.4 <6.1.0'
+
+  '@typescript-eslint/type-utils@8.67.0':
+    resolution: {integrity: sha512-aVWDXbRmdXO9siTfX4ditQI1T9+zVcNazT48EJCD0v40/9RIFoUgZ05CmGEq9H2gixRpjUn/iplwvlcvutJW/Q==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
       typescript: '>=4.8.4 <6.1.0'
 
-  '@typescript-eslint/visitor-keys@8.66.0':
-    resolution: {integrity: sha512-dkKR8q+lKciskj1Y3vthHktl+3cMLWGyVUP23bRiPZ5O9BRT++4EqDDV+TVeIKBL1VXVEqrJlz8MYbcnvJcAlg==}
+  '@typescript-eslint/types@8.67.0':
+    resolution: {integrity: sha512-sBtgslww8nsMYUjhdPBiSyUqSzT8uR6g93A2QXnQC8+cGdjz0CyaOdqHDRJb1AtORbZCNUJBBeFA/tNR2uQmww==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@typescript-eslint/typescript-estree@8.67.0':
+    resolution: {integrity: sha512-EKQBCE9yNlRJYm7jdTW5AhDacDUmSwQb0FAJAmK2EKYrNXIsa2vxcSZx6PvJ/dEdI6lS+Y9W+EXckLj0iPFGcw==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: '>=4.8.4 <6.1.0'
+
+  '@typescript-eslint/utils@8.67.0':
+    resolution: {integrity: sha512-U9D1FdwEWBwok3hxxSdhclMb0twvt9QnjIQ0VfQ1AiX2epnpSgv2ubVDsayOFyY8K6FX+AQ7E0FKWVG3iKsj1A==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      typescript: '>=4.8.4 <6.1.0'
+
+  '@typescript-eslint/visitor-keys@8.67.0':
+    resolution: {integrity: sha512-fkv8dHRDqfGtTHuJeebdrQ7cX6Ad4WAS00rgHh9UGvMycF1mjBfsxry1XsLIFhWZ6Judlh6UdzK+TYlbpCXgnA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   '@vitejs/plugin-vue@6.0.8':
@@ -1312,8 +1312,8 @@ packages:
     resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
     engines: {node: '>=8'}
 
-  ansi-regex@6.2.2:
-    resolution: {integrity: sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==}
+  ansi-regex@6.3.0:
+    resolution: {integrity: sha512-WpDfL7NO6j7tH88IDBNVdUJxDh9nmCteAVW9dsep846XdwF4naCBK+/tGLX3KJgcpgMRXCFlTM2hKGoK9FsdrQ==}
     engines: {node: '>=12'}
 
   ansi-styles@3.2.1:
@@ -1488,12 +1488,12 @@ packages:
   config-chain@1.1.13:
     resolution: {integrity: sha512-qj+f8APARXHrM0hraqXYb2/bOVSV4PvJQlNZ/DVj0QrmNM2q2euizkeuVckQ57J+W0mRH6Hvi+k50M4Jul2VRQ==}
 
-  conventional-changelog-angular@9.2.1:
-    resolution: {integrity: sha512-oWSL6ZhnXbYraOFTK3PgRAQJ8fADDAEv5K6AdeyQPLvjFmhG8+ejL0jZZp/R7vTmGJaBvZEE+sE7dB4bCv7sAw==}
+  conventional-changelog-angular@9.3.0:
+    resolution: {integrity: sha512-0MWQLVUT1oVCsUGs9aAWteBVxPlLwJTn5VbQH7B0B3fDizZgrJ9QGnKl/2mp1+5P7153GCBCjO/v1aKJ6eysCg==}
     engines: {node: '>=22'}
 
-  conventional-changelog-conventionalcommits@10.2.1:
-    resolution: {integrity: sha512-n4Kr1HFMTf3iMbES0TMxKIcYtUUv4rKqyQQp2JwfOEfFCOfGT3Tq4mCyJ8S9/YPyWhydjfKrrvnyl+gCjA+mJQ==}
+  conventional-changelog-conventionalcommits@10.3.0:
+    resolution: {integrity: sha512-qag0zFD867Qq1DK0jAWicyWlEMS1FFC/BLVLISaoeI7Y6Em6aWchk7BCkhOTsecRpMsV6qX41XmlNnghiiTmSw==}
     engines: {node: '>=22'}
 
   conventional-commit-types@3.0.0:
@@ -1562,8 +1562,8 @@ packages:
     peerDependencies:
       cytoscape: ^3.2.0
 
-  cytoscape@3.34.0:
-    resolution: {integrity: sha512-62rNSrioXw93uliKFBwjukeQyeWwH2PqDrTac31r2P6464u3AUvTk0xS4LVvT251g7IgkFunrI48ZEZGjywSOg==}
+  cytoscape@3.34.1:
+    resolution: {integrity: sha512-Lr0RvH9H75y9ar8h9Toy6u4lxRSCcxUq+hHcQ26sVWo6BnaQp1gwEZOYqwuYTZhyW7npyKnNLP8oJ2p1/3OZ7g==}
     engines: {node: '>=0.10'}
 
   cz-conventional-changelog@3.3.0:
@@ -1649,8 +1649,8 @@ packages:
   es-toolkit@1.50.0:
     resolution: {integrity: sha512-OyZKhUVvEep9ITEiwHn8GKnMRQIVqoSIX7WnRbkWgJkllCujilqP2rD0u979tkl8wqyc8ICwlc1UBVv/Sl1G6w==}
 
-  esbuild@0.28.1:
-    resolution: {integrity: sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==}
+  esbuild@0.28.2:
+    resolution: {integrity: sha512-HKVLS8dvII+xoKW9kmqxbRKrnWEXfJJr/FZhhJmiqIB0e053QNYFqOBouTMO/k5sID4MvCiUCvv8b9M4h32wIA==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -1712,8 +1712,8 @@ packages:
     resolution: {integrity: sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==}
     engines: {node: ^20.19.0 || ^22.13.0 || >=24}
 
-  eslint@10.8.0:
-    resolution: {integrity: sha512-nuKKvN+oIBO0koN7Tm7dlkmnkc21mtt0QJLwAKzjLq14y6lRTdVG36MZHJ8eQHwdJMwZbQNMlPOYedMq/oVJvQ==}
+  eslint@10.8.1:
+    resolution: {integrity: sha512-wqA7W2jbsC/BnV9Iv1UZpKVFkO1AdNoSmYW8NWG4HNOBbkAMvIqDZ27pI2f07dqn583NcIC44ckjAcOXDL1QbQ==}
     engines: {node: ^20.19.0 || ^22.13.0 || >=24}
     hasBin: true
     peerDependencies:
@@ -1883,8 +1883,8 @@ packages:
     resolution: {integrity: sha512-5lsx1NUDHtSjfg0eHlmYvZKv8/nVqX4ckFbM+FrGcQ+04KWcWFo9P5MxPZYSzUvyzmdTbI7Eix8Q4IbELDqzKg==}
     engines: {node: '>=0.10.0'}
 
-  globals@17.9.0:
-    resolution: {integrity: sha512-m/MvAW61QVU5VDNF1Vj8axt016h8w7L5TU1e9zlab7XIttAT2YAlCwl75K1fOqvMM9apmD7lbCIRhpfkhmxhCg==}
+  globals@17.11.0:
+    resolution: {integrity: sha512-Z2I8hM+PbJDXQDq3Icgpzv+mPdwr68iZUU9d5WW4FuXfDUQfkZaZuvjMv42/5crNyw154+9+VWXbYrUgDXbxNw==}
     engines: {node: '>=18'}
 
   graceful-fs@4.2.11:
@@ -2264,8 +2264,8 @@ packages:
   mute-stream@0.0.8:
     resolution: {integrity: sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==}
 
-  nanoid@3.3.17:
-    resolution: {integrity: sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==}
+  nanoid@3.3.18:
+    resolution: {integrity: sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -2381,8 +2381,8 @@ packages:
   pkg-types@2.3.1:
     resolution: {integrity: sha512-y+ichcgc2LrADuhLNAx8DFjVfgz91pRxfZdI3UDhxHvcVEZsenLO+7XaU5vOp0u/7V/wZ+plyuQxtrDlZJ+yeg==}
 
-  postcss-selector-parser@7.1.4:
-    resolution: {integrity: sha512-HeP7D2wyhkR+XaK6v4W8oRF62Dsz4flyuczALJp61GckGm42u1saSSJ/0auvcBqxs3jMRFEcPK34At/0JBKdOg==}
+  postcss-selector-parser@7.1.5:
+    resolution: {integrity: sha512-KvvtD7SrlBP7dlgkBghEE3r84CABm5SmV2aNcG4oCA+qDnJ/tvKonFVvwWAyyWUEwxuNawdfEAZKP9zM3oZ2Uw==}
     engines: {node: '>=4'}
 
   postcss@8.5.26:
@@ -2447,8 +2447,8 @@ packages:
     resolution: {integrity: sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==}
     engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
 
-  rolldown@1.2.3:
-    resolution: {integrity: sha512-rn9wpmxplLf7NLNyCk9FyWh3FM43DbY8jOzCdEPzH7uflhTftRbCEpqi6Ly2osgoU8OwObtmavMbWLaWy4LX7A==}
+  rolldown@1.2.4:
+    resolution: {integrity: sha512-rSr7irW0K7QRWzjdJXqZowkcRdDtjRduh43rBltnVKd0VFq839l1lJoDvGJb6gl7+4rTTCrPWu+YfujUL8Ug7w==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
 
@@ -2623,8 +2623,8 @@ packages:
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
-  tsx@4.23.10:
-    resolution: {integrity: sha512-0Vb9eKU47njkxv/6B8CRZRDsxNDT/Pz+BIU+M5jw7xL3TdzAjSxlZUxu0xFL/kLpaG3sHZ0LH2wbK1T1yo7CUQ==}
+  tsx@4.23.12:
+    resolution: {integrity: sha512-FDf4L4sYzKtzWYhU/Xm0AQFdTjdIxNo9ElTf2mxXM6k8YMHXzYUe4yODVaXP4V9uMFbVg8c0qyBccK2OOxb45Q==}
     engines: {node: '>=18.0.0'}
     hasBin: true
 
@@ -2636,8 +2636,8 @@ packages:
     resolution: {integrity: sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==}
     engines: {node: '>=10'}
 
-  typescript-eslint@8.66.0:
-    resolution: {integrity: sha512-QlEbBPz/RuJ1XUHj29nm3t0F/O/cSlEnntozqPOYHnnTGAXFamnMBu5i9Vn6vhUPHGAjR+Vl+5J8vPN/BMUrJw==}
+  typescript-eslint@8.67.0:
+    resolution: {integrity: sha512-S2udFs8tCKEKffuJ4TB1idGUZiXdCPGi3IPBGWXarbLQ5UPXORV8QEVzJ4gCRduURMb5EkpNCdjbk0eDIuI8Yg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
@@ -2842,8 +2842,8 @@ packages:
       typescript:
         optional: true
 
-  vuetify@4.1.8:
-    resolution: {integrity: sha512-003D/8b5462uZCD5CMRTZF3smADmOn47mzthNY0aP/xkslovR5yIc1qXjPdFN0LHcu+p3GEAVmMQabldaIQ5pg==}
+  vuetify@4.1.9:
+    resolution: {integrity: sha512-2NlpUiSwkUAGxKmkKwoRCst3IJF6EPP7msNJd+VxFjcAN9xCG+RFODzsfXfO2ypl9aSj3T/PJ65BBjQeTGgFKA==}
     peerDependencies:
       typescript: '>=4.7'
       vite-plugin-vuetify: '>=2.1.0'
@@ -2927,8 +2927,8 @@ packages:
   wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
 
-  ws@8.21.2:
-    resolution: {integrity: sha512-54dMVAo4WIe6SKy3vBgN+9bJZqqQ8IMRevAkOLQALhi49qkkQDQfWdAZ8KQlXiEabw88ARXXdUrlvtbKQX+aKw==}
+  ws@8.21.3:
+    resolution: {integrity: sha512-201TZ/kPWxoPr/OKWjquZR1SWKXcvxdH+e1xrx89b3YbmzLMFCLfnaG1HFIgWzJOEWZ7MvpK++odZufgYR50Rw==}
     engines: {node: '>=10.0.0'}
     peerDependencies:
       bufferutil: ^4.0.1
@@ -3089,12 +3089,12 @@ snapshots:
       style-mod: 4.1.3
       w3c-keyname: 2.2.8
 
-  '@commitlint/cli@21.2.1(@types/node@26.1.2)(conventional-commits-parser@7.1.2)(typescript@6.0.3)':
+  '@commitlint/cli@21.2.2(@types/node@26.2.0)(conventional-commits-parser@7.1.2)(typescript@6.0.3)':
     dependencies:
-      '@commitlint/config-conventional': 21.2.0
-      '@commitlint/format': 21.2.0
-      '@commitlint/lint': 21.2.0
-      '@commitlint/load': 21.2.0(@types/node@26.1.2)(typescript@6.0.3)
+      '@commitlint/config-conventional': 21.2.2
+      '@commitlint/format': 21.2.2
+      '@commitlint/lint': 21.2.2
+      '@commitlint/load': 21.2.2(@types/node@26.2.0)(typescript@6.0.3)
       '@commitlint/read': 21.2.1(conventional-commits-parser@7.1.2)
       '@commitlint/types': 21.2.0
       tinyexec: 1.3.0
@@ -3105,10 +3105,10 @@ snapshots:
       - conventional-commits-parser
       - typescript
 
-  '@commitlint/config-conventional@21.2.0':
+  '@commitlint/config-conventional@21.2.2':
     dependencies:
       '@commitlint/types': 21.2.0
-      conventional-changelog-conventionalcommits: 10.2.1
+      conventional-changelog-conventionalcommits: 10.3.0
 
   '@commitlint/config-validator@21.2.0':
     dependencies:
@@ -3122,31 +3122,31 @@ snapshots:
 
   '@commitlint/execute-rule@21.0.1': {}
 
-  '@commitlint/format@21.2.0':
+  '@commitlint/format@21.2.2':
     dependencies:
       '@commitlint/types': 21.2.0
       picocolors: 1.1.1
 
-  '@commitlint/is-ignored@21.2.0':
+  '@commitlint/is-ignored@21.2.2':
     dependencies:
       '@commitlint/types': 21.2.0
       semver: 7.8.5
 
-  '@commitlint/lint@21.2.0':
+  '@commitlint/lint@21.2.2':
     dependencies:
-      '@commitlint/is-ignored': 21.2.0
-      '@commitlint/parse': 21.2.0
-      '@commitlint/rules': 21.2.0
+      '@commitlint/is-ignored': 21.2.2
+      '@commitlint/parse': 21.2.2
+      '@commitlint/rules': 21.2.2
       '@commitlint/types': 21.2.0
 
-  '@commitlint/load@21.2.0(@types/node@26.1.2)(typescript@6.0.3)':
+  '@commitlint/load@21.2.2(@types/node@26.2.0)(typescript@6.0.3)':
     dependencies:
       '@commitlint/config-validator': 21.2.0
       '@commitlint/execute-rule': 21.0.1
-      '@commitlint/resolve-extends': 21.2.0
+      '@commitlint/resolve-extends': 21.2.2
       '@commitlint/types': 21.2.0
       cosmiconfig: 9.0.2(typescript@6.0.3)
-      cosmiconfig-typescript-loader: 6.3.0(@types/node@26.1.2)(cosmiconfig@9.0.2(typescript@6.0.3))(typescript@6.0.3)
+      cosmiconfig-typescript-loader: 6.3.0(@types/node@26.2.0)(cosmiconfig@9.0.2(typescript@6.0.3))(typescript@6.0.3)
       es-toolkit: 1.50.0
       is-plain-obj: 4.1.0
       picocolors: 1.1.1
@@ -3156,23 +3156,23 @@ snapshots:
 
   '@commitlint/message@21.2.0': {}
 
-  '@commitlint/parse@21.2.0':
+  '@commitlint/parse@21.2.2':
     dependencies:
       '@commitlint/types': 21.2.0
-      conventional-changelog-angular: 9.2.1
+      conventional-changelog-angular: 9.3.0
       conventional-commits-parser: 7.1.2
 
   '@commitlint/read@21.2.1(conventional-commits-parser@7.1.2)':
     dependencies:
       '@commitlint/top-level': 21.2.0
       '@commitlint/types': 21.2.0
-      '@conventional-changelog/git-client': 3.1.0(conventional-commits-parser@7.1.2)
+      '@conventional-changelog/git-client': 3.1.2(conventional-commits-parser@7.1.2)
       tinyexec: 1.3.0
     transitivePeerDependencies:
       - conventional-commits-filter
       - conventional-commits-parser
 
-  '@commitlint/resolve-extends@21.2.0':
+  '@commitlint/resolve-extends@21.2.2':
     dependencies:
       '@commitlint/config-validator': 21.2.0
       '@commitlint/types': 21.2.0
@@ -3180,7 +3180,7 @@ snapshots:
       global-directory: 5.0.0
       resolve-from: 5.0.0
 
-  '@commitlint/rules@21.2.0':
+  '@commitlint/rules@21.2.2':
     dependencies:
       '@commitlint/ensure': 21.2.0
       '@commitlint/message': 21.2.0
@@ -3198,7 +3198,7 @@ snapshots:
       conventional-commits-parser: 7.1.2
       picocolors: 1.1.1
 
-  '@conventional-changelog/git-client@3.1.0(conventional-commits-parser@7.1.2)':
+  '@conventional-changelog/git-client@3.1.2(conventional-commits-parser@7.1.2)':
     dependencies:
       '@simple-libs/child-process-utils': 2.0.0
       '@simple-libs/stream-utils': 2.0.0
@@ -3206,7 +3206,7 @@ snapshots:
     optionalDependencies:
       conventional-commits-parser: 7.1.2
 
-  '@conventional-changelog/template@1.2.1': {}
+  '@conventional-changelog/template@1.3.0': {}
 
   '@csstools/color-helpers@6.1.0': {}
 
@@ -3232,87 +3232,87 @@ snapshots:
 
   '@csstools/css-tokenizer@4.0.0': {}
 
-  '@esbuild/aix-ppc64@0.28.1':
+  '@esbuild/aix-ppc64@0.28.2':
     optional: true
 
-  '@esbuild/android-arm64@0.28.1':
+  '@esbuild/android-arm64@0.28.2':
     optional: true
 
-  '@esbuild/android-arm@0.28.1':
+  '@esbuild/android-arm@0.28.2':
     optional: true
 
-  '@esbuild/android-x64@0.28.1':
+  '@esbuild/android-x64@0.28.2':
     optional: true
 
-  '@esbuild/darwin-arm64@0.28.1':
+  '@esbuild/darwin-arm64@0.28.2':
     optional: true
 
-  '@esbuild/darwin-x64@0.28.1':
+  '@esbuild/darwin-x64@0.28.2':
     optional: true
 
-  '@esbuild/freebsd-arm64@0.28.1':
+  '@esbuild/freebsd-arm64@0.28.2':
     optional: true
 
-  '@esbuild/freebsd-x64@0.28.1':
+  '@esbuild/freebsd-x64@0.28.2':
     optional: true
 
-  '@esbuild/linux-arm64@0.28.1':
+  '@esbuild/linux-arm64@0.28.2':
     optional: true
 
-  '@esbuild/linux-arm@0.28.1':
+  '@esbuild/linux-arm@0.28.2':
     optional: true
 
-  '@esbuild/linux-ia32@0.28.1':
+  '@esbuild/linux-ia32@0.28.2':
     optional: true
 
-  '@esbuild/linux-loong64@0.28.1':
+  '@esbuild/linux-loong64@0.28.2':
     optional: true
 
-  '@esbuild/linux-mips64el@0.28.1':
+  '@esbuild/linux-mips64el@0.28.2':
     optional: true
 
-  '@esbuild/linux-ppc64@0.28.1':
+  '@esbuild/linux-ppc64@0.28.2':
     optional: true
 
-  '@esbuild/linux-riscv64@0.28.1':
+  '@esbuild/linux-riscv64@0.28.2':
     optional: true
 
-  '@esbuild/linux-s390x@0.28.1':
+  '@esbuild/linux-s390x@0.28.2':
     optional: true
 
-  '@esbuild/linux-x64@0.28.1':
+  '@esbuild/linux-x64@0.28.2':
     optional: true
 
-  '@esbuild/netbsd-arm64@0.28.1':
+  '@esbuild/netbsd-arm64@0.28.2':
     optional: true
 
-  '@esbuild/netbsd-x64@0.28.1':
+  '@esbuild/netbsd-x64@0.28.2':
     optional: true
 
-  '@esbuild/openbsd-arm64@0.28.1':
+  '@esbuild/openbsd-arm64@0.28.2':
     optional: true
 
-  '@esbuild/openbsd-x64@0.28.1':
+  '@esbuild/openbsd-x64@0.28.2':
     optional: true
 
-  '@esbuild/openharmony-arm64@0.28.1':
+  '@esbuild/openharmony-arm64@0.28.2':
     optional: true
 
-  '@esbuild/sunos-x64@0.28.1':
+  '@esbuild/sunos-x64@0.28.2':
     optional: true
 
-  '@esbuild/win32-arm64@0.28.1':
+  '@esbuild/win32-arm64@0.28.2':
     optional: true
 
-  '@esbuild/win32-ia32@0.28.1':
+  '@esbuild/win32-ia32@0.28.2':
     optional: true
 
-  '@esbuild/win32-x64@0.28.1':
+  '@esbuild/win32-x64@0.28.2':
     optional: true
 
-  '@eslint-community/eslint-utils@4.10.1(eslint@10.8.0(jiti@2.6.1)(supports-color@7.2.0))':
+  '@eslint-community/eslint-utils@4.10.1(eslint@10.8.1(jiti@2.6.1)(supports-color@7.2.0))':
     dependencies:
-      eslint: 10.8.0(jiti@2.6.1)(supports-color@7.2.0)
+      eslint: 10.8.1(jiti@2.6.1)(supports-color@7.2.0)
       eslint-visitor-keys: 3.4.3
 
   '@eslint-community/regexpp@4.12.2': {}
@@ -3333,9 +3333,9 @@ snapshots:
     dependencies:
       '@types/json-schema': 7.0.15
 
-  '@eslint/js@10.0.1(eslint@10.8.0(jiti@2.6.1)(supports-color@7.2.0))':
+  '@eslint/js@10.0.1(eslint@10.8.1(jiti@2.6.1)(supports-color@7.2.0))':
     optionalDependencies:
-      eslint: 10.8.0(jiti@2.6.1)(supports-color@7.2.0)
+      eslint: 10.8.1(jiti@2.6.1)(supports-color@7.2.0)
 
   '@eslint/object-schema@3.0.5': {}
 
@@ -3357,12 +3357,12 @@ snapshots:
 
   '@floating-ui/utils@0.2.12': {}
 
-  '@formulavize/lang-fiz@2.1.2':
+  '@formulavize/lang-fiz@2.2.0':
     dependencies:
       '@codemirror/language': 6.12.4
-      '@formulavize/lezer-fiz': 2.1.1
+      '@formulavize/lezer-fiz': 2.2.0
 
-  '@formulavize/lezer-fiz@2.1.1':
+  '@formulavize/lezer-fiz@2.2.0':
     dependencies:
       '@lezer/highlight': 1.2.3
       '@lezer/lr': 1.4.10
@@ -3383,12 +3383,12 @@ snapshots:
 
   '@humanwhocodes/retry@0.4.3': {}
 
-  '@inquirer/external-editor@1.0.3(@types/node@26.1.2)':
+  '@inquirer/external-editor@1.0.3(@types/node@26.2.0)':
     dependencies:
       chardet: 2.2.0
       iconv-lite: 0.7.3
     optionalDependencies:
-      '@types/node': 26.1.2
+      '@types/node': 26.2.0
 
   '@isaacs/cliui@8.0.2':
     dependencies:
@@ -3495,53 +3495,53 @@ snapshots:
 
   '@one-ini/wasm@0.1.1': {}
 
-  '@oxc-project/types@0.143.0': {}
+  '@oxc-project/types@0.144.0': {}
 
   '@pkgjs/parseargs@0.11.0':
     optional: true
 
   '@pkgr/core@0.3.6': {}
 
-  '@rolldown/binding-android-arm64@1.2.3':
+  '@rolldown/binding-android-arm64@1.2.4':
     optional: true
 
-  '@rolldown/binding-darwin-arm64@1.2.3':
+  '@rolldown/binding-darwin-arm64@1.2.4':
     optional: true
 
-  '@rolldown/binding-darwin-x64@1.2.3':
+  '@rolldown/binding-darwin-x64@1.2.4':
     optional: true
 
-  '@rolldown/binding-freebsd-x64@1.2.3':
+  '@rolldown/binding-freebsd-x64@1.2.4':
     optional: true
 
-  '@rolldown/binding-linux-arm-gnueabihf@1.2.3':
+  '@rolldown/binding-linux-arm-gnueabihf@1.2.4':
     optional: true
 
-  '@rolldown/binding-linux-arm64-gnu@1.2.3':
+  '@rolldown/binding-linux-arm64-gnu@1.2.4':
     optional: true
 
-  '@rolldown/binding-linux-arm64-musl@1.2.3':
+  '@rolldown/binding-linux-arm64-musl@1.2.4':
     optional: true
 
-  '@rolldown/binding-linux-ppc64-gnu@1.2.3':
+  '@rolldown/binding-linux-ppc64-gnu@1.2.4':
     optional: true
 
-  '@rolldown/binding-linux-s390x-gnu@1.2.3':
+  '@rolldown/binding-linux-s390x-gnu@1.2.4':
     optional: true
 
-  '@rolldown/binding-linux-x64-gnu@1.2.3':
+  '@rolldown/binding-linux-x64-gnu@1.2.4':
     optional: true
 
-  '@rolldown/binding-linux-x64-musl@1.2.3':
+  '@rolldown/binding-linux-x64-musl@1.2.4':
     optional: true
 
-  '@rolldown/binding-openharmony-arm64@1.2.3':
+  '@rolldown/binding-openharmony-arm64@1.2.4':
     optional: true
 
-  '@rolldown/binding-win32-arm64-msvc@1.2.3':
+  '@rolldown/binding-win32-arm64-msvc@1.2.4':
     optional: true
 
-  '@rolldown/binding-win32-x64-msvc@1.2.3':
+  '@rolldown/binding-win32-x64-msvc@1.2.4':
     optional: true
 
   '@rolldown/pluginutils@1.0.1': {}
@@ -3715,7 +3715,7 @@ snapshots:
 
   '@types/cytoscape-dagre@2.3.4':
     dependencies:
-      cytoscape: 3.34.0
+      cytoscape: 3.34.1
 
   '@types/deep-eql@4.0.2': {}
 
@@ -3729,7 +3729,7 @@ snapshots:
 
   '@types/jsdom@27.0.0':
     dependencies:
-      '@types/node': 26.1.2
+      '@types/node': 26.2.0
       '@types/tough-cookie': 4.0.5
       parse5: 7.3.0
 
@@ -3739,21 +3739,21 @@ snapshots:
 
   '@types/lodash@4.17.25': {}
 
-  '@types/node@26.1.2':
+  '@types/node@26.2.0':
     dependencies:
       undici-types: 8.3.0
 
   '@types/tough-cookie@4.0.5': {}
 
-  '@typescript-eslint/eslint-plugin@8.66.0(@typescript-eslint/parser@8.66.0(eslint@10.8.0(jiti@2.6.1)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@6.0.3))(eslint@10.8.0(jiti@2.6.1)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@6.0.3)':
+  '@typescript-eslint/eslint-plugin@8.67.0(@typescript-eslint/parser@8.67.0(eslint@10.8.1(jiti@2.6.1)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@6.0.3))(eslint@10.8.1(jiti@2.6.1)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@6.0.3)':
     dependencies:
       '@eslint-community/regexpp': 4.12.2
-      '@typescript-eslint/parser': 8.66.0(eslint@10.8.0(jiti@2.6.1)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@6.0.3)
-      '@typescript-eslint/scope-manager': 8.66.0
-      '@typescript-eslint/type-utils': 8.66.0(eslint@10.8.0(jiti@2.6.1)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@6.0.3)
-      '@typescript-eslint/utils': 8.66.0(eslint@10.8.0(jiti@2.6.1)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@6.0.3)
-      '@typescript-eslint/visitor-keys': 8.66.0
-      eslint: 10.8.0(jiti@2.6.1)(supports-color@7.2.0)
+      '@typescript-eslint/parser': 8.67.0(eslint@10.8.1(jiti@2.6.1)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@6.0.3)
+      '@typescript-eslint/scope-manager': 8.67.0
+      '@typescript-eslint/type-utils': 8.67.0(eslint@10.8.1(jiti@2.6.1)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@6.0.3)
+      '@typescript-eslint/utils': 8.67.0(eslint@10.8.1(jiti@2.6.1)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@6.0.3)
+      '@typescript-eslint/visitor-keys': 8.67.0
+      eslint: 10.8.1(jiti@2.6.1)(supports-color@7.2.0)
       ignore: 7.0.6
       natural-compare: 1.4.0
       ts-api-utils: 2.5.0(typescript@6.0.3)
@@ -3761,56 +3761,56 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/parser@8.66.0(eslint@10.8.0(jiti@2.6.1)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@6.0.3)':
+  '@typescript-eslint/parser@8.67.0(eslint@10.8.1(jiti@2.6.1)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@6.0.3)':
     dependencies:
-      '@typescript-eslint/scope-manager': 8.66.0
-      '@typescript-eslint/types': 8.66.0
-      '@typescript-eslint/typescript-estree': 8.66.0(supports-color@7.2.0)(typescript@6.0.3)
-      '@typescript-eslint/visitor-keys': 8.66.0
+      '@typescript-eslint/scope-manager': 8.67.0
+      '@typescript-eslint/types': 8.67.0
+      '@typescript-eslint/typescript-estree': 8.67.0(supports-color@7.2.0)(typescript@6.0.3)
+      '@typescript-eslint/visitor-keys': 8.67.0
       debug: 4.4.3(supports-color@7.2.0)
-      eslint: 10.8.0(jiti@2.6.1)(supports-color@7.2.0)
+      eslint: 10.8.1(jiti@2.6.1)(supports-color@7.2.0)
       typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/project-service@8.66.0(supports-color@7.2.0)(typescript@6.0.3)':
+  '@typescript-eslint/project-service@8.67.0(supports-color@7.2.0)(typescript@6.0.3)':
     dependencies:
-      '@typescript-eslint/tsconfig-utils': 8.66.0(typescript@6.0.3)
-      '@typescript-eslint/types': 8.66.0
+      '@typescript-eslint/tsconfig-utils': 8.67.0(typescript@6.0.3)
+      '@typescript-eslint/types': 8.67.0
       debug: 4.4.3(supports-color@7.2.0)
       typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/scope-manager@8.66.0':
+  '@typescript-eslint/scope-manager@8.67.0':
     dependencies:
-      '@typescript-eslint/types': 8.66.0
-      '@typescript-eslint/visitor-keys': 8.66.0
+      '@typescript-eslint/types': 8.67.0
+      '@typescript-eslint/visitor-keys': 8.67.0
 
-  '@typescript-eslint/tsconfig-utils@8.66.0(typescript@6.0.3)':
+  '@typescript-eslint/tsconfig-utils@8.67.0(typescript@6.0.3)':
     dependencies:
       typescript: 6.0.3
 
-  '@typescript-eslint/type-utils@8.66.0(eslint@10.8.0(jiti@2.6.1)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@6.0.3)':
+  '@typescript-eslint/type-utils@8.67.0(eslint@10.8.1(jiti@2.6.1)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@6.0.3)':
     dependencies:
-      '@typescript-eslint/types': 8.66.0
-      '@typescript-eslint/typescript-estree': 8.66.0(supports-color@7.2.0)(typescript@6.0.3)
-      '@typescript-eslint/utils': 8.66.0(eslint@10.8.0(jiti@2.6.1)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@6.0.3)
+      '@typescript-eslint/types': 8.67.0
+      '@typescript-eslint/typescript-estree': 8.67.0(supports-color@7.2.0)(typescript@6.0.3)
+      '@typescript-eslint/utils': 8.67.0(eslint@10.8.1(jiti@2.6.1)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@6.0.3)
       debug: 4.4.3(supports-color@7.2.0)
-      eslint: 10.8.0(jiti@2.6.1)(supports-color@7.2.0)
+      eslint: 10.8.1(jiti@2.6.1)(supports-color@7.2.0)
       ts-api-utils: 2.5.0(typescript@6.0.3)
       typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/types@8.66.0': {}
+  '@typescript-eslint/types@8.67.0': {}
 
-  '@typescript-eslint/typescript-estree@8.66.0(supports-color@7.2.0)(typescript@6.0.3)':
+  '@typescript-eslint/typescript-estree@8.67.0(supports-color@7.2.0)(typescript@6.0.3)':
     dependencies:
-      '@typescript-eslint/project-service': 8.66.0(supports-color@7.2.0)(typescript@6.0.3)
-      '@typescript-eslint/tsconfig-utils': 8.66.0(typescript@6.0.3)
-      '@typescript-eslint/types': 8.66.0
-      '@typescript-eslint/visitor-keys': 8.66.0
+      '@typescript-eslint/project-service': 8.67.0(supports-color@7.2.0)(typescript@6.0.3)
+      '@typescript-eslint/tsconfig-utils': 8.67.0(typescript@6.0.3)
+      '@typescript-eslint/types': 8.67.0
+      '@typescript-eslint/visitor-keys': 8.67.0
       debug: 4.4.3(supports-color@7.2.0)
       minimatch: 10.2.6
       semver: 7.8.5
@@ -3820,26 +3820,26 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/utils@8.66.0(eslint@10.8.0(jiti@2.6.1)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@6.0.3)':
+  '@typescript-eslint/utils@8.67.0(eslint@10.8.1(jiti@2.6.1)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@6.0.3)':
     dependencies:
-      '@eslint-community/eslint-utils': 4.10.1(eslint@10.8.0(jiti@2.6.1)(supports-color@7.2.0))
-      '@typescript-eslint/scope-manager': 8.66.0
-      '@typescript-eslint/types': 8.66.0
-      '@typescript-eslint/typescript-estree': 8.66.0(supports-color@7.2.0)(typescript@6.0.3)
-      eslint: 10.8.0(jiti@2.6.1)(supports-color@7.2.0)
+      '@eslint-community/eslint-utils': 4.10.1(eslint@10.8.1(jiti@2.6.1)(supports-color@7.2.0))
+      '@typescript-eslint/scope-manager': 8.67.0
+      '@typescript-eslint/types': 8.67.0
+      '@typescript-eslint/typescript-estree': 8.67.0(supports-color@7.2.0)(typescript@6.0.3)
+      eslint: 10.8.1(jiti@2.6.1)(supports-color@7.2.0)
       typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/visitor-keys@8.66.0':
+  '@typescript-eslint/visitor-keys@8.67.0':
     dependencies:
-      '@typescript-eslint/types': 8.66.0
+      '@typescript-eslint/types': 8.67.0
       eslint-visitor-keys: 5.0.1
 
-  '@vitejs/plugin-vue@6.0.8(vite@8.2.1(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.6.1)(tsx@4.23.10)(yaml@2.9.0))(vue@3.5.41(typescript@6.0.3))':
+  '@vitejs/plugin-vue@6.0.8(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.6.1)(tsx@4.23.12)(yaml@2.9.0))(vue@3.5.41(typescript@6.0.3))':
     dependencies:
       '@rolldown/pluginutils': 1.0.1
-      vite: 8.2.1(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.6.1)(tsx@4.23.10)(yaml@2.9.0)
+      vite: 8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.6.1)(tsx@4.23.12)(yaml@2.9.0)
       vue: 3.5.41(typescript@6.0.3)
 
   '@vitest/coverage-v8@4.1.10(vitest@4.1.10)':
@@ -3854,7 +3854,7 @@ snapshots:
       obug: 2.1.4
       std-env: 4.2.0
       tinyrainbow: 3.1.1
-      vitest: 4.1.10(@types/node@26.1.2)(@vitest/coverage-v8@4.1.10)(jsdom@27.4.0(supports-color@7.2.0))(vite@8.2.1(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.6.1)(tsx@4.23.10)(yaml@2.9.0))
+      vitest: 4.1.10(@types/node@26.2.0)(@vitest/coverage-v8@4.1.10)(jsdom@27.4.0(supports-color@7.2.0))(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.6.1)(tsx@4.23.12)(yaml@2.9.0))
 
   '@vitest/expect@4.1.10':
     dependencies:
@@ -3865,13 +3865,13 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.1.1
 
-  '@vitest/mocker@4.1.10(vite@8.2.1(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.6.1)(tsx@4.23.10)(yaml@2.9.0))':
+  '@vitest/mocker@4.1.10(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.6.1)(tsx@4.23.12)(yaml@2.9.0))':
     dependencies:
       '@vitest/spy': 4.1.10
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 8.2.1(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.6.1)(tsx@4.23.10)(yaml@2.9.0)
+      vite: 8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.6.1)(tsx@4.23.12)(yaml@2.9.0)
 
   '@vitest/pretty-format@4.1.10':
     dependencies:
@@ -3964,14 +3964,14 @@ snapshots:
 
   '@vue/devtools-shared@8.2.1': {}
 
-  '@vue/eslint-config-typescript@14.9.0(eslint-plugin-vue@10.10.0(@typescript-eslint/parser@8.66.0(eslint@10.8.0(jiti@2.6.1)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@6.0.3))(eslint@10.8.0(jiti@2.6.1)(supports-color@7.2.0))(vue-eslint-parser@10.4.1(eslint@10.8.0(jiti@2.6.1)(supports-color@7.2.0))(supports-color@7.2.0)))(eslint@10.8.0(jiti@2.6.1)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@6.0.3)':
+  '@vue/eslint-config-typescript@14.9.0(eslint-plugin-vue@10.10.0(@typescript-eslint/parser@8.67.0(eslint@10.8.1(jiti@2.6.1)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@6.0.3))(eslint@10.8.1(jiti@2.6.1)(supports-color@7.2.0))(vue-eslint-parser@10.4.1(eslint@10.8.1(jiti@2.6.1)(supports-color@7.2.0))(supports-color@7.2.0)))(eslint@10.8.1(jiti@2.6.1)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@6.0.3)':
     dependencies:
-      '@typescript-eslint/utils': 8.66.0(eslint@10.8.0(jiti@2.6.1)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@6.0.3)
-      eslint: 10.8.0(jiti@2.6.1)(supports-color@7.2.0)
-      eslint-plugin-vue: 10.10.0(@typescript-eslint/parser@8.66.0(eslint@10.8.0(jiti@2.6.1)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@6.0.3))(eslint@10.8.0(jiti@2.6.1)(supports-color@7.2.0))(vue-eslint-parser@10.4.1(eslint@10.8.0(jiti@2.6.1)(supports-color@7.2.0))(supports-color@7.2.0))
+      '@typescript-eslint/utils': 8.67.0(eslint@10.8.1(jiti@2.6.1)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@6.0.3)
+      eslint: 10.8.1(jiti@2.6.1)(supports-color@7.2.0)
+      eslint-plugin-vue: 10.10.0(@typescript-eslint/parser@8.67.0(eslint@10.8.1(jiti@2.6.1)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@6.0.3))(eslint@10.8.1(jiti@2.6.1)(supports-color@7.2.0))(vue-eslint-parser@10.4.1(eslint@10.8.1(jiti@2.6.1)(supports-color@7.2.0))(supports-color@7.2.0))
       fast-glob: 3.3.3
-      typescript-eslint: 8.66.0(eslint@10.8.0(jiti@2.6.1)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@6.0.3)
-      vue-eslint-parser: 10.4.1(eslint@10.8.0(jiti@2.6.1)(supports-color@7.2.0))(supports-color@7.2.0)
+      typescript-eslint: 8.67.0(eslint@10.8.1(jiti@2.6.1)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@6.0.3)
+      vue-eslint-parser: 10.4.1(eslint@10.8.1(jiti@2.6.1)(supports-color@7.2.0))(supports-color@7.2.0)
     optionalDependencies:
       typescript: 6.0.3
     transitivePeerDependencies:
@@ -4052,7 +4052,7 @@ snapshots:
 
   ansi-regex@5.0.1: {}
 
-  ansi-regex@6.2.2: {}
+  ansi-regex@6.3.0: {}
 
   ansi-styles@3.2.1:
     dependencies:
@@ -4200,17 +4200,17 @@ snapshots:
 
   commander@15.0.0: {}
 
-  commitizen@4.3.2(@types/node@26.1.2)(typescript@6.0.3):
+  commitizen@4.3.2(@types/node@26.2.0)(typescript@6.0.3):
     dependencies:
       cachedir: 2.4.0
-      cz-conventional-changelog: 3.3.0(@types/node@26.1.2)(typescript@6.0.3)
+      cz-conventional-changelog: 3.3.0(@types/node@26.2.0)(typescript@6.0.3)
       dedent: 0.7.0
       detect-indent: 6.1.0
       find-node-modules: 2.1.3
       find-root: 1.1.0
       fs-extra: 9.1.0
       glob: 7.2.3
-      inquirer: 8.2.7(@types/node@26.1.2)
+      inquirer: 8.2.7(@types/node@26.2.0)
       is-utf8: 0.2.1
       lodash: 4.18.1
       minimist: 1.2.8
@@ -4231,13 +4231,13 @@ snapshots:
       ini: 1.3.8
       proto-list: 1.2.4
 
-  conventional-changelog-angular@9.2.1:
+  conventional-changelog-angular@9.3.0:
     dependencies:
-      '@conventional-changelog/template': 1.2.1
+      '@conventional-changelog/template': 1.3.0
 
-  conventional-changelog-conventionalcommits@10.2.1:
+  conventional-changelog-conventionalcommits@10.3.0:
     dependencies:
-      '@conventional-changelog/template': 1.2.1
+      '@conventional-changelog/template': 1.3.0
 
   conventional-commit-types@3.0.0: {}
 
@@ -4248,9 +4248,9 @@ snapshots:
 
   convert-source-map@2.0.0: {}
 
-  cosmiconfig-typescript-loader@6.3.0(@types/node@26.1.2)(cosmiconfig@9.0.2(typescript@6.0.3))(typescript@6.0.3):
+  cosmiconfig-typescript-loader@6.3.0(@types/node@26.2.0)(cosmiconfig@9.0.2(typescript@6.0.3))(typescript@6.0.3):
     dependencies:
-      '@types/node': 26.1.2
+      '@types/node': 26.2.0
       cosmiconfig: 9.0.2(typescript@6.0.3)
       jiti: 2.6.1
       typescript: 6.0.3
@@ -4288,30 +4288,30 @@ snapshots:
 
   csstype@3.2.3: {}
 
-  cytoscape-dagre@4.0.0(cytoscape@3.34.0):
+  cytoscape-dagre@4.0.0(cytoscape@3.34.1):
     dependencies:
-      cytoscape: 3.34.0
+      cytoscape: 3.34.1
 
-  cytoscape-popper@4.0.1(cytoscape@3.34.0):
+  cytoscape-popper@4.0.1(cytoscape@3.34.1):
     dependencies:
-      cytoscape: 3.34.0
+      cytoscape: 3.34.1
 
-  cytoscape-svg@0.4.0(cytoscape@3.34.0):
+  cytoscape-svg@0.4.0(cytoscape@3.34.1):
     dependencies:
-      cytoscape: 3.34.0
+      cytoscape: 3.34.1
 
-  cytoscape@3.34.0: {}
+  cytoscape@3.34.1: {}
 
-  cz-conventional-changelog@3.3.0(@types/node@26.1.2)(typescript@6.0.3):
+  cz-conventional-changelog@3.3.0(@types/node@26.2.0)(typescript@6.0.3):
     dependencies:
       chalk: 2.4.2
-      commitizen: 4.3.2(@types/node@26.1.2)(typescript@6.0.3)
+      commitizen: 4.3.2(@types/node@26.2.0)(typescript@6.0.3)
       conventional-commit-types: 3.0.0
       lodash.map: 4.6.0
       longest: 2.0.1
       word-wrap: 1.2.5
     optionalDependencies:
-      '@commitlint/load': 21.2.0(@types/node@26.1.2)(typescript@6.0.3)
+      '@commitlint/load': 21.2.2(@types/node@26.2.0)(typescript@6.0.3)
     transitivePeerDependencies:
       - '@types/node'
       - typescript
@@ -4374,34 +4374,34 @@ snapshots:
 
   es-toolkit@1.50.0: {}
 
-  esbuild@0.28.1:
+  esbuild@0.28.2:
     optionalDependencies:
-      '@esbuild/aix-ppc64': 0.28.1
-      '@esbuild/android-arm': 0.28.1
-      '@esbuild/android-arm64': 0.28.1
-      '@esbuild/android-x64': 0.28.1
-      '@esbuild/darwin-arm64': 0.28.1
-      '@esbuild/darwin-x64': 0.28.1
-      '@esbuild/freebsd-arm64': 0.28.1
-      '@esbuild/freebsd-x64': 0.28.1
-      '@esbuild/linux-arm': 0.28.1
-      '@esbuild/linux-arm64': 0.28.1
-      '@esbuild/linux-ia32': 0.28.1
-      '@esbuild/linux-loong64': 0.28.1
-      '@esbuild/linux-mips64el': 0.28.1
-      '@esbuild/linux-ppc64': 0.28.1
-      '@esbuild/linux-riscv64': 0.28.1
-      '@esbuild/linux-s390x': 0.28.1
-      '@esbuild/linux-x64': 0.28.1
-      '@esbuild/netbsd-arm64': 0.28.1
-      '@esbuild/netbsd-x64': 0.28.1
-      '@esbuild/openbsd-arm64': 0.28.1
-      '@esbuild/openbsd-x64': 0.28.1
-      '@esbuild/openharmony-arm64': 0.28.1
-      '@esbuild/sunos-x64': 0.28.1
-      '@esbuild/win32-arm64': 0.28.1
-      '@esbuild/win32-ia32': 0.28.1
-      '@esbuild/win32-x64': 0.28.1
+      '@esbuild/aix-ppc64': 0.28.2
+      '@esbuild/android-arm': 0.28.2
+      '@esbuild/android-arm64': 0.28.2
+      '@esbuild/android-x64': 0.28.2
+      '@esbuild/darwin-arm64': 0.28.2
+      '@esbuild/darwin-x64': 0.28.2
+      '@esbuild/freebsd-arm64': 0.28.2
+      '@esbuild/freebsd-x64': 0.28.2
+      '@esbuild/linux-arm': 0.28.2
+      '@esbuild/linux-arm64': 0.28.2
+      '@esbuild/linux-ia32': 0.28.2
+      '@esbuild/linux-loong64': 0.28.2
+      '@esbuild/linux-mips64el': 0.28.2
+      '@esbuild/linux-ppc64': 0.28.2
+      '@esbuild/linux-riscv64': 0.28.2
+      '@esbuild/linux-s390x': 0.28.2
+      '@esbuild/linux-x64': 0.28.2
+      '@esbuild/netbsd-arm64': 0.28.2
+      '@esbuild/netbsd-x64': 0.28.2
+      '@esbuild/openbsd-arm64': 0.28.2
+      '@esbuild/openbsd-x64': 0.28.2
+      '@esbuild/openharmony-arm64': 0.28.2
+      '@esbuild/sunos-x64': 0.28.2
+      '@esbuild/win32-arm64': 0.28.2
+      '@esbuild/win32-ia32': 0.28.2
+      '@esbuild/win32-x64': 0.28.2
 
   escalade@3.2.0: {}
 
@@ -4409,31 +4409,31 @@ snapshots:
 
   escape-string-regexp@4.0.0: {}
 
-  eslint-config-prettier@10.1.8(eslint@10.8.0(jiti@2.6.1)(supports-color@7.2.0)):
+  eslint-config-prettier@10.1.8(eslint@10.8.1(jiti@2.6.1)(supports-color@7.2.0)):
     dependencies:
-      eslint: 10.8.0(jiti@2.6.1)(supports-color@7.2.0)
+      eslint: 10.8.1(jiti@2.6.1)(supports-color@7.2.0)
 
-  eslint-plugin-prettier@5.5.6(eslint-config-prettier@10.1.8(eslint@10.8.0(jiti@2.6.1)(supports-color@7.2.0)))(eslint@10.8.0(jiti@2.6.1)(supports-color@7.2.0))(prettier@3.9.6):
+  eslint-plugin-prettier@5.5.6(eslint-config-prettier@10.1.8(eslint@10.8.1(jiti@2.6.1)(supports-color@7.2.0)))(eslint@10.8.1(jiti@2.6.1)(supports-color@7.2.0))(prettier@3.9.6):
     dependencies:
-      eslint: 10.8.0(jiti@2.6.1)(supports-color@7.2.0)
+      eslint: 10.8.1(jiti@2.6.1)(supports-color@7.2.0)
       prettier: 3.9.6
       prettier-linter-helpers: 1.0.1
       synckit: 0.11.13
     optionalDependencies:
-      eslint-config-prettier: 10.1.8(eslint@10.8.0(jiti@2.6.1)(supports-color@7.2.0))
+      eslint-config-prettier: 10.1.8(eslint@10.8.1(jiti@2.6.1)(supports-color@7.2.0))
 
-  eslint-plugin-vue@10.10.0(@typescript-eslint/parser@8.66.0(eslint@10.8.0(jiti@2.6.1)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@6.0.3))(eslint@10.8.0(jiti@2.6.1)(supports-color@7.2.0))(vue-eslint-parser@10.4.1(eslint@10.8.0(jiti@2.6.1)(supports-color@7.2.0))(supports-color@7.2.0)):
+  eslint-plugin-vue@10.10.0(@typescript-eslint/parser@8.67.0(eslint@10.8.1(jiti@2.6.1)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@6.0.3))(eslint@10.8.1(jiti@2.6.1)(supports-color@7.2.0))(vue-eslint-parser@10.4.1(eslint@10.8.1(jiti@2.6.1)(supports-color@7.2.0))(supports-color@7.2.0)):
     dependencies:
-      '@eslint-community/eslint-utils': 4.10.1(eslint@10.8.0(jiti@2.6.1)(supports-color@7.2.0))
-      eslint: 10.8.0(jiti@2.6.1)(supports-color@7.2.0)
+      '@eslint-community/eslint-utils': 4.10.1(eslint@10.8.1(jiti@2.6.1)(supports-color@7.2.0))
+      eslint: 10.8.1(jiti@2.6.1)(supports-color@7.2.0)
       natural-compare: 1.4.0
       nth-check: 2.1.1
-      postcss-selector-parser: 7.1.4
+      postcss-selector-parser: 7.1.5
       semver: 7.8.5
-      vue-eslint-parser: 10.4.1(eslint@10.8.0(jiti@2.6.1)(supports-color@7.2.0))(supports-color@7.2.0)
+      vue-eslint-parser: 10.4.1(eslint@10.8.1(jiti@2.6.1)(supports-color@7.2.0))(supports-color@7.2.0)
       xml-name-validator: 5.0.0
     optionalDependencies:
-      '@typescript-eslint/parser': 8.66.0(eslint@10.8.0(jiti@2.6.1)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@6.0.3)
+      '@typescript-eslint/parser': 8.67.0(eslint@10.8.1(jiti@2.6.1)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@6.0.3)
 
   eslint-scope@9.1.2:
     dependencies:
@@ -4446,9 +4446,9 @@ snapshots:
 
   eslint-visitor-keys@5.0.1: {}
 
-  eslint@10.8.0(jiti@2.6.1)(supports-color@7.2.0):
+  eslint@10.8.1(jiti@2.6.1)(supports-color@7.2.0):
     dependencies:
-      '@eslint-community/eslint-utils': 4.10.1(eslint@10.8.0(jiti@2.6.1)(supports-color@7.2.0))
+      '@eslint-community/eslint-utils': 4.10.1(eslint@10.8.1(jiti@2.6.1)(supports-color@7.2.0))
       '@eslint-community/regexpp': 4.12.2
       '@eslint/config-array': 0.23.5(supports-color@7.2.0)
       '@eslint/config-helpers': 0.7.0
@@ -4652,7 +4652,7 @@ snapshots:
       is-windows: 1.0.2
       which: 1.3.1
 
-  globals@17.9.0: {}
+  globals@17.11.0: {}
 
   graceful-fs@4.2.11: {}
 
@@ -4718,9 +4718,9 @@ snapshots:
 
   ini@6.0.0: {}
 
-  inquirer@8.2.7(@types/node@26.1.2):
+  inquirer@8.2.7(@types/node@26.2.0):
     dependencies:
-      '@inquirer/external-editor': 1.0.3(@types/node@26.1.2)
+      '@inquirer/external-editor': 1.0.3(@types/node@26.2.0)
       ansi-escapes: 4.3.2
       chalk: 4.1.2
       cli-cursor: 3.1.0
@@ -4823,7 +4823,7 @@ snapshots:
       webidl-conversions: 8.0.1
       whatwg-mimetype: 4.0.0
       whatwg-url: 15.1.0
-      ws: 8.21.2
+      ws: 8.21.3
       xml-name-validator: 5.0.0
     transitivePeerDependencies:
       - '@noble/hashes'
@@ -5004,7 +5004,7 @@ snapshots:
 
   mute-stream@0.0.8: {}
 
-  nanoid@3.3.17: {}
+  nanoid@3.3.18: {}
 
   natural-compare@1.4.0: {}
 
@@ -5124,14 +5124,14 @@ snapshots:
       exsolve: 1.1.1
       pathe: 2.0.3
 
-  postcss-selector-parser@7.1.4:
+  postcss-selector-parser@7.1.5:
     dependencies:
       cssesc: 3.0.0
       util-deprecate: 1.0.2
 
   postcss@8.5.26:
     dependencies:
-      nanoid: 3.3.17
+      nanoid: 3.3.18
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
@@ -5177,25 +5177,25 @@ snapshots:
 
   reusify@1.1.0: {}
 
-  rolldown@1.2.3:
+  rolldown@1.2.4:
     dependencies:
-      '@oxc-project/types': 0.143.0
+      '@oxc-project/types': 0.144.0
       '@rolldown/pluginutils': 1.0.1
     optionalDependencies:
-      '@rolldown/binding-android-arm64': 1.2.3
-      '@rolldown/binding-darwin-arm64': 1.2.3
-      '@rolldown/binding-darwin-x64': 1.2.3
-      '@rolldown/binding-freebsd-x64': 1.2.3
-      '@rolldown/binding-linux-arm-gnueabihf': 1.2.3
-      '@rolldown/binding-linux-arm64-gnu': 1.2.3
-      '@rolldown/binding-linux-arm64-musl': 1.2.3
-      '@rolldown/binding-linux-ppc64-gnu': 1.2.3
-      '@rolldown/binding-linux-s390x-gnu': 1.2.3
-      '@rolldown/binding-linux-x64-gnu': 1.2.3
-      '@rolldown/binding-linux-x64-musl': 1.2.3
-      '@rolldown/binding-openharmony-arm64': 1.2.3
-      '@rolldown/binding-win32-arm64-msvc': 1.2.3
-      '@rolldown/binding-win32-x64-msvc': 1.2.3
+      '@rolldown/binding-android-arm64': 1.2.4
+      '@rolldown/binding-darwin-arm64': 1.2.4
+      '@rolldown/binding-darwin-x64': 1.2.4
+      '@rolldown/binding-freebsd-x64': 1.2.4
+      '@rolldown/binding-linux-arm-gnueabihf': 1.2.4
+      '@rolldown/binding-linux-arm64-gnu': 1.2.4
+      '@rolldown/binding-linux-arm64-musl': 1.2.4
+      '@rolldown/binding-linux-ppc64-gnu': 1.2.4
+      '@rolldown/binding-linux-s390x-gnu': 1.2.4
+      '@rolldown/binding-linux-x64-gnu': 1.2.4
+      '@rolldown/binding-linux-x64-musl': 1.2.4
+      '@rolldown/binding-openharmony-arm64': 1.2.4
+      '@rolldown/binding-win32-arm64-msvc': 1.2.4
+      '@rolldown/binding-win32-x64-msvc': 1.2.4
 
   run-async@2.4.1: {}
 
@@ -5276,7 +5276,7 @@ snapshots:
 
   strip-ansi@7.2.0:
     dependencies:
-      ansi-regex: 6.2.2
+      ansi-regex: 6.3.0
 
   strip-bom@4.0.0: {}
 
@@ -5343,9 +5343,9 @@ snapshots:
 
   tslib@2.8.1: {}
 
-  tsx@4.23.10:
+  tsx@4.23.12:
     dependencies:
-      esbuild: 0.28.1
+      esbuild: 0.28.2
     optionalDependencies:
       fsevents: 2.3.3
 
@@ -5355,13 +5355,13 @@ snapshots:
 
   type-fest@0.21.3: {}
 
-  typescript-eslint@8.66.0(eslint@10.8.0(jiti@2.6.1)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@6.0.3):
+  typescript-eslint@8.67.0(eslint@10.8.1(jiti@2.6.1)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@6.0.3):
     dependencies:
-      '@typescript-eslint/eslint-plugin': 8.66.0(@typescript-eslint/parser@8.66.0(eslint@10.8.0(jiti@2.6.1)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@6.0.3))(eslint@10.8.0(jiti@2.6.1)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@6.0.3)
-      '@typescript-eslint/parser': 8.66.0(eslint@10.8.0(jiti@2.6.1)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@6.0.3)
-      '@typescript-eslint/typescript-estree': 8.66.0(supports-color@7.2.0)(typescript@6.0.3)
-      '@typescript-eslint/utils': 8.66.0(eslint@10.8.0(jiti@2.6.1)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@6.0.3)
-      eslint: 10.8.0(jiti@2.6.1)(supports-color@7.2.0)
+      '@typescript-eslint/eslint-plugin': 8.67.0(@typescript-eslint/parser@8.67.0(eslint@10.8.1(jiti@2.6.1)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@6.0.3))(eslint@10.8.1(jiti@2.6.1)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@6.0.3)
+      '@typescript-eslint/parser': 8.67.0(eslint@10.8.1(jiti@2.6.1)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@6.0.3)
+      '@typescript-eslint/typescript-estree': 8.67.0(supports-color@7.2.0)(typescript@6.0.3)
+      '@typescript-eslint/utils': 8.67.0(eslint@10.8.1(jiti@2.6.1)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@6.0.3)
+      eslint: 10.8.1(jiti@2.6.1)(supports-color@7.2.0)
       typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
@@ -5379,15 +5379,15 @@ snapshots:
       pathe: 2.0.3
       picomatch: 4.0.5
 
-  unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.2.3)(vite@8.2.1(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.6.1)(tsx@4.23.10)(yaml@2.9.0)):
+  unplugin@3.3.0(esbuild@0.28.2)(rolldown@1.2.4)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.6.1)(tsx@4.23.12)(yaml@2.9.0)):
     dependencies:
       '@jridgewell/remapping': 2.3.5
       picomatch: 4.0.5
       webpack-virtual-modules: 0.6.2
     optionalDependencies:
-      esbuild: 0.28.1
-      rolldown: 1.2.3
-      vite: 8.2.1(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.6.1)(tsx@4.23.10)(yaml@2.9.0)
+      esbuild: 0.28.2
+      rolldown: 1.2.4
+      vite: 8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.6.1)(tsx@4.23.12)(yaml@2.9.0)
 
   uri-js@4.4.1:
     dependencies:
@@ -5403,25 +5403,25 @@ snapshots:
       '@types/istanbul-lib-coverage': 2.0.6
       convert-source-map: 2.0.0
 
-  vite@8.2.1(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.6.1)(tsx@4.23.10)(yaml@2.9.0):
+  vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.6.1)(tsx@4.23.12)(yaml@2.9.0):
     dependencies:
       lightningcss: 1.33.0
       picomatch: 4.0.5
       postcss: 8.5.26
-      rolldown: 1.2.3
+      rolldown: 1.2.4
       tinyglobby: 0.2.17
     optionalDependencies:
-      '@types/node': 26.1.2
-      esbuild: 0.28.1
+      '@types/node': 26.2.0
+      esbuild: 0.28.2
       fsevents: 2.3.3
       jiti: 2.6.1
-      tsx: 4.23.10
+      tsx: 4.23.12
       yaml: 2.9.0
 
-  vitest@4.1.10(@types/node@26.1.2)(@vitest/coverage-v8@4.1.10)(jsdom@27.4.0(supports-color@7.2.0))(vite@8.2.1(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.6.1)(tsx@4.23.10)(yaml@2.9.0)):
+  vitest@4.1.10(@types/node@26.2.0)(@vitest/coverage-v8@4.1.10)(jsdom@27.4.0(supports-color@7.2.0))(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.6.1)(tsx@4.23.12)(yaml@2.9.0)):
     dependencies:
       '@vitest/expect': 4.1.10
-      '@vitest/mocker': 4.1.10(vite@8.2.1(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.6.1)(tsx@4.23.10)(yaml@2.9.0))
+      '@vitest/mocker': 4.1.10(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.6.1)(tsx@4.23.12)(yaml@2.9.0))
       '@vitest/pretty-format': 4.1.10
       '@vitest/runner': 4.1.10
       '@vitest/snapshot': 4.1.10
@@ -5438,10 +5438,10 @@ snapshots:
       tinyexec: 1.3.0
       tinyglobby: 0.2.17
       tinyrainbow: 3.1.1
-      vite: 8.2.1(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.6.1)(tsx@4.23.10)(yaml@2.9.0)
+      vite: 8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.6.1)(tsx@4.23.12)(yaml@2.9.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
-      '@types/node': 26.1.2
+      '@types/node': 26.2.0
       '@vitest/coverage-v8': 4.1.10(vitest@4.1.10)
       jsdom: 27.4.0(supports-color@7.2.0)
     transitivePeerDependencies:
@@ -5451,10 +5451,10 @@ snapshots:
 
   vue-component-type-helpers@3.3.9: {}
 
-  vue-eslint-parser@10.4.1(eslint@10.8.0(jiti@2.6.1)(supports-color@7.2.0))(supports-color@7.2.0):
+  vue-eslint-parser@10.4.1(eslint@10.8.1(jiti@2.6.1)(supports-color@7.2.0))(supports-color@7.2.0):
     dependencies:
       debug: 4.4.3(supports-color@7.2.0)
-      eslint: 10.8.0(jiti@2.6.1)(supports-color@7.2.0)
+      eslint: 10.8.1(jiti@2.6.1)(supports-color@7.2.0)
       eslint-scope: 9.1.2
       eslint-visitor-keys: 5.0.1
       espree: 11.2.0
@@ -5463,7 +5463,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  vue-router@5.2.0(@vue/compiler-sfc@3.5.41)(esbuild@0.28.1)(rolldown@1.2.3)(vite@8.2.1(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.6.1)(tsx@4.23.10)(yaml@2.9.0))(vue@3.5.41(typescript@6.0.3)):
+  vue-router@5.2.0(@vue/compiler-sfc@3.5.41)(esbuild@0.28.2)(rolldown@1.2.4)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.6.1)(tsx@4.23.12)(yaml@2.9.0))(vue@3.5.41(typescript@6.0.3)):
     dependencies:
       '@babel/generator': 8.0.0
       '@vue-macros/common': 3.1.4(vue@3.5.41(typescript@6.0.3))
@@ -5480,13 +5480,13 @@ snapshots:
       picomatch: 4.0.5
       scule: 1.3.0
       tinyglobby: 0.2.17
-      unplugin: 3.3.0(esbuild@0.28.1)(rolldown@1.2.3)(vite@8.2.1(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.6.1)(tsx@4.23.10)(yaml@2.9.0))
+      unplugin: 3.3.0(esbuild@0.28.2)(rolldown@1.2.4)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.6.1)(tsx@4.23.12)(yaml@2.9.0))
       unplugin-utils: 0.3.2
       vue: 3.5.41(typescript@6.0.3)
       yaml: 2.9.0
     optionalDependencies:
       '@vue/compiler-sfc': 3.5.41
-      vite: 8.2.1(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.6.1)(tsx@4.23.10)(yaml@2.9.0)
+      vite: 8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.6.1)(tsx@4.23.12)(yaml@2.9.0)
     transitivePeerDependencies:
       - '@farmfe/core'
       - '@rspack/core'
@@ -5517,7 +5517,7 @@ snapshots:
     optionalDependencies:
       typescript: 6.0.3
 
-  vuetify@4.1.8(typescript@6.0.3)(vue@3.5.41(typescript@6.0.3)):
+  vuetify@4.1.9(typescript@6.0.3)(vue@3.5.41(typescript@6.0.3)):
     dependencies:
       vue: 3.5.41(typescript@6.0.3)
     optionalDependencies:
@@ -5589,7 +5589,7 @@ snapshots:
 
   wrappy@1.0.2: {}
 
-  ws@8.21.2: {}
+  ws@8.21.3: {}
 
   xml-name-validator@5.0.0: {}
 

--- a/src/autocomplete/autocompleter.ts
+++ b/src/autocomplete/autocompleter.ts
@@ -10,7 +10,10 @@ import {
   ScenarioToTokenTypes,
   TokenType,
 } from "./autocompletion";
-import { GLOBAL_STYLE_KEYWORD_MAP } from "../compiler/constants";
+import {
+  GLOBAL_STYLE_KEYWORD_MAP,
+  RENDERER_NAMES,
+} from "../compiler/constants";
 
 export function createCompletions(
   completionIndex: CompletionIndex,
@@ -416,6 +419,27 @@ export function createGlobalStyleKeywordCompletionSource(): CompletionSource {
   };
 }
 
+export function createRendererDirectiveNameCompletionSource(): CompletionSource {
+  return (context: CompletionContext): CompletionResult | null => {
+    const match = context.matchBefore(/\^\w*/);
+    if (!match || (match.from === match.to && !context.explicit)) {
+      return null;
+    }
+
+    const word = match.text.slice(1); // Remove the leading '^'
+    const from = match.from + 1;
+
+    const options = RENDERER_NAMES.filter((rendererName) =>
+      rendererName.startsWith(word),
+    ).map((rendererName) => ({
+      label: rendererName,
+      type: "keyword",
+    }));
+
+    return { from, options };
+  };
+}
+
 export function getAllDynamicCompletionSources(
   completionIndex: CompletionIndex,
 ): CompletionSource[] {
@@ -427,6 +451,7 @@ export function getAllDynamicCompletionSources(
     createStyleCompletionSource,
     createStatementCompletionSource,
     createGlobalStyleKeywordCompletionSource,
+    createRendererDirectiveNameCompletionSource,
   ];
   return sources.map((sourceFn) => sourceFn(completionIndex));
 }

--- a/src/autocomplete/autocompletion.ts
+++ b/src/autocomplete/autocompletion.ts
@@ -22,6 +22,9 @@ export interface ContextScenario {
   // Used only by rendererPropertyCompleter to filter Cytoscape properties
   // by element type (node/edge/subgraph) inside global style bindings.
   globalStyleKeyword?: string;
+  // Set inside a '^<rendererName>{ }' block. Directive properties are offered
+  // only when this matches the active renderer.
+  rendererDirectiveName?: string;
 }
 
 // An autocompletion token definition

--- a/src/autocomplete/autocompletionFactory.ts
+++ b/src/autocomplete/autocompletionFactory.ts
@@ -8,6 +8,7 @@ import {
   NamedStyleTreeNode,
   StyleBindingTreeNode,
   GlobalStyleBindingTreeNode,
+  RendererDirectiveTreeNode,
   NamespaceTreeNode,
   ImportTreeNode,
 } from "../compiler/ast";
@@ -52,6 +53,7 @@ function makeTokenRecords(statement: StatementTreeNode): TokenInfo[] {
       ];
     })
     .with(NodeType.GlobalStyleBinding, () => [])
+    .with(NodeType.RendererDirective, () => [])
     .with(NodeType.Namespace, () => {
       const namespaceNode = statement as NamespaceTreeNode;
       return [
@@ -171,6 +173,18 @@ function makeContextScenarios(statement: StatementTreeNode): ContextScenario[] {
           from: globalStyleBindingNode.StyleNode.Position.from + 1,
           to: globalStyleBindingNode.StyleNode.Position.to - 1,
           globalStyleKeyword: canonicalKeyword,
+        },
+      ];
+    })
+    .with(NodeType.RendererDirective, () => {
+      const rendererDirectiveNode = statement as RendererDirectiveTreeNode;
+      if (!rendererDirectiveNode.StyleNode.Position) return [];
+      return [
+        {
+          type: ContextScenarioType.StyleArgList,
+          from: rendererDirectiveNode.StyleNode.Position.from + 1,
+          to: rendererDirectiveNode.StyleNode.Position.to - 1,
+          rendererDirectiveId: rendererDirectiveNode.RendererName,
         },
       ];
     })

--- a/src/autocomplete/rendererProperties.ts
+++ b/src/autocomplete/rendererProperties.ts
@@ -1,7 +1,10 @@
 import { Completion } from "@codemirror/autocomplete";
 import {
+  BACKGROUND_COLOR_PROPERTY,
+  CYTOSCAPE_RENDERER_NAME,
   DESCRIPTION_PREFIX,
   DESCRIPTION_PROPERTY,
+  RANK_DIR_PROPERTY,
 } from "../compiler/constants";
 
 // Cytoscape properties sourced from https://js.cytoscape.org/#style
@@ -240,19 +243,30 @@ const cytoscapeEdgeCompletions = buildCompletions([
   ...CYTOSCAPE_SHARED_PROPERTIES,
 ]);
 
+// Properties consumed directly by the cytoscape renderer from a
+// '^cytoscape{ }' directive. These are not cytoscape stylesheet properties:
+// the background fill applies to the drawing surface (editor view and exported
+// images) and rankDir configures the dagre layout.
+const cytoscapeDirectiveCompletions = buildCompletions([
+  BACKGROUND_COLOR_PROPERTY,
+  RANK_DIR_PROPERTY,
+]);
+
 interface RendererPropertyEntry {
   all: Completion[];
   byElementType: Record<string, Completion[]>;
+  directives: Completion[];
 }
 
 const rendererPropertyRegistry: Record<string, RendererPropertyEntry> = {
-  cytoscape: {
+  [CYTOSCAPE_RENDERER_NAME]: {
     all: cytoscapeCompletions,
     byElementType: {
       node: cytoscapeNodeCompletions,
       edge: cytoscapeEdgeCompletions,
       subgraph: cytoscapeNodeCompletions,
     },
+    directives: cytoscapeDirectiveCompletions,
   },
 };
 
@@ -269,4 +283,10 @@ export function getRendererPropertyCompletionsByElementType(
   const entry = rendererPropertyRegistry[rendererId];
   if (!entry) return [];
   return entry.byElementType[elementType] ?? entry.all;
+}
+
+export function getRendererDirectiveCompletions(
+  rendererId: string,
+): Completion[] {
+  return rendererPropertyRegistry[rendererId]?.directives ?? [];
 }

--- a/src/autocomplete/rendererPropertyCompleter.ts
+++ b/src/autocomplete/rendererPropertyCompleter.ts
@@ -8,14 +8,15 @@ import { CompletionIndex, ContextScenarioType } from "./autocompletion";
 import {
   getRendererPropertyCompletions,
   getRendererPropertyCompletionsByElementType,
+  getRendererDirectiveCompletions,
 } from "./rendererProperties";
 import { GLOBAL_STYLE_KEYWORD_MAP } from "../compiler/constants";
 
 export function createRendererPropertyCompletionSource(
   completionIndex: CompletionIndex,
-  rendererId: string,
+  rendererName: string,
 ): CompletionSource {
-  const rendererProperties = getRendererPropertyCompletions(rendererId);
+  const rendererProperties = getRendererPropertyCompletions(rendererName);
 
   return (context: CompletionContext): CompletionResult | null => {
     if (rendererProperties.length === 0) return null;
@@ -40,30 +41,42 @@ export function createRendererPropertyCompletionSource(
       match = context.matchBefore(/[\w-]*/);
     } else {
       // Fallback: inside braces but context not yet registered (debounce lag)
-      match = context.matchBefore(/\*?\w*\{(?:[^{}]*[;{])?\s*[\w-]*/);
+      match = context.matchBefore(/[*^]?\w*\{(?:[^{}]*[;{])?\s*[\w-]*/);
     }
 
     if (!match || (match.from === match.to && !context.explicit)) return null;
 
     // Determine which properties to offer
     let activeProperties = rendererProperties;
-    if (contextScenario?.globalStyleKeyword) {
+    if (contextScenario?.rendererDirectiveName !== undefined) {
+      // A block addressed to another renderer has nothing we can suggest.
+      activeProperties =
+        contextScenario.rendererDirectiveName === rendererName
+          ? getRendererDirectiveCompletions(rendererName)
+          : [];
+    } else if (contextScenario?.globalStyleKeyword) {
       // Context scenario registered — use its element keyword
       activeProperties = getRendererPropertyCompletionsByElementType(
-        rendererId,
+        rendererName,
         contextScenario.globalStyleKeyword,
       );
     } else if (!isStyleContext) {
-      // Fallback: detect *keyword{ pattern from matched text
+      // Fallback: detect *keyword{ or ^rendererName{ pattern from matched text
       const keywordMatch = /^\*(\w+)\{/.exec(match.text);
+      const directiveMatch = /^\^(\w+)\{/.exec(match.text);
       if (keywordMatch) {
         const canonicalKeyword = GLOBAL_STYLE_KEYWORD_MAP.get(keywordMatch[1]);
         if (canonicalKeyword) {
           activeProperties = getRendererPropertyCompletionsByElementType(
-            rendererId,
+            rendererName,
             canonicalKeyword,
           );
         }
+      } else if (directiveMatch) {
+        activeProperties =
+          directiveMatch[1] === rendererName
+            ? getRendererDirectiveCompletions(rendererName)
+            : [];
       }
     }
 

--- a/src/cli/headlessCytoscape.ts
+++ b/src/cli/headlessCytoscape.ts
@@ -4,7 +4,7 @@ import { Dag } from "../compiler/dag";
 import { ExportFormat } from "../compiler/constants";
 import { makeCyElements } from "../renderers/cyDag/cyGraphFactory";
 import { makeCyStylesheets } from "../renderers/cyDag/cyStyleSheetsFactory";
-import { dagreLayoutOptions } from "../renderers/cyDag/cyLayout";
+import { getCanvasBackgroundColor } from "../renderers/cyDag/cyRendererDirectives";
 import { exportCyToBlob } from "../renderers/cyDag/cyExport";
 import { addDescriptionGhostNodes } from "../renderers/cyDag/cyPopperExtender";
 
@@ -223,6 +223,7 @@ export async function renderDagToBytes(
       fileName: "formulavize",
       fileType: options.fileType,
       scalingFactor: options.scalingFactor,
+      backgroundColor: getCanvasBackgroundColor(dag),
     });
 
     for (const id of ghostIds) cy.getElementById(id).remove();

--- a/src/cli/headlessCytoscape.ts
+++ b/src/cli/headlessCytoscape.ts
@@ -5,6 +5,7 @@ import { ExportFormat } from "../compiler/constants";
 import { makeCyElements } from "../renderers/cyDag/cyGraphFactory";
 import { makeCyStylesheets } from "../renderers/cyDag/cyStyleSheetsFactory";
 import { getCanvasBackgroundColor } from "../renderers/cyDag/cyRendererDirectives";
+import { makeDagreLayoutOptions } from "../renderers/cyDag/cyLayout";
 import { exportCyToBlob } from "../renderers/cyDag/cyExport";
 import { addDescriptionGhostNodes } from "../renderers/cyDag/cyPopperExtender";
 
@@ -210,7 +211,7 @@ export async function renderDagToBytes(
     // Run the dagre layout and wait for it to settle before exporting.
     await new Promise<void>((resolve) => {
       cy.one("layoutstop", () => resolve());
-      cy.layout(dagreLayoutOptions).run();
+      cy.layout(makeDagreLayoutOptions(dag)).run();
     });
 
     // Description text is captured by invisible ghost nodes, mirroring the app's

--- a/src/compiler/ast.ts
+++ b/src/compiler/ast.ts
@@ -11,6 +11,7 @@ export enum NodeType {
   NamedStyle,
   StyleBinding,
   GlobalStyleBinding,
+  RendererDirective,
   StyleTag,
   Namespace,
   Import,
@@ -68,6 +69,7 @@ export type StatementTreeNode =
   | NamedStyleTreeNode
   | StyleBindingTreeNode
   | GlobalStyleBindingTreeNode
+  | RendererDirectiveTreeNode
   | NamespaceTreeNode
   | ImportTreeNode;
 
@@ -410,6 +412,37 @@ export class GlobalStyleBindingTreeNode extends BaseTreeNode {
 
   get Keyword(): string {
     return this.keyword;
+  }
+
+  get StyleNode(): StyleTreeNode {
+    return this.styleNode;
+  }
+}
+
+export class RendererDirectiveTreeNode extends BaseTreeNode {
+  private rendererName: string;
+  private styleNode: StyleTreeNode;
+
+  constructor(
+    rendererName: string = "",
+    styleNode: StyleTreeNode = new StyleTreeNode(new Map(), [], null),
+    position: Position | null = null,
+  ) {
+    super(NodeType.RendererDirective, position);
+    this.rendererName = rendererName;
+    this.styleNode = styleNode;
+  }
+
+  getChildren(): BaseTreeNode[] {
+    return [this.styleNode];
+  }
+
+  debugDump(): string {
+    return "RendererDirective: " + this.rendererName;
+  }
+
+  get RendererName(): string {
+    return this.rendererName;
   }
 
   get StyleNode(): StyleTreeNode {

--- a/src/compiler/astFactory.ts
+++ b/src/compiler/astFactory.ts
@@ -16,6 +16,7 @@ import {
   NamedStyleTreeNode,
   StyleBindingTreeNode,
   GlobalStyleBindingTreeNode,
+  RendererDirectiveTreeNode,
   NamespaceTreeNode,
   ImportTreeNode,
   StatementListTreeNode,
@@ -185,6 +186,22 @@ function makeGlobalStyleBinding(
   return new GlobalStyleBindingTreeNode(keyword, styleArgList, getPosition(c));
 }
 
+function makeRendererDirective(
+  c: TreeCursor,
+  t: Text,
+  e: Error[],
+): RendererDirectiveTreeNode {
+  const rendererId = getTextFromChild("Identifier", c, t);
+  const styleArgList =
+    makeNullableChild("StyleArgList", makeStyle, c, t, e) ??
+    new StyleTreeNode(new Map(), [], getPosition(c));
+  return new RendererDirectiveTreeNode(
+    rendererId,
+    styleArgList,
+    getPosition(c),
+  );
+}
+
 function makeRhsVariable(c: TreeCursor, t: Text): QualifiedVarTreeNode {
   const varQualifiedIdent = getQualifiableIdentifer(c, t);
   return new QualifiedVarTreeNode(varQualifiedIdent, getPosition(c));
@@ -305,6 +322,7 @@ function makeStatement(
     .with("StyleTagDeclaration", () => makeNamedStyle(c, t, e))
     .with("StyleBinding", () => makeStyleBinding(c, t, e))
     .with("GlobalStyleBinding", () => makeGlobalStyleBinding(c, t, e))
+    .with("RendererDirective", () => makeRendererDirective(c, t, e))
     .with("Namespace", () => makeNamespace(c, t, e))
     .with("Import", () => makeImport(c, t))
     .with("⚠", () => null) // Error token for incomplete trees

--- a/src/compiler/astFactory.ts
+++ b/src/compiler/astFactory.ts
@@ -191,12 +191,12 @@ function makeRendererDirective(
   t: Text,
   e: Error[],
 ): RendererDirectiveTreeNode {
-  const rendererId = getTextFromChild("Identifier", c, t);
+  const rendererName = getTextFromChild("Identifier", c, t);
   const styleArgList =
     makeNullableChild("StyleArgList", makeStyle, c, t, e) ??
     new StyleTreeNode(new Map(), [], getPosition(c));
   return new RendererDirectiveTreeNode(
-    rendererId,
+    rendererName,
     styleArgList,
     getPosition(c),
   );

--- a/src/compiler/compilationErrors.ts
+++ b/src/compiler/compilationErrors.ts
@@ -25,6 +25,7 @@ export enum ErrorCode {
   MismatchedBracket = "SYN_MISMATCHED_BRACKET",
   UnexpectedToken = "SYN_UNEXPECTED_TOKEN",
   InvalidGlobalStyleKeyword = "SYN_INVALID_GLOBAL_STYLE_KEYWORD",
+  RendererDirectiveNotAtTopLevel = "SYN_RENDERER_DIRECTIVE_NOT_TOP_LEVEL",
 
   // Import errors
   ImportFetchFailed = "IMP_FETCH_FAILED",

--- a/src/compiler/constants.ts
+++ b/src/compiler/constants.ts
@@ -3,6 +3,9 @@ export const DESCRIPTION_PROPERTY: string = "description";
 export const DESCRIPTION_PREFIX: string = DESCRIPTION_PROPERTY + "-";
 export const BACKGROUND_COLOR_PROPERTY: string = "background-color";
 
+// Renderer directive property consumed by the cytoscape renderer's layout
+export const RANK_DIR_PROPERTY: string = "rankDir";
+
 // Renderer names. These are the identifiers usable in a '^<rendererName>{ }'
 // directive and the keys used by useRendererRegistry and
 // rendererPropertyRegistry. Keeping them here keeps that agreement typed.

--- a/src/compiler/constants.ts
+++ b/src/compiler/constants.ts
@@ -1,12 +1,27 @@
 // Special properties for styles
 export const DESCRIPTION_PROPERTY: string = "description";
 export const DESCRIPTION_PREFIX: string = DESCRIPTION_PROPERTY + "-";
+export const BACKGROUND_COLOR_PROPERTY: string = "background-color";
+
+// Renderer names. These are the identifiers usable in a '^<rendererName>{ }'
+// directive and the keys used by useRendererRegistry and
+// rendererPropertyRegistry. Keeping them here keeps that agreement typed.
+export const CYTOSCAPE_RENDERER_NAME: string = "cytoscape";
+export const MINIMAL_RENDERER_NAME: string = "minimal";
+export const RENDERER_NAMES: readonly string[] = [
+  CYTOSCAPE_RENDERER_NAME,
+  MINIMAL_RENDERER_NAME,
+];
 
 // Import constants
 export const FIZ_FILE_EXTENSION: string = ".fiz";
 
 // Global style binding keywords
-// Maps multilingual keywords to canonical element types ("node", "edge", or "subgraph")
+// Maps multilingual keywords to canonical element types
+// ("node", "edge", or "subgraph")
+// Every keyword here must have a selector in the renderer's selector map:
+// '*' means "becomes a renderer selector". Concerns that the renderer consumes
+// directly belong in a '^<rendererName>{ }' directive instead.
 export const GLOBAL_STYLE_KEYWORD_MAP: Map<string, string> = new Map([
   ["node", "node"],
   ["edge", "edge"],

--- a/src/compiler/dag.ts
+++ b/src/compiler/dag.ts
@@ -37,6 +37,7 @@ export class Dag {
   private styleTagNameToFlatStyleMap: Map<string, StyleProperties>;
   private styleBinding: Map<Keyword, DagStyle>;
   private globalStyleBinding: Map<Keyword, DagStyle>;
+  private rendererDirectives: Map<string, DagStyle>;
   private childDags: Map<DagId, Dag>;
   private namespaceNameToDagId: Map<string, DagId>;
   private lineagePath: string;
@@ -66,6 +67,7 @@ export class Dag {
     this.styleTagNameToFlatStyleMap = new Map();
     this.styleBinding = new Map();
     this.globalStyleBinding = new Map();
+    this.rendererDirectives = new Map();
     this.childDags = new Map();
     this.namespaceNameToDagId = new Map();
     if (parent !== null) {
@@ -95,6 +97,10 @@ export class Dag {
 
   addGlobalStyleBinding(keyword: Keyword, dagStyle: DagStyle): void {
     this.globalStyleBinding.set(keyword, dagStyle);
+  }
+
+  addRendererDirective(rendererName: string, dagStyle: DagStyle): void {
+    this.rendererDirectives.set(rendererName, dagStyle);
   }
 
   private addChildDagWithOrder(childDag: Dag, insertionOrder: number): void {
@@ -300,6 +306,10 @@ export class Dag {
     return this.globalStyleBinding;
   }
 
+  getRendererDirectives(): Map<string, DagStyle> {
+    return this.rendererDirectives;
+  }
+
   getChildDags(): Dag[] {
     return Array.from(this.childDags.values());
   }
@@ -373,6 +383,9 @@ export class Dag {
     });
     dag.getGlobalStyleBindings().forEach((dagStyle, keyword) => {
       this.addGlobalStyleBinding(keyword, dagStyle);
+    });
+    dag.getRendererDirectives().forEach((dagStyle, rendererName) => {
+      this.addRendererDirective(rendererName, dagStyle);
     });
     dag.getVarNameToNodeIdMap().forEach((nodeId, varName) => {
       this.setVarNode(varName, nodeId);
@@ -454,6 +467,15 @@ export class Dag {
         childLeftPad +
         "GlobalStyleBinding: " +
         keyword +
+        styleTagDump(dagStyle.styleTags) +
+        stylePropertiesDump(dagStyle.styleProperties) +
+        "\n";
+    });
+    this.rendererDirectives.forEach((dagStyle, rendererName) => {
+      result +=
+        childLeftPad +
+        "RendererDirective: " +
+        rendererName +
         styleTagDump(dagStyle.styleTags) +
         stylePropertiesDump(dagStyle.styleProperties) +
         "\n";

--- a/src/compiler/dagFactory.ts
+++ b/src/compiler/dagFactory.ts
@@ -11,6 +11,7 @@ import {
   NamedStyleTreeNode,
   StyleBindingTreeNode,
   GlobalStyleBindingTreeNode,
+  RendererDirectiveTreeNode,
   NamespaceTreeNode,
   ValueTreeNode,
   ImportTreeNode,
@@ -528,6 +529,37 @@ function processGlobalStyleBinding(
   workingDag.addGlobalStyleBinding(canonicalKeyword, makeDagStyle(styleNode));
 }
 
+function processRendererDirective(
+  rendererDirectiveStmt: RendererDirectiveTreeNode,
+  workingDag: Dag,
+  errors: Error[],
+): void {
+  // Renderer directives configure the drawing surface and layout, which are
+  // properties of the whole graph. A renderer instantiates one layout for the
+  // root dag, so a directive nested in a namespace could never take effect.
+  if (workingDag.Parent) {
+    const errMsg = makeError(
+      rendererDirectiveStmt,
+      `Renderer directive '^${rendererDirectiveStmt.RendererName}' is only ` +
+        `allowed at the top level, not inside namespace '${workingDag.Name}'`,
+      ErrorSource.Syntax,
+      ErrorCode.RendererDirectiveNotAtTopLevel,
+    );
+    errors.push(errMsg);
+    console.debug(errMsg);
+    return;
+  }
+  // The renderer name is deliberately not validated. The compiler has no
+  // knowledge of the renderer registry, and a directive addressed to a
+  // renderer that is not active is simply never read.
+  const styleNode = rendererDirectiveStmt.StyleNode;
+  checkStyleTagsInStyleNode(styleNode, workingDag, errors);
+  workingDag.addRendererDirective(
+    rendererDirectiveStmt.RendererName,
+    makeDagStyle(styleNode),
+  );
+}
+
 async function processStatement(
   stmt: BaseTreeNode,
   workingDag: Dag,
@@ -559,6 +591,13 @@ async function processStatement(
     .with(NodeType.GlobalStyleBinding, () => {
       processGlobalStyleBinding(
         stmt as GlobalStyleBindingTreeNode,
+        workingDag,
+        errors,
+      );
+    })
+    .with(NodeType.RendererDirective, () => {
+      processRendererDirective(
+        stmt as RendererDirectiveTreeNode,
         workingDag,
         errors,
       );

--- a/src/compiler/rendererTypes.ts
+++ b/src/compiler/rendererTypes.ts
@@ -9,6 +9,9 @@ export interface FileExportOptions {
   fileName: string;
   fileType: ExportFormat;
   scalingFactor: number;
+  // Background fill for the exported image. When omitted, the underlying
+  // exporter's default applies (transparent for png/svg, white for jpg).
+  backgroundColor?: string;
 }
 
 /**

--- a/src/composables/useRendererRegistry.ts
+++ b/src/composables/useRendererRegistry.ts
@@ -1,11 +1,15 @@
 import { ref, shallowRef, computed, watch, markRaw } from "vue";
-import { ExportFormat } from "../compiler/constants";
+import {
+  CYTOSCAPE_RENDERER_NAME,
+  ExportFormat,
+  MINIMAL_RENDERER_NAME,
+} from "../compiler/constants";
 import { RendererComponent } from "../compiler/rendererTypes";
 import CytoscapeRenderer from "../renderers/cyDag/CytoscapeRenderer.vue";
 import MinimalExampleRenderer from "../renderers/minExample/MinimalExampleRenderer.vue";
 
 export function useRendererRegistry(
-  initialRenderer: string = "cytoscape",
+  initialRenderer: string = CYTOSCAPE_RENDERER_NAME,
   onRendererChanged?: () => void,
 ) {
   const registeredRenderers = new Map<string, RendererComponent>();
@@ -20,11 +24,11 @@ export function useRendererRegistry(
 
   // Register default renderers
   registerRenderer(
-    "cytoscape",
+    CYTOSCAPE_RENDERER_NAME,
     markRaw(CytoscapeRenderer) as RendererComponent,
   );
   registerRenderer(
-    "minimal",
+    MINIMAL_RENDERER_NAME,
     markRaw(MinimalExampleRenderer) as RendererComponent,
   );
 

--- a/src/optionsStore.ts
+++ b/src/optionsStore.ts
@@ -1,3 +1,4 @@
+import { CYTOSCAPE_RENDERER_NAME } from "./compiler/constants";
 import { VersionedStore } from "./versionedStore";
 
 export type ThemeMode = "light" | "dark" | "system";
@@ -12,7 +13,7 @@ export interface Options {
 const DEFAULTS: Options = {
   enableTabbingInEditor: false, // off by default to avoid focus trapping
   debugMode: false,
-  selectedRenderer: "cytoscape",
+  selectedRenderer: CYTOSCAPE_RENDERER_NAME,
 };
 
 export class OptionsStore extends VersionedStore<Options> {

--- a/src/renderers/cyDag/CytoscapeRenderer.vue
+++ b/src/renderers/cyDag/CytoscapeRenderer.vue
@@ -23,7 +23,7 @@ import {
 import svg from "cytoscape-svg";
 import { makeCyElements } from "./cyGraphFactory";
 import { makeCyStylesheets } from "./cyStyleSheetsFactory";
-import { dagreLayoutOptions } from "./cyLayout";
+import { getCanvasBackgroundColor } from "./cyRendererDirectives";
 import { exportCyToBlob } from "./cyExport";
 import {
   setupCyPoppers,
@@ -148,10 +148,21 @@ const CytoscapeRenderer = defineComponent({
       }
     },
 
+    // Paint the container with the '^cytoscape' background so the editor shows
+    // what an export will contain. Clearing the inline style hands the
+    // background back to the themed --fviz-bg rule.
+    applyCanvasBackground(): void {
+      const container = this.$refs.container as HTMLElement | undefined;
+      if (!container) return;
+      container.style.backgroundColor =
+        getCanvasBackgroundColor(this.dag) ?? "";
+    },
+
     applyThemeStyles(): void {
       if (!this.cy) return;
       const newStylesheets = makeCyStylesheets(this.dag, this.isDark);
       this.applyStyles(newStylesheets);
+      this.applyCanvasBackground();
     },
 
     updateDag(dag: Dag): void {
@@ -198,6 +209,7 @@ const CytoscapeRenderer = defineComponent({
         if (diff.topologyChanged) this.runLayout();
       }
 
+      this.applyCanvasBackground();
       this.previousElements = newElements;
     },
 
@@ -223,7 +235,10 @@ const CytoscapeRenderer = defineComponent({
       // so Cytoscape's canvas-based exporters capture them natively.
       const ghostIds = this.addGhostNodes();
 
-      const imgBlob = exportCyToBlob(this.cy, exportOptions);
+      const imgBlob = exportCyToBlob(this.cy, {
+        ...exportOptions,
+        backgroundColor: getCanvasBackgroundColor(this.dag),
+      });
 
       this.removeGhostNodes(ghostIds);
 

--- a/src/renderers/cyDag/CytoscapeRenderer.vue
+++ b/src/renderers/cyDag/CytoscapeRenderer.vue
@@ -24,6 +24,11 @@ import svg from "cytoscape-svg";
 import { makeCyElements } from "./cyGraphFactory";
 import { makeCyStylesheets } from "./cyStyleSheetsFactory";
 import { getCanvasBackgroundColor } from "./cyRendererDirectives";
+import {
+  makeDagreLayoutOptions,
+  getRankDirection,
+  RankDirection,
+} from "./cyLayout";
 import { exportCyToBlob } from "./cyExport";
 import {
   setupCyPoppers,
@@ -96,6 +101,7 @@ const CytoscapeRenderer = defineComponent({
       cy: null as Core | null,
       previousElements: null as ElementsDefinition | null,
       previousStylesheetsJson: null as string | null,
+      previousRankDir: undefined as RankDirection | undefined,
       popperCleanup: null as PopperCleanup | null,
     };
   },
@@ -133,7 +139,7 @@ const CytoscapeRenderer = defineComponent({
     runLayout(): void {
       Promise.resolve().then(() => {
         if (this.cy) {
-          this.cy.layout(dagreLayoutOptions).run();
+          this.cy.layout(makeDagreLayoutOptions(this.dag)).run();
         }
       });
     },
@@ -181,6 +187,7 @@ const CytoscapeRenderer = defineComponent({
           dag,
           this.$refs.popperContainer as HTMLElement,
         );
+        this.previousRankDir = getRankDirection(dag);
         this.runLayout();
       } else {
         const diff = diffCyElements(this.previousElements, newElements);
@@ -205,8 +212,16 @@ const CytoscapeRenderer = defineComponent({
           this.$refs.popperContainer as HTMLElement,
         );
 
+        // Editing only a '^cytoscape{ rankDir }' line leaves the element set
+        // identical, so the topology check alone would never relayout and the
+        // directive would appear to do nothing. Compare the resolved direction
+        // so an unrecognized value doesn't trigger a pointless relayout.
+        const rankDir = getRankDirection(dag);
+        const rankDirChanged = rankDir !== this.previousRankDir;
+        this.previousRankDir = rankDir;
+
         // Avoid unnecessary layout runs by checking if the topology has changed
-        if (diff.topologyChanged) this.runLayout();
+        if (diff.topologyChanged || rankDirChanged) this.runLayout();
       }
 
       this.applyCanvasBackground();

--- a/src/renderers/cyDag/cyExport.ts
+++ b/src/renderers/cyDag/cyExport.ts
@@ -23,12 +23,16 @@ export function exportCyToBlob(
   // Svg export is still a useful starting point for those who want to
   // manually edit layouts in an svg editor.
   const scaleFactor = exportOptions.scalingFactor;
+  // Leaving bg undefined keeps each exporter's own default:
+  // transparent for png and svg, white for jpg.
+  const bgColor = exportOptions.backgroundColor;
   return match(exportOptions.fileType)
     .with(ExportFormat.PNG, () => {
       return cy.png({
         full: true,
         scale: scaleFactor,
         output: "blob",
+        bg: bgColor,
       });
     })
     .with(ExportFormat.JPG, () => {
@@ -36,11 +40,12 @@ export function exportCyToBlob(
         full: true,
         scale: scaleFactor,
         output: "blob",
+        bg: bgColor,
       });
     })
     .with(ExportFormat.SVG, () => {
       // @ts-expect-error: missing types
-      const svgData = cy.svg({ full: true, scale: scaleFactor });
+      const svgData = cy.svg({ full: true, scale: scaleFactor, bg: bgColor });
       return new Blob([svgData], {
         type: "image/svg+xml;charset=utf-8",
       });

--- a/src/renderers/cyDag/cyLayout.ts
+++ b/src/renderers/cyDag/cyLayout.ts
@@ -1,24 +1,55 @@
 import { LayoutOptions, NodeSingular } from "cytoscape";
+import { Dag } from "../../compiler/dag";
+import { RANK_DIR_PROPERTY } from "../../compiler/constants";
+import { getCytoscapeDirectiveProperties } from "./cyRendererDirectives";
+
+export const RANK_DIRECTIONS = ["TB", "BT", "LR", "RL"] as const;
+export type RankDirection = (typeof RANK_DIRECTIONS)[number];
 
 // Dagre layout options type - refer to dagre documentation and cytoscape-dagre typings
 // https://github.com/cytoscape/cytoscape.js-dagre?tab=readme-ov-file#api
+// cytoscape's LayoutOptions has no rankDir and cytoscape-dagre ships no
+// typings, so the dagre-specific members are declared here.
 export type DagreLayoutOptions = LayoutOptions & {
   name: "dagre";
   sort: (a: NodeSingular, b: NodeSingular) => number;
+  rankDir?: RankDirection;
 };
 
 // We define a custom sort function to encourage the layout manager
 // to follow the insertion order of nodes in the DAG.
 // However, Dagre's crossing minimization may still rearrange nodes in a way
 // that doesn't preserve the insertion order.
-export const dagreLayoutOptions = {
-  name: "dagre",
-  sort: (A: NodeSingular, B: NodeSingular) => {
-    const orderA: number[] = A.data("order") ?? [];
-    const orderB: number[] = B.data("order") ?? [];
-    for (let i = 0; i < Math.min(orderA.length, orderB.length); i++) {
-      if (orderA[i] !== orderB[i]) return orderA[i] - orderB[i];
-    }
-    return orderA.length - orderB.length;
-  },
-} satisfies DagreLayoutOptions;
+const sortByInsertionOrder = (A: NodeSingular, B: NodeSingular): number => {
+  const orderA: number[] = A.data("order") ?? [];
+  const orderB: number[] = B.data("order") ?? [];
+  for (let i = 0; i < Math.min(orderA.length, orderB.length); i++) {
+    if (orderA[i] !== orderB[i]) return orderA[i] - orderB[i];
+  }
+  return orderA.length - orderB.length;
+};
+
+/**
+ * Rank direction from a '^cytoscape{ rankDir: "LR" }' directive.
+ *
+ * Unrecognized values resolve to undefined so the key is omitted entirely and
+ * dagre applies its own default ('TB'). Renderer directives are never
+ * validated at compile time, so a typo silently changes nothing.
+ */
+export function getRankDirection(dag: Dag): RankDirection | undefined {
+  const value = getCytoscapeDirectiveProperties(dag).get(RANK_DIR_PROPERTY);
+  if (!value) return undefined;
+  const normalized = value.trim().toUpperCase();
+  return (RANK_DIRECTIONS as readonly string[]).includes(normalized)
+    ? (normalized as RankDirection)
+    : undefined;
+}
+
+export function makeDagreLayoutOptions(dag: Dag): DagreLayoutOptions {
+  const rankDir = getRankDirection(dag);
+  return {
+    name: "dagre",
+    sort: sortByInsertionOrder,
+    ...(rankDir ? { rankDir } : {}),
+  } satisfies DagreLayoutOptions;
+}

--- a/src/renderers/cyDag/cyRendererDirectives.ts
+++ b/src/renderers/cyDag/cyRendererDirectives.ts
@@ -1,0 +1,46 @@
+import {
+  BACKGROUND_COLOR_PROPERTY,
+  CYTOSCAPE_RENDERER_NAME,
+} from "../../compiler/constants";
+import { Dag, DagStyle, StyleProperties } from "../../compiler/dag";
+
+// Resolve a binding's style tags and inline properties into a single map,
+// matching the precedence used throughout renderer-directive processing: tags
+// are applied in declaration order and inline properties win over all of them.
+function resolveBindingProperties(
+  dag: Dag,
+  dagStyle: DagStyle,
+): StyleProperties {
+  const tagProperties = dagStyle.styleTags.map(
+    (styleTag) => dag.getStyle(styleTag) ?? new Map<string, string>(),
+  );
+  return new Map([
+    ...tagProperties.flatMap((properties) => Array.from(properties)),
+    ...dagStyle.styleProperties,
+  ]);
+}
+
+/**
+ * Resolved properties from the '^<rendererName>' directive block on the given Dag.
+ *
+ * Directives describe things cytoscape has no stylesheet properties for, such
+ * as the drawing surface and the layout, so they are consumed by the renderer
+ * directly and never emitted as a selector. Style tags resolve with the same
+ * precedence as style bindings: tags in declaration order, inline properties win.
+ */
+export function getRendererDirectiveProperties(
+  dag: Dag,
+  rendererName: string,
+): StyleProperties {
+  const directive = dag.getRendererDirectives().get(rendererName);
+  if (!directive) return new Map();
+  return resolveBindingProperties(dag, directive);
+}
+
+export function getCytoscapeDirectiveProperties(dag: Dag): StyleProperties {
+  return getRendererDirectiveProperties(dag, CYTOSCAPE_RENDERER_NAME);
+}
+
+export function getCanvasBackgroundColor(dag: Dag): string | undefined {
+  return getCytoscapeDirectiveProperties(dag).get(BACKGROUND_COLOR_PROPERTY);
+}

--- a/src/renderers/cyDag/cyStyleSheetsFactory.ts
+++ b/src/renderers/cyDag/cyStyleSheetsFactory.ts
@@ -192,13 +192,16 @@ const GLOBAL_STYLE_SELECTOR_MAP: Record<string, string> = {
 };
 
 export function makeGlobalStyleSheets(dag: Dag): StylesheetCSS[] {
+  const elementBindings = new Map(
+    Array.from(dag.getGlobalStyleBindings()).filter(
+      ([keyword, _]) => keyword in GLOBAL_STYLE_SELECTOR_MAP,
+    ),
+  );
   return makeBindingStyleSheets(
     dag,
-    dag.getGlobalStyleBindings(),
-    (keyword, lineageSelector) => {
-      const baseSelector = GLOBAL_STYLE_SELECTOR_MAP[keyword] ?? keyword;
-      return `${baseSelector}${lineageSelector}`;
-    },
+    elementBindings,
+    (keyword, lineageSelector) =>
+      `${GLOBAL_STYLE_SELECTOR_MAP[keyword]}${lineageSelector}`,
   );
 }
 

--- a/tests/samples/bg_color_sample.fiz
+++ b/tests/samples/bg_color_sample.fiz
@@ -1,0 +1,2 @@
+^cytoscape{background-color:"lightblue"}
+f()

--- a/tests/unit/autocomplete/autocompleter.test.ts
+++ b/tests/unit/autocomplete/autocompleter.test.ts
@@ -12,6 +12,7 @@ import {
   createQualifiedVariableCompletionSource,
   createQualifiedStyleCompletionSource,
   createGlobalStyleKeywordCompletionSource,
+  createRendererDirectiveNameCompletionSource,
   getAllDynamicCompletionSources,
 } from "src/autocomplete/autocompleter";
 import {
@@ -939,6 +940,59 @@ describe("autocompleter", () => {
 
     test("returns null when no asterisk", async () => {
       const context = createMockContext(4, "node");
+      const result = await runSource(source, context);
+
+      expect(result).toBeNull();
+    });
+
+    test("canvas is no longer a global style keyword", async () => {
+      const context = createMockContext(4, "*can");
+      const result = await runSource(source, context);
+
+      expect(result!.options.map((o) => o.label)).not.toContain("canvas");
+    });
+  });
+
+  describe("createRendererDirectiveNameCompletionSource", () => {
+    let source: CompletionSource;
+
+    beforeEach(() => {
+      source = createRendererDirectiveNameCompletionSource();
+    });
+
+    test("completes renderer names after caret", async () => {
+      const context = createMockContext(3, "^cy");
+      const result = await runSource(source, context);
+
+      expect(result).toBeTruthy();
+      expect(result!.from).toBe(1);
+      expect(result!.options).toContainEqual({
+        label: "cytoscape",
+        type: "keyword",
+      });
+    });
+
+    test("completes with empty prefix after caret", async () => {
+      const context = createMockContext(1, "^");
+      const result = await runSource(source, context);
+
+      expect(result).toBeTruthy();
+      expect(result!.from).toBe(1);
+      expect(result!.options.map((o) => o.label)).toContain("cytoscape");
+      expect(result!.options.map((o) => o.label)).toContain("minimal");
+    });
+
+    test("filters renderer names by prefix", async () => {
+      const context = createMockContext(2, "^m");
+      const result = await runSource(source, context);
+
+      expect(result).toBeTruthy();
+      expect(result!.options.map((o) => o.label)).toContain("minimal");
+      expect(result!.options.map((o) => o.label)).not.toContain("cytoscape");
+    });
+
+    test("returns null when no caret", async () => {
+      const context = createMockContext(9, "cytoscape");
       const result = await runSource(source, context);
 
       expect(result).toBeNull();

--- a/tests/unit/autocomplete/autocompletionFactory.test.ts
+++ b/tests/unit/autocomplete/autocompletionFactory.test.ts
@@ -13,6 +13,7 @@ import {
   StyleTreeNode as Style,
   NamedStyleTreeNode as NamedStyle,
   StyleBindingTreeNode as StyleBinding,
+  RendererDirectiveTreeNode as RendererDirective,
   NamespaceTreeNode as Namespace,
   ValueListTreeNode as ValueList,
   StatementListTreeNode as StatementList,
@@ -205,6 +206,51 @@ describe("makeCompletionIndex captures context scenarios", () => {
       from: 11, // styleArgList.from + 1
       to: 19, // styleArgList.to - 1
     });
+  });
+
+  test("creates context scenario for renderer directive", async () => {
+    const styleArgList = new Style(new Map(), [], pos(10, 20));
+    const directiveNode = new RendererDirective(
+      "cytoscape",
+      styleArgList,
+      pos(0, 25),
+    );
+
+    const index = await makeCompletionIndex([directiveNode]);
+
+    expect(index.contextScenarios).toHaveLength(1);
+    expect(index.contextScenarios[0]).toEqual({
+      type: ContextScenarioType.StyleArgList,
+      from: 11, // styleArgList.from + 1
+      to: 19, // styleArgList.to - 1
+      rendererDirectiveId: "cytoscape",
+    });
+  });
+
+  test("renderer directive carries an unregistered id through", async () => {
+    const directiveNode = new RendererDirective(
+      "madeup",
+      new Style(new Map(), [], pos(10, 20)),
+      pos(0, 25),
+    );
+
+    const index = await makeCompletionIndex([directiveNode]);
+
+    expect(index.contextScenarios[0]).toMatchObject({
+      rendererDirectiveId: "madeup",
+    });
+  });
+
+  test("renderer directive declares no tokens", async () => {
+    const directiveNode = new RendererDirective(
+      "cytoscape",
+      new Style(new Map(), [], pos(10, 20)),
+      pos(0, 25),
+    );
+
+    const index = await makeCompletionIndex([directiveNode]);
+
+    expect(index.tokens).toHaveLength(0);
   });
 
   test("creates multiple context scenarios for namespace", async () => {

--- a/tests/unit/autocomplete/rendererProperties.test.ts
+++ b/tests/unit/autocomplete/rendererProperties.test.ts
@@ -1,5 +1,8 @@
 import { describe, test, expect } from "vitest";
-import { getRendererPropertyCompletions } from "src/autocomplete/rendererProperties";
+import {
+  getRendererPropertyCompletions,
+  getRendererDirectiveCompletions,
+} from "src/autocomplete/rendererProperties";
 
 describe("rendererProperties", () => {
   test("cytoscape returns a non-empty array", () => {
@@ -23,5 +26,28 @@ describe("rendererProperties", () => {
   test("unknown renderer returns empty array", () => {
     const completions = getRendererPropertyCompletions("nonexistent");
     expect(completions).toEqual([]);
+  });
+});
+
+describe("renderer directive completions", () => {
+  test("cytoscape directives cover the supported keys", () => {
+    const labels = getRendererDirectiveCompletions("cytoscape").map(
+      (c) => c.label,
+    );
+    expect(labels).toContain("rankDir");
+    expect(labels).toContain("background-color");
+  });
+
+  test("directives exclude stylesheet properties", () => {
+    const labels = getRendererDirectiveCompletions("cytoscape").map(
+      (c) => c.label,
+    );
+    expect(labels).not.toContain("border-width");
+    expect(labels).not.toContain("curve-style");
+  });
+
+  test("renderer without directives returns empty array", () => {
+    expect(getRendererDirectiveCompletions("minimal")).toEqual([]);
+    expect(getRendererDirectiveCompletions("nonexistent")).toEqual([]);
   });
 });

--- a/tests/unit/autocomplete/rendererPropertyCompleter.test.ts
+++ b/tests/unit/autocomplete/rendererPropertyCompleter.test.ts
@@ -205,6 +205,73 @@ describe("rendererPropertyCompleter", () => {
   });
 });
 
+describe("renderer directive completions", () => {
+  function makeDirectiveIndex(rendererDirectiveName: string): CompletionIndex {
+    return new CompletionIndex(
+      [],
+      [
+        {
+          type: ContextScenarioType.StyleArgList,
+          from: 10,
+          to: 30,
+          rendererDirectiveName: rendererDirectiveName,
+        },
+      ],
+      [],
+    );
+  }
+
+  test("offers only directive properties inside a matching directive", async () => {
+    const source = createRendererPropertyCompletionSource(
+      makeDirectiveIndex("cytoscape"),
+      "cytoscape",
+    );
+    const ctx = createMockContext(15, "^cytoscape{ ra", false);
+    const result = await runSource(source, ctx);
+    expect(result).not.toBeNull();
+    const labels = result!.options.map((o) => o.label);
+    expect(labels).toContain("rankDir");
+    // Stylesheet properties are not directives
+    expect(labels).not.toContain("border-width");
+    expect(labels).not.toContain("line-color");
+  });
+
+  test("offers nothing inside a directive for another renderer", async () => {
+    const source = createRendererPropertyCompletionSource(
+      makeDirectiveIndex("minimal"),
+      "cytoscape",
+    );
+    const ctx = createMockContext(15, "^minimal{ ra", false);
+    const result = await runSource(source, ctx);
+    expect(result!.options).toEqual([]);
+  });
+
+  test("regex fallback handles a directive before the index registers", async () => {
+    // The CompletionIndex lags the debounce, so the completer must recognize
+    // '^rendererName{' from the raw text alone.
+    const source = createRendererPropertyCompletionSource(
+      new CompletionIndex([], [], []),
+      "cytoscape",
+    );
+    const ctx = createMockContext(15, "^cytoscape{ ba", false);
+    const result = await runSource(source, ctx);
+    expect(result).not.toBeNull();
+    const labels = result!.options.map((o) => o.label);
+    expect(labels).toContain("background-color");
+    expect(labels).not.toContain("background-opacity");
+  });
+
+  test("regex fallback offers nothing for another renderer", async () => {
+    const source = createRendererPropertyCompletionSource(
+      new CompletionIndex([], [], []),
+      "cytoscape",
+    );
+    const ctx = createMockContext(15, "^minimal{ ba", false);
+    const result = await runSource(source, ctx);
+    expect(result!.options).toEqual([]);
+  });
+});
+
 describe("rendererPropertyCompletionsByElementType", () => {
   test("node completions include node properties and shared properties", () => {
     const nodeProps = getRendererPropertyCompletionsByElementType(

--- a/tests/unit/cli/headlessCytoscape.test.ts
+++ b/tests/unit/cli/headlessCytoscape.test.ts
@@ -1,4 +1,5 @@
 import { describe, test, expect } from "vitest";
+import { createCanvas, loadImage } from "@napi-rs/canvas";
 import { Compiler } from "src/compiler/driver";
 import { ExportFormat } from "src/compiler/constants";
 import {
@@ -19,6 +20,15 @@ async function render(
 ): Promise<Buffer> {
   const { DAG } = await new Compiler().compileFromSource(source);
   return renderDagToBytes(DAG, { ...baseOptions, ...overrides });
+}
+
+// Decode PNG bytes and read the top-left pixel as [r, g, b, a].
+async function getCornerPixel(bytes: Buffer): Promise<number[]> {
+  const image = await loadImage(bytes);
+  const canvas = createCanvas(image.width, image.height);
+  const ctx = canvas.getContext("2d");
+  ctx.drawImage(image, 0, 0);
+  return [...ctx.getImageData(0, 0, 1, 1).data];
 }
 
 describe("headless CLI rendering", () => {
@@ -47,6 +57,27 @@ describe("headless CLI rendering", () => {
     expect(svg).toContain("<svg");
     expect(svg).toContain("alpha");
     expect(svg).toContain("beta");
+  });
+
+  test("canvas background color fills the exported PNG", async () => {
+    const bytes = await render(
+      '^cytoscape{ background-color: "#ff0000" }\na = load()\nprocess(a)\n',
+    );
+    expect(await getCornerPixel(bytes)).toEqual([0xff, 0x00, 0x00, 0xff]);
+  });
+
+  test("PNG stays transparent without a canvas binding", async () => {
+    const bytes = await render("a = load()\nprocess(a)\n");
+    const [, , , alpha] = await getCornerPixel(bytes);
+    expect(alpha).toBe(0);
+  });
+
+  test("canvas background color fills the exported SVG", async () => {
+    const bytes = await render(
+      '^cytoscape{ background-color: "#ff0000" }\na = alpha()\nbeta(a)\n',
+      { fileType: ExportFormat.SVG, includeDescriptions: false },
+    );
+    expect(bytes.toString("utf8")).toContain("#ff0000");
   });
 
   test("scaling factor increases the rendered image size", async () => {

--- a/tests/unit/cli/headlessCytoscape.test.ts
+++ b/tests/unit/cli/headlessCytoscape.test.ts
@@ -80,6 +80,50 @@ describe("headless CLI rendering", () => {
     expect(bytes.toString("utf8")).toContain("#ff0000");
   });
 
+  test("rankDir directive changes the rendered layout", async () => {
+    const recipe = "a = alpha()\nbeta(a)\n";
+    const svgOptions = {
+      fileType: ExportFormat.SVG,
+      includeDescriptions: false,
+    };
+    const topToBottom = await render(recipe, svgOptions);
+    const leftToRight = await render(
+      `^cytoscape{ rankDir: "LR" }\n${recipe}`,
+      svgOptions,
+    );
+    expect(leftToRight.toString("utf8")).not.toEqual(
+      topToBottom.toString("utf8"),
+    );
+  });
+
+  test("unrecognized rankDir falls back to the default layout", async () => {
+    const recipe = "a = alpha()\nbeta(a)\n";
+    const svgOptions = {
+      fileType: ExportFormat.SVG,
+      includeDescriptions: false,
+    };
+    const baseline = await render(recipe, svgOptions);
+    const typo = await render(
+      `^cytoscape{ rankDir: "sideways" }\n${recipe}`,
+      svgOptions,
+    );
+    expect(typo.toString("utf8")).toEqual(baseline.toString("utf8"));
+  });
+
+  test("directive for another renderer does not affect cytoscape", async () => {
+    const recipe = "a = alpha()\nbeta(a)\n";
+    const svgOptions = {
+      fileType: ExportFormat.SVG,
+      includeDescriptions: false,
+    };
+    const baseline = await render(recipe, svgOptions);
+    const otherRenderer = await render(
+      `^minimal{ rankDir: "LR" }\n${recipe}`,
+      svgOptions,
+    );
+    expect(otherRenderer.toString("utf8")).toEqual(baseline.toString("utf8"));
+  });
+
   test("scaling factor increases the rendered image size", async () => {
     const small = await render("a = load()\nprocess(a)\n", {
       scalingFactor: 1,

--- a/tests/unit/compiler/astFactory.test.ts
+++ b/tests/unit/compiler/astFactory.test.ts
@@ -12,6 +12,7 @@ import {
   NamedStyleTreeNode as NamedStyle,
   StyleBindingTreeNode as StyleBinding,
   GlobalStyleBindingTreeNode as GlobalStyleBinding,
+  RendererDirectiveTreeNode as RendererDirective,
   NamespaceTreeNode as Namespace,
   ImportTreeNode as Import,
   BaseTreeNode,
@@ -340,6 +341,50 @@ describe("global style bindings", () => {
     const input = "*node{";
     expect(makeTree(input)).toEqual(
       new Recipe([new GlobalStyleBinding("node", new Style(new Map(), []))]),
+    );
+  });
+});
+
+describe("renderer directives", () => {
+  test("empty renderer directive", () => {
+    const input = "^cytoscape{}";
+    expect(makeTree(input)).toEqual(
+      new Recipe([
+        new RendererDirective("cytoscape", new Style(new Map(), [])),
+      ]),
+    );
+  });
+  test("renderer directive with mixed types", () => {
+    const input = '^cytoscape{rankDir:"LR";a:2\n#d #e}';
+    expect(makeTree(input)).toEqual(
+      new Recipe([
+        new RendererDirective(
+          "cytoscape",
+          new Style(
+            new Map([
+              ["rankDir", "LR"],
+              ["a", "2"],
+            ]),
+            [new StyleTag(["d"]), new StyleTag(["e"])],
+          ),
+        ),
+      ]),
+    );
+  });
+  test("renderer directive for an unregistered renderer parses", () => {
+    const input = '^madeup{x:"y"}';
+    expect(makeTree(input)).toEqual(
+      new Recipe([
+        new RendererDirective("madeup", new Style(new Map([["x", "y"]]), [])),
+      ]),
+    );
+  });
+  test("incomplete renderer directive", () => {
+    const input = "^cytoscape{";
+    expect(makeTree(input)).toEqual(
+      new Recipe([
+        new RendererDirective("cytoscape", new Style(new Map(), [])),
+      ]),
     );
   });
 });

--- a/tests/unit/compiler/dag.test.ts
+++ b/tests/unit/compiler/dag.test.ts
@@ -288,6 +288,48 @@ describe("merge dag tests", () => {
       new Map([["keyword1", styleNode2]]),
     );
   });
+  test("merge dag renderer directives", () => {
+    // Anonymous imports merge into the importing dag, so a directive carried
+    // by an imported file would be silently dropped without this.
+    const dag1 = new Dag("root1");
+    const directive1 = {
+      styleTags: [],
+      styleProperties: new Map([["rankDir", "LR"]]),
+    };
+    dag1.addRendererDirective("cytoscape", directive1);
+    const dag2 = new Dag("root2");
+    const directive2 = {
+      styleTags: [],
+      styleProperties: new Map([["spacing", "2"]]),
+    };
+    dag2.addRendererDirective("minimal", directive2);
+
+    dag1.mergeDag(dag2);
+    expect(dag1.getRendererDirectives()).toEqual(
+      new Map([
+        ["cytoscape", directive1],
+        ["minimal", directive2],
+      ]),
+    );
+  });
+  test("merge dag renderer directives with conflicting ids", () => {
+    const dag1 = new Dag("root1");
+    dag1.addRendererDirective("cytoscape", {
+      styleTags: [],
+      styleProperties: new Map([["rankDir", "LR"]]),
+    });
+    const dag2 = new Dag("root2");
+    const directive2 = {
+      styleTags: [],
+      styleProperties: new Map([["rankDir", "BT"]]),
+    };
+    dag2.addRendererDirective("cytoscape", directive2);
+
+    dag1.mergeDag(dag2);
+    expect(dag1.getRendererDirectives()).toEqual(
+      new Map([["cytoscape", directive2]]),
+    );
+  });
   test("merge dag var nodes with no conflicts", () => {
     const dag1 = new Dag("root1");
     dag1.setVarNode("x", "node1");

--- a/tests/unit/compiler/dagFactory.test.ts
+++ b/tests/unit/compiler/dagFactory.test.ts
@@ -10,6 +10,7 @@ import {
   NamedStyleTreeNode as NamedStyle,
   StyleBindingTreeNode as StyleBinding,
   GlobalStyleBindingTreeNode as GlobalStyleBinding,
+  RendererDirectiveTreeNode as RendererDirective,
   NamespaceTreeNode as Namespace,
   ImportTreeNode as Import,
   ValueListTreeNode as ValueList,
@@ -22,6 +23,8 @@ import { ImportCacher } from "src/compiler/importCacher";
 import {
   DEFAULT_POSITION,
   CompilationError,
+  ErrorCode,
+  ErrorSource,
 } from "src/compiler/compilationErrors";
 
 const dummyImporter = {} as ImportCacher;
@@ -880,6 +883,100 @@ describe("global style binding tests", () => {
     expect(errors).toHaveLength(1);
     expect(errors[0].message).toContain("Invalid global style binding keyword");
     expect(errors[0].message).toContain("foo");
+  });
+});
+
+describe("renderer directive tests", () => {
+  test("no renderer directive", async () => {
+    const recipe = new Recipe([]);
+    const { dag } = await makeDag(recipe, dummyImporter);
+    expect(dag.getRendererDirectives()).toEqual(new Map<string, DagStyle>());
+  });
+  test("renderer directive with inline properties", async () => {
+    const recipe = new Recipe([
+      new RendererDirective(
+        "cytoscape",
+        new Style(new Map([["rankDir", "LR"]]), []),
+      ),
+    ]);
+    const { dag, errors } = await makeDag(recipe, dummyImporter);
+    expect(errors).toHaveLength(0);
+    expect(dag.getRendererDirectives()).toEqual(
+      new Map<string, DagStyle>([
+        [
+          "cytoscape",
+          { styleTags: [], styleProperties: new Map([["rankDir", "LR"]]) },
+        ],
+      ]),
+    );
+  });
+  test("renderer directive with style tags", async () => {
+    const recipe = new Recipe([
+      new NamedStyle("compact", new Style(new Map([["rankDir", "LR"]]))),
+      new RendererDirective(
+        "cytoscape",
+        new Style(new Map(), [new StyleTagNode(["compact"])]),
+      ),
+    ]);
+    const { dag, errors } = await makeDag(recipe, dummyImporter);
+    expect(errors).toHaveLength(0);
+    expect(dag.getRendererDirectives()).toEqual(
+      new Map<string, DagStyle>([
+        ["cytoscape", { styleTags: [["compact"]], styleProperties: new Map() }],
+      ]),
+    );
+  });
+  test("unknown renderer id is stored without error", async () => {
+    // Renderer ids are deliberately not validated: the compiler has no
+    // knowledge of the renderer registry.
+    const recipe = new Recipe([
+      new RendererDirective("madeup", new Style(new Map([["x", "y"]]), [])),
+    ]);
+    const { dag, errors } = await makeDag(recipe, dummyImporter);
+    expect(errors).toHaveLength(0);
+    expect(dag.getRendererDirectives().has("madeup")).toBe(true);
+  });
+  test("repeated directives for one renderer are last-wins", async () => {
+    const recipe = new Recipe([
+      new RendererDirective(
+        "cytoscape",
+        new Style(new Map([["rankDir", "LR"]]), []),
+      ),
+      new RendererDirective(
+        "cytoscape",
+        new Style(new Map([["background-color", "#fff"]]), []),
+      ),
+    ]);
+    const { dag } = await makeDag(recipe, dummyImporter);
+    expect(dag.getRendererDirectives().get("cytoscape")).toEqual({
+      styleTags: [],
+      styleProperties: new Map([["background-color", "#fff"]]),
+    });
+  });
+  test("directive inside a namespace produces an error", async () => {
+    const recipe = new Recipe([
+      new Namespace(
+        "ns",
+        new StatementList([
+          new RendererDirective(
+            "cytoscape",
+            new Style(new Map([["rankDir", "LR"]]), []),
+          ),
+        ]),
+      ),
+    ]);
+    const { dag, errors } = await makeDag(recipe, dummyImporter);
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toMatchObject({
+      code: ErrorCode.RendererDirectiveNotAtTopLevel,
+      severity: "error",
+      source: ErrorSource.Syntax,
+    });
+    expect(dag.getRendererDirectives()).toEqual(new Map<string, DagStyle>());
+    const childDag = dag.getChildDags()[0];
+    expect(childDag.getRendererDirectives()).toEqual(
+      new Map<string, DagStyle>(),
+    );
   });
 });
 

--- a/tests/unit/renderers/cyDag/cyExport.test.ts
+++ b/tests/unit/renderers/cyDag/cyExport.test.ts
@@ -1,0 +1,65 @@
+import { describe, test, expect, vi } from "vitest";
+import { Core } from "cytoscape";
+import { exportCyToBlob } from "src/renderers/cyDag/cyExport";
+import { ExportFormat } from "src/compiler/constants";
+
+function makeStubCy() {
+  const png = vi.fn(() => new Blob(["png"]));
+  const jpg = vi.fn(() => new Blob(["jpg"]));
+  const svg = vi.fn(() => "<svg></svg>");
+  return { cy: { png, jpg, svg } as unknown as Core, png, jpg, svg };
+}
+
+describe("background color is forwarded to the exporters", () => {
+  test("png receives bg", () => {
+    const { cy, png } = makeStubCy();
+    exportCyToBlob(cy, {
+      fileName: "test",
+      fileType: ExportFormat.PNG,
+      scalingFactor: 1,
+      backgroundColor: "#fff",
+    });
+    expect(png).toHaveBeenCalledWith(expect.objectContaining({ bg: "#fff" }));
+  });
+  test("jpg receives bg", () => {
+    const { cy, jpg } = makeStubCy();
+    exportCyToBlob(cy, {
+      fileName: "test",
+      fileType: ExportFormat.JPG,
+      scalingFactor: 1,
+      backgroundColor: "#fff",
+    });
+    expect(jpg).toHaveBeenCalledWith(expect.objectContaining({ bg: "#fff" }));
+  });
+  test("svg receives bg", () => {
+    const { cy, svg } = makeStubCy();
+    exportCyToBlob(cy, {
+      fileName: "test",
+      fileType: ExportFormat.SVG,
+      scalingFactor: 1,
+      backgroundColor: "#fff",
+    });
+    expect(svg).toHaveBeenCalledWith(expect.objectContaining({ bg: "#fff" }));
+  });
+  test("bg is undefined when no background color is given", () => {
+    const { cy, png } = makeStubCy();
+    exportCyToBlob(cy, {
+      fileName: "test",
+      fileType: ExportFormat.PNG,
+      scalingFactor: 1,
+    });
+    expect(png).toHaveBeenCalledWith(
+      expect.objectContaining({ bg: undefined }),
+    );
+  });
+  test("unsupported format returns null", () => {
+    const { cy } = makeStubCy();
+    expect(
+      exportCyToBlob(cy, {
+        fileName: "test",
+        fileType: ExportFormat.TXT,
+        scalingFactor: 1,
+      }),
+    ).toBeNull();
+  });
+});

--- a/tests/unit/renderers/cyDag/cyLayout.test.ts
+++ b/tests/unit/renderers/cyDag/cyLayout.test.ts
@@ -1,0 +1,91 @@
+import { describe, test, expect } from "vitest";
+import { NodeSingular } from "cytoscape";
+import { Dag } from "src/compiler/dag";
+import {
+  getRankDirection,
+  makeDagreLayoutOptions,
+} from "src/renderers/cyDag/cyLayout";
+
+function makeDagWithDirective(
+  rendererName: string,
+  properties: [string, string][],
+): Dag {
+  const dag = new Dag("DagId");
+  dag.addRendererDirective(rendererName, {
+    styleTags: [],
+    styleProperties: new Map(properties),
+  });
+  return dag;
+}
+
+// Minimal stand-in for a cytoscape node exposing only data("order"),
+// which is all the sort hint reads.
+function makeOrderedNode(order: number[]): NodeSingular {
+  return { data: () => order } as unknown as NodeSingular;
+}
+
+describe("rank direction resolution", () => {
+  test("no directive leaves rankDir unset", () => {
+    const dag = new Dag("DagId");
+    expect(getRankDirection(dag)).toBeUndefined();
+    expect(makeDagreLayoutOptions(dag)).not.toHaveProperty("rankDir");
+  });
+  test("recognized direction is applied", () => {
+    const dag = makeDagWithDirective("cytoscape", [["rankDir", "LR"]]);
+    expect(getRankDirection(dag)).toBe("LR");
+    expect(makeDagreLayoutOptions(dag).rankDir).toBe("LR");
+  });
+  test("lowercase direction is normalized", () => {
+    const dag = makeDagWithDirective("cytoscape", [["rankDir", "lr"]]);
+    expect(getRankDirection(dag)).toBe("LR");
+  });
+  test("surrounding whitespace is tolerated", () => {
+    const dag = makeDagWithDirective("cytoscape", [["rankDir", " BT "]]);
+    expect(getRankDirection(dag)).toBe("BT");
+  });
+  test("unrecognized direction is omitted entirely", () => {
+    // Directives are not validated, so a typo silently falls back to the
+    // dagre default rather than emitting an invalid option.
+    const dag = makeDagWithDirective("cytoscape", [["rankDir", "sideways"]]);
+    expect(getRankDirection(dag)).toBeUndefined();
+    expect(makeDagreLayoutOptions(dag)).not.toHaveProperty("rankDir");
+  });
+  test("directive for another renderer is ignored", () => {
+    const dag = makeDagWithDirective("minimal", [["rankDir", "LR"]]);
+    expect(getRankDirection(dag)).toBeUndefined();
+  });
+  test("rankDir resolves through a style tag", () => {
+    const dag = new Dag("DagId");
+    dag.setStyle("compact", new Map([["rankDir", "RL"]]));
+    dag.addRendererDirective("cytoscape", {
+      styleTags: [["compact"]],
+      styleProperties: new Map(),
+    });
+    expect(getRankDirection(dag)).toBe("RL");
+  });
+});
+
+describe("dagre layout options", () => {
+  test("layout name is always dagre", () => {
+    expect(makeDagreLayoutOptions(new Dag("DagId")).name).toBe("dagre");
+  });
+  test("insertion order sort hint is preserved", () => {
+    const { sort } = makeDagreLayoutOptions(new Dag("DagId"));
+    expect(sort(makeOrderedNode([0]), makeOrderedNode([1]))).toBeLessThan(0);
+    expect(sort(makeOrderedNode([2]), makeOrderedNode([1]))).toBeGreaterThan(0);
+    expect(sort(makeOrderedNode([1]), makeOrderedNode([1]))).toBe(0);
+  });
+  test("sort hint compares nested lineage order", () => {
+    const { sort } = makeDagreLayoutOptions(new Dag("DagId"));
+    expect(sort(makeOrderedNode([1, 0]), makeOrderedNode([1, 1]))).toBeLessThan(
+      0,
+    );
+    expect(sort(makeOrderedNode([1]), makeOrderedNode([1, 0]))).toBeLessThan(0);
+  });
+  test("sort hint is present alongside a rankDir", () => {
+    const dag = makeDagWithDirective("cytoscape", [["rankDir", "LR"]]);
+    const options = makeDagreLayoutOptions(dag);
+    expect(options.rankDir).toBe("LR");
+    expect(typeof options.sort).toBe("function");
+  });
+});

--- a/tests/unit/renderers/cyDag/cyRendererDirectives.test.ts
+++ b/tests/unit/renderers/cyDag/cyRendererDirectives.test.ts
@@ -1,0 +1,65 @@
+import { describe, test, expect } from "vitest";
+import { Dag } from "src/compiler/dag";
+import {
+  getCytoscapeDirectiveProperties,
+  getCanvasBackgroundColor,
+} from "src/renderers/cyDag/cyRendererDirectives";
+
+describe("renderer directive properties", () => {
+  test("no directive", () => {
+    const testDag = new Dag("DagId");
+    expect(getCytoscapeDirectiveProperties(testDag)).toEqual(new Map());
+    expect(getCanvasBackgroundColor(testDag)).toBeUndefined();
+  });
+  test("directive without a background color", () => {
+    const testDag = new Dag("DagId");
+    testDag.addRendererDirective("cytoscape", {
+      styleTags: [],
+      styleProperties: new Map([["color", "red"]]),
+    });
+    expect(getCanvasBackgroundColor(testDag)).toBeUndefined();
+  });
+  test("directive with inline properties", () => {
+    const testDag = new Dag("DagId");
+    testDag.addRendererDirective("cytoscape", {
+      styleTags: [],
+      styleProperties: new Map([["background-color", "#fff"]]),
+    });
+    expect(getCanvasBackgroundColor(testDag)).toBe("#fff");
+  });
+  test("directive with style tags", () => {
+    const testDag = new Dag("DagId");
+    testDag.setStyle("light", new Map([["background-color", "#eee"]]));
+    testDag.addRendererDirective("cytoscape", {
+      styleTags: [["light"]],
+      styleProperties: new Map(),
+    });
+    expect(getCanvasBackgroundColor(testDag)).toBe("#eee");
+  });
+  test("inline properties take precedence over style tags", () => {
+    const testDag = new Dag("DagId");
+    testDag.setStyle("light", new Map([["background-color", "#eee"]]));
+    testDag.addRendererDirective("cytoscape", {
+      styleTags: [["light"]],
+      styleProperties: new Map([["background-color", "#fff"]]),
+    });
+    expect(getCanvasBackgroundColor(testDag)).toBe("#fff");
+  });
+  test("unresolved style tag is skipped", () => {
+    const testDag = new Dag("DagId");
+    testDag.addRendererDirective("cytoscape", {
+      styleTags: [["missing"]],
+      styleProperties: new Map(),
+    });
+    expect(getCytoscapeDirectiveProperties(testDag)).toEqual(new Map());
+  });
+  test("directive for another renderer is not read", () => {
+    const testDag = new Dag("DagId");
+    testDag.addRendererDirective("minimal", {
+      styleTags: [],
+      styleProperties: new Map([["background-color", "#fff"]]),
+    });
+    expect(getCytoscapeDirectiveProperties(testDag)).toEqual(new Map());
+    expect(getCanvasBackgroundColor(testDag)).toBeUndefined();
+  });
+});

--- a/tests/unit/renderers/cyDag/cyStyleSheetsFactory.test.ts
+++ b/tests/unit/renderers/cyDag/cyStyleSheetsFactory.test.ts
@@ -551,4 +551,31 @@ describe("makes cytoscape stylesheets", () => {
     ]);
     expect(makeCyStylesheets(testDag)).toEqual(expectedCyStyles);
   });
+  test("canvas global style binding emits no selector", () => {
+    const testDag = new Dag("DagId");
+    testDag.addGlobalStyleBinding("canvas", {
+      styleTags: [],
+      styleProperties: new Map([["background-color", "#fff"]]),
+    });
+    expect(makeGlobalStyleSheets(testDag)).toEqual([]);
+    expect(makeCyStylesheets(testDag)).toEqual(getBaseStylesheet());
+  });
+  test("canvas global style binding does not hide element bindings", () => {
+    const testDag = new Dag("DagId");
+    testDag.addGlobalStyleBinding("canvas", {
+      styleTags: [],
+      styleProperties: new Map([["background-color", "#fff"]]),
+    });
+    testDag.addGlobalStyleBinding("edge", {
+      styleTags: [],
+      styleProperties: new Map([["color", "blue"]]),
+    });
+    const expectedStyles = [
+      {
+        selector: "edge",
+        css: { color: "blue" },
+      },
+    ];
+    expect(makeGlobalStyleSheets(testDag)).toEqual(expectedStyles);
+  });
 });


### PR DESCRIPTION
This pull request introduces support for renderer directives (e.g., `^cytoscape{ ... }`) to the language and codebase, enabling renderer-specific configuration blocks. It extends the parser and AST, updates the autocompletion system to suggest renderer directive names and properties, and adds support for handling these directives in the DAG and rendering pipeline. The main changes are grouped as follows:

**Language & AST Enhancements:**
* Added a new `RendererDirectiveTreeNode` to the AST to represent renderer-specific directive blocks (e.g., `^cytoscape{ ... }`). Updated the parser (`astFactory.ts`) and node type enums to recognize and construct these nodes. [[1]](diffhunk://#diff-27f8f31970758699d6207354c76125f6c38c3ca205a551abf77021c72904110cR14) [[2]](diffhunk://#diff-27f8f31970758699d6207354c76125f6c38c3ca205a551abf77021c72904110cR72) [[3]](diffhunk://#diff-27f8f31970758699d6207354c76125f6c38c3ca205a551abf77021c72904110cR422-R452) [[4]](diffhunk://#diff-9cc963f4164aed458581db542921bca995c1e0c646dab9bc3d5652a1a0403336R19) [[5]](diffhunk://#diff-9cc963f4164aed458581db542921bca995c1e0c646dab9bc3d5652a1a0403336R189-R204) [[6]](diffhunk://#diff-9cc963f4164aed458581db542921bca995c1e0c646dab9bc3d5652a1a0403336R325)
* Introduced a new error code for renderer directives not at the top level.

**Autocompletion Improvements:**
* Added completion support for renderer directive names (e.g., suggesting `cytoscape` after typing `^`) and their properties, including context-aware suggestions inside directive blocks. [[1]](diffhunk://#diff-20c7a493b5e87e90c9d7bbbb2a63140092e95d4b1d31864e8a2c0fbcb83339a6L13-R16) [[2]](diffhunk://#diff-20c7a493b5e87e90c9d7bbbb2a63140092e95d4b1d31864e8a2c0fbcb83339a6R422-R442) [[3]](diffhunk://#diff-20c7a493b5e87e90c9d7bbbb2a63140092e95d4b1d31864e8a2c0fbcb83339a6R454) [[4]](diffhunk://#diff-0dd4d81f3db9a9a4e45f5d57e9ea15631a4db6e50b60c769ddbe005caa92b27aR25-R27) [[5]](diffhunk://#diff-03d2581e99f35ba82c85afbc41b7077d749da893442dad2e12574d51ff2b9f2eR11) [[6]](diffhunk://#diff-03d2581e99f35ba82c85afbc41b7077d749da893442dad2e12574d51ff2b9f2eR56) [[7]](diffhunk://#diff-03d2581e99f35ba82c85afbc41b7077d749da893442dad2e12574d51ff2b9f2eR179-R190) [[8]](diffhunk://#diff-c9687bcad0d3feb5e5eed1909cf8937f95a6ee8966115bb5dd4828520a8c3868R11-R19) [[9]](diffhunk://#diff-c9687bcad0d3feb5e5eed1909cf8937f95a6ee8966115bb5dd4828520a8c3868L43-R79) [[10]](diffhunk://#diff-e03fcb51bc84e83155a492d8e64f8dad3f7b95530c5cd89b7def29c53e63f7aaR3-R7) [[11]](diffhunk://#diff-e03fcb51bc84e83155a492d8e64f8dad3f7b95530c5cd89b7def29c53e63f7aaR246-R269) [[12]](diffhunk://#diff-e03fcb51bc84e83155a492d8e64f8dad3f7b95530c5cd89b7def29c53e63f7aaR287-R292)

**Renderer Properties & Constants:**
* Defined new renderer directive properties (e.g., `background-color`, `rankDir`) in `constants.ts` and registered them for the cytoscape renderer. Standardized renderer names and made them available for completion and registry lookups. [[1]](diffhunk://#diff-3bd33b99920586606c1b18d9fdda6efbb665e6758ff770809f89425b943e0797R4-R27) [[2]](diffhunk://#diff-e03fcb51bc84e83155a492d8e64f8dad3f7b95530c5cd89b7def29c53e63f7aaR246-R269)

**DAG & Rendering Pipeline Updates:**
* Extended the `Dag` class to store and merge renderer directives, and exposed them for use by renderers. [[1]](diffhunk://#diff-1f8a78bafd7966387cb4f9998cd20c48f4ece2c133a7bbbac7eaa3b54e1a591eR40) [[2]](diffhunk://#diff-1f8a78bafd7966387cb4f9998cd20c48f4ece2c133a7bbbac7eaa3b54e1a591eR70) [[3]](diffhunk://#diff-1f8a78bafd7966387cb4f9998cd20c48f4ece2c133a7bbbac7eaa3b54e1a591eR102-R105) [[4]](diffhunk://#diff-1f8a78bafd7966387cb4f9998cd20c48f4ece2c133a7bbbac7eaa3b54e1a591eR309-R312) [[5]](diffhunk://#diff-1f8a78bafd7966387cb4f9998cd20c48f4ece2c133a7bbbac7eaa3b54e1a591eR387-R389)
* Updated the headless cytoscape renderer to consume renderer directive properties, such as canvas background color and layout direction, from the DAG. [[1]](diffhunk://#diff-f6d4c60d673e4e49e9f70a305610bfd03a998322475dda80caf0a296068efa76L7-R8) [[2]](diffhunk://#diff-f6d4c60d673e4e49e9f70a305610bfd03a998322475dda80caf0a296068efa76L213-R214) [[3]](diffhunk://#diff-f6d4c60d673e4e49e9f70a305610bfd03a998322475dda80caf0a296068efa76R227)