### PR TITLE
feat(CytoscapeRenderer): Add additional layout options to Cytoscape renderer

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "commander": "^15.0.0",
     "cytoscape": "^3.34.0",
     "cytoscape-dagre": "^4.0.0",
+    "cytoscape-elk": "^2.3.0",
     "cytoscape-popper": "^4.0.1",
     "cytoscape-svg": "^0.4.0",
     "file-saver": "^2.0.5",
@@ -44,7 +45,8 @@
     "vue": "^3.5.40",
     "vue-router": "^5.2.0",
     "vue3-tabs-component": "^1.4.0",
-    "vuetify": "^4.1.7"
+    "vuetify": "^4.1.7",
+    "zod": "^4.4.3"
   },
   "devDependencies": {
     "@babel/types": "^7.29.8",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -56,6 +56,9 @@ importers:
       cytoscape-dagre:
         specifier: ^4.0.0
         version: 4.0.0(cytoscape@3.34.1)
+      cytoscape-elk:
+        specifier: ^2.3.0
+        version: 2.3.0(cytoscape@3.34.1)
       cytoscape-popper:
         specifier: ^4.0.1
         version: 4.0.1(cytoscape@3.34.1)
@@ -92,6 +95,9 @@ importers:
       vuetify:
         specifier: ^4.1.7
         version: 4.1.9(typescript@6.0.3)(vue@3.5.41(typescript@6.0.3))
+      zod:
+        specifier: ^4.4.3
+        version: 4.4.3
     devDependencies:
       '@babel/types':
         specifier: ^7.29.8
@@ -1552,6 +1558,11 @@ packages:
     peerDependencies:
       cytoscape: ^3.2.22
 
+  cytoscape-elk@2.3.0:
+    resolution: {integrity: sha512-1h2ZmPOy5HD2+mrfF3P2ICxfnDyPCWg/xLVs7fIjTOzdQu51ydrMtm6Sb7KnhFwLBzhGIVYI2Gbns0njggBarQ==}
+    peerDependencies:
+      cytoscape: ^3.2.0
+
   cytoscape-popper@4.0.1:
     resolution: {integrity: sha512-u2gYDMMvGSlAJbNfKvMljOM/p+BrHu0A4VcpELa+xJf54HoMn+nV0iuhALZx+O89b74SKJRy7jYo2WfkD5uvsw==}
     peerDependencies:
@@ -1614,6 +1625,9 @@ packages:
     resolution: {integrity: sha512-e0GOtq/aTQhVdNyDU9e02+wz9oDDM+SIOQxWME2QRjzRX5yyLAuHDE+0aE8vHb9XRC8XD37eO2u57+F09JqFhw==}
     engines: {node: '>=14'}
     hasBin: true
+
+  elkjs@0.9.3:
+    resolution: {integrity: sha512-f/ZeWvW/BCXbhGEf1Ujp29EASo/lk1FDnETgNKwJrsVvGZhUWCZyg3xLJjAsxfOmt8KjswHmI5EwCQcPMpOYhQ==}
 
   emoji-regex@10.6.0:
     resolution: {integrity: sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==}
@@ -2971,6 +2985,9 @@ packages:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
 
+  zod@4.4.3:
+    resolution: {integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==}
+
 snapshots:
 
   '@acemir/cssom@0.9.31': {}
@@ -4292,6 +4309,11 @@ snapshots:
     dependencies:
       cytoscape: 3.34.1
 
+  cytoscape-elk@2.3.0(cytoscape@3.34.1):
+    dependencies:
+      cytoscape: 3.34.1
+      elkjs: 0.9.3
+
   cytoscape-popper@4.0.1(cytoscape@3.34.1):
     dependencies:
       cytoscape: 3.34.1
@@ -4351,6 +4373,8 @@ snapshots:
       commander: 10.0.1
       minimatch: 9.0.9
       semver: 7.8.5
+
+  elkjs@0.9.3: {}
 
   emoji-regex@10.6.0: {}
 
@@ -5613,3 +5637,5 @@ snapshots:
       yargs-parser: 22.0.0
 
   yocto-queue@0.1.0: {}
+
+  zod@4.4.3: {}

--- a/src/App.vue
+++ b/src/App.vue
@@ -9,7 +9,7 @@
         :completion-index="curCompletionIndex"
         :debug-mode="debugMode"
         :tutorial-mode="tutorialMode"
-        :selected-renderer="selectedRenderer"
+        :active-renderer="activeRendererName"
         :is-dark="resolvedTheme === 'dark'"
         @update-editorstate="updateEditorState"
       />
@@ -74,8 +74,6 @@
     v-model:enable-tabbing-in-editor="enableTabbingInEditor"
     v-model:debug-mode="debugMode"
     v-model:theme-mode="themeMode"
-    v-model:selected-renderer="selectedRenderer"
-    :renderer-options="rendererOptions"
   />
   <TutorialLevelSelect
     v-model:show-dialog="showTutorialLevelSelect"
@@ -152,12 +150,8 @@ const {
   },
 );
 
-const {
-  selectedRenderer,
-  rendererComponent,
-  rendererOptions,
-  supportedExportFormats,
-} = useRendererRegistry("cytoscape", repaint);
+const { activeRendererName, rendererComponent, supportedExportFormats } =
+  useRendererRegistry(() => curDag.value as Dag);
 
 // Tutorial computed properties
 const tutorialModules = computed(() =>
@@ -175,7 +169,6 @@ function persistOptions() {
   optionsStore.save({
     enableTabbingInEditor: enableTabbingInEditor.value,
     debugMode: debugMode.value,
-    selectedRenderer: selectedRenderer.value,
     themeMode: themeMode.value,
   });
 }
@@ -188,7 +181,6 @@ watch(debugMode, (newVal: boolean) => {
 });
 watch(resolvedTheme, (newTheme) => applyTheme(newTheme));
 watch(themeMode, () => persistOptions());
-watch(selectedRenderer, () => persistOptions());
 
 watch(tutorialMode, (newVal: boolean) => {
   try {
@@ -246,7 +238,6 @@ onMounted(() => {
   const savedOptions = optionsStore.load();
   enableTabbingInEditor.value = savedOptions.enableTabbingInEditor;
   debugMode.value = savedOptions.debugMode;
-  selectedRenderer.value = savedOptions.selectedRenderer;
   themeMode.value = savedOptions.themeMode ?? "system";
 
   applyTheme(resolvedTheme.value);

--- a/src/autocomplete/autocompletion.ts
+++ b/src/autocomplete/autocompletion.ts
@@ -25,6 +25,10 @@ export interface ContextScenario {
   // Set inside a '^<rendererName>{ }' block. Directive properties are offered
   // only when this matches the active renderer.
   rendererDirectiveName?: string;
+  // The layout the same directive block selects, used to narrow the offered
+  // properties to that layout's options. Undefined when the block does not
+  // declare a layout inline.
+  rendererDirectiveLayout?: string;
 }
 
 // An autocompletion token definition

--- a/src/autocomplete/autocompletionFactory.ts
+++ b/src/autocomplete/autocompletionFactory.ts
@@ -12,7 +12,10 @@ import {
   NamespaceTreeNode,
   ImportTreeNode,
 } from "../compiler/ast";
-import { GLOBAL_STYLE_KEYWORD_MAP } from "../compiler/constants";
+import {
+  GLOBAL_STYLE_KEYWORD_MAP,
+  LAYOUT_PROPERTY,
+} from "../compiler/constants";
 import {
   CompletionIndex,
   TokenInfo,
@@ -184,7 +187,9 @@ function makeContextScenarios(statement: StatementTreeNode): ContextScenario[] {
           type: ContextScenarioType.StyleArgList,
           from: rendererDirectiveNode.StyleNode.Position.from + 1,
           to: rendererDirectiveNode.StyleNode.Position.to - 1,
-          rendererDirectiveId: rendererDirectiveNode.RendererName,
+          rendererDirectiveName: rendererDirectiveNode.RendererName,
+          rendererDirectiveLayout:
+            rendererDirectiveNode.StyleNode.KeyValueMap.get(LAYOUT_PROPERTY),
         },
       ];
     })

--- a/src/autocomplete/rendererProperties.ts
+++ b/src/autocomplete/rendererProperties.ts
@@ -1,11 +1,16 @@
 import { Completion } from "@codemirror/autocomplete";
 import {
   BACKGROUND_COLOR_PROPERTY,
+  CYTOSCAPE_LAYOUT_NAMES,
   CYTOSCAPE_RENDERER_NAME,
   DESCRIPTION_PREFIX,
   DESCRIPTION_PROPERTY,
-  RANK_DIR_PROPERTY,
+  LAYOUT_PROPERTY,
 } from "../compiler/constants";
+import {
+  CyLayoutName,
+  getLayoutOptionKeys,
+} from "../renderers/cyDag/cyLayoutSchema";
 
 // Cytoscape properties sourced from https://js.cytoscape.org/#style
 
@@ -246,16 +251,35 @@ const cytoscapeEdgeCompletions = buildCompletions([
 // Properties consumed directly by the cytoscape renderer from a
 // '^cytoscape{ }' directive. These are not cytoscape stylesheet properties:
 // the background fill applies to the drawing surface (editor view and exported
-// images) and rankDir configures the dagre layout.
-const cytoscapeDirectiveCompletions = buildCompletions([
+// images) and the rest select and configure the layout. The layout option keys
+// come from the renderer's own schema so the two can never drift apart.
+const CYTOSCAPE_DIRECTIVE_BASE_PROPERTIES = [
   BACKGROUND_COLOR_PROPERTY,
-  RANK_DIR_PROPERTY,
-]);
+  LAYOUT_PROPERTY,
+];
+
+const cytoscapeDirectiveCompletionsByLayout: Record<string, Completion[]> =
+  Object.fromEntries(
+    CYTOSCAPE_LAYOUT_NAMES.map((layoutName) => [
+      layoutName,
+      buildCompletions([
+        ...CYTOSCAPE_DIRECTIVE_BASE_PROPERTIES,
+        ...getLayoutOptionKeys(layoutName),
+      ]),
+    ]),
+  );
+
+// Offered when the active layout is unknown: base properties only, since
+// layout-specific option keys can't be resolved without a known layout.
+const cytoscapeDirectiveCompletions = buildCompletions(
+  CYTOSCAPE_DIRECTIVE_BASE_PROPERTIES,
+);
 
 interface RendererPropertyEntry {
   all: Completion[];
   byElementType: Record<string, Completion[]>;
   directives: Completion[];
+  directivesByLayout?: Record<string, Completion[]>;
 }
 
 const rendererPropertyRegistry: Record<string, RendererPropertyEntry> = {
@@ -267,26 +291,44 @@ const rendererPropertyRegistry: Record<string, RendererPropertyEntry> = {
       subgraph: cytoscapeNodeCompletions,
     },
     directives: cytoscapeDirectiveCompletions,
+    directivesByLayout: cytoscapeDirectiveCompletionsByLayout,
   },
 };
 
 export function getRendererPropertyCompletions(
-  rendererId: string,
+  rendererName: string,
 ): Completion[] {
-  return rendererPropertyRegistry[rendererId]?.all ?? [];
+  return rendererPropertyRegistry[rendererName]?.all ?? [];
 }
 
 export function getRendererPropertyCompletionsByElementType(
-  rendererId: string,
+  rendererName: string,
   elementType: string,
 ): Completion[] {
-  const entry = rendererPropertyRegistry[rendererId];
+  const entry = rendererPropertyRegistry[rendererName];
   if (!entry) return [];
   return entry.byElementType[elementType] ?? entry.all;
 }
 
+/**
+ * Directive properties for a renderer, narrowed to a single layout's options
+ * when the directive block names one. An unrecognized or absent layout falls
+ * back to base properties only, since layout-specific options can't be
+ * resolved without a known layout.
+ */
 export function getRendererDirectiveCompletions(
-  rendererId: string,
+  rendererName: string,
+  layoutName?: string,
 ): Completion[] {
-  return rendererPropertyRegistry[rendererId]?.directives ?? [];
+  const entry = rendererPropertyRegistry[rendererName];
+  if (!entry) return [];
+  const normalizedLayout = layoutName?.trim().toLowerCase();
+  const isKnownLayout = (CYTOSCAPE_LAYOUT_NAMES as readonly string[]).includes(
+    normalizedLayout ?? "",
+  );
+  if (!isKnownLayout) return entry.directives;
+  return (
+    entry.directivesByLayout?.[normalizedLayout as CyLayoutName] ??
+    entry.directives
+  );
 }

--- a/src/autocomplete/rendererProperties.ts
+++ b/src/autocomplete/rendererProperties.ts
@@ -3,6 +3,7 @@ import {
   BACKGROUND_COLOR_PROPERTY,
   CYTOSCAPE_LAYOUT_NAMES,
   CYTOSCAPE_RENDERER_NAME,
+  DEFAULT_CYTOSCAPE_LAYOUT,
   DESCRIPTION_PREFIX,
   DESCRIPTION_PROPERTY,
   LAYOUT_PROPERTY,
@@ -269,11 +270,11 @@ const cytoscapeDirectiveCompletionsByLayout: Record<string, Completion[]> =
     ]),
   );
 
-// Offered when the active layout is unknown: base properties only, since
-// layout-specific option keys can't be resolved without a known layout.
-const cytoscapeDirectiveCompletions = buildCompletions(
-  CYTOSCAPE_DIRECTIVE_BASE_PROPERTIES,
-);
+// Offered when the directive names no layout, or names one that isn't
+// recognized. getLayoutName() resolves both of those cases to the default
+// layout, so those are the options the block will really accept.
+const cytoscapeDirectiveCompletions =
+  cytoscapeDirectiveCompletionsByLayout[DEFAULT_CYTOSCAPE_LAYOUT];
 
 interface RendererPropertyEntry {
   all: Completion[];
@@ -313,8 +314,8 @@ export function getRendererPropertyCompletionsByElementType(
 /**
  * Directive properties for a renderer, narrowed to a single layout's options
  * when the directive block names one. An unrecognized or absent layout falls
- * back to base properties only, since layout-specific options can't be
- * resolved without a known layout.
+ * back to the renderer's default-layout options, matching how the renderer
+ * itself resolves the layout name.
  */
 export function getRendererDirectiveCompletions(
   rendererName: string,

--- a/src/autocomplete/rendererPropertyCompleter.ts
+++ b/src/autocomplete/rendererPropertyCompleter.ts
@@ -52,7 +52,10 @@ export function createRendererPropertyCompletionSource(
       // A block addressed to another renderer has nothing we can suggest.
       activeProperties =
         contextScenario.rendererDirectiveName === rendererName
-          ? getRendererDirectiveCompletions(rendererName)
+          ? getRendererDirectiveCompletions(
+              rendererName,
+              contextScenario.rendererDirectiveLayout,
+            )
           : [];
     } else if (contextScenario?.globalStyleKeyword) {
       // Context scenario registered — use its element keyword
@@ -73,9 +76,11 @@ export function createRendererPropertyCompletionSource(
           );
         }
       } else if (directiveMatch) {
+        // The block's own 'layout:' declaration narrows what we can offer.
+        const layoutMatch = /\blayout\s*:\s*"?([\w-]+)"?/.exec(match.text);
         activeProperties =
           directiveMatch[1] === rendererName
-            ? getRendererDirectiveCompletions(rendererName)
+            ? getRendererDirectiveCompletions(rendererName, layoutMatch?.[1])
             : [];
       }
     }

--- a/src/cli/headlessCytoscape.ts
+++ b/src/cli/headlessCytoscape.ts
@@ -5,12 +5,14 @@ import { ExportFormat } from "../compiler/constants";
 import { makeCyElements } from "../renderers/cyDag/cyGraphFactory";
 import { makeCyStylesheets } from "../renderers/cyDag/cyStyleSheetsFactory";
 import { getCanvasBackgroundColor } from "../renderers/cyDag/cyRendererDirectives";
-import { makeDagreLayoutOptions } from "../renderers/cyDag/cyLayout";
+import { makeLayoutOptions } from "../renderers/cyDag/cyLayout";
+import { ensureLayoutRegistered } from "../renderers/cyDag/cyLayoutExtensions";
 import { exportCyToBlob } from "../renderers/cyDag/cyExport";
 import { addDescriptionGhostNodes } from "../renderers/cyDag/cyPopperExtender";
 
 const CONTAINER_WIDTH = 1024;
 const CONTAINER_HEIGHT = 768;
+const LAYOUT_TIMEOUT_MS = 60_000;
 
 function setGlobal(key: string, value: unknown): void {
   try {
@@ -91,9 +93,27 @@ function installCanvasShim(window: Window & typeof globalThis): void {
   const mimeToNapi = (mime: string) =>
     mime === "image/jpeg" ? "image/jpeg" : "image/png";
 
+  // Cytoscape's texture cache draws offscreen <canvas> elements onto the main
+  // one. Those elements are jsdom nodes, which @napi-rs/canvas rejects, so
+  // swap each one for the Skia canvas backing it before handing it over.
+  const patchedContexts = new WeakSet<object>();
+  const unwrapCanvas = (image: unknown): unknown =>
+    image instanceof window.HTMLCanvasElement ? ensure(image) : image;
+  const withCanvasUnwrapping = (context: object): object => {
+    if (patchedContexts.has(context)) return context;
+    patchedContexts.add(context);
+    const ctx = context as {
+      drawImage: (image: unknown, ...rest: number[]) => void;
+    };
+    const drawImage = ctx.drawImage.bind(ctx);
+    ctx.drawImage = (image: unknown, ...rest: number[]) =>
+      drawImage(unwrapCanvas(image), ...rest);
+    return context;
+  };
+
   proto.getContext = function (this: object, type: string) {
     if (type !== "2d") return null;
-    return ensure(this).getContext("2d");
+    return withCanvasUnwrapping(ensure(this).getContext("2d"));
   };
   proto.toDataURL = function (
     this: object,
@@ -171,7 +191,7 @@ export interface HeadlessRenderOptions {
 /**
  * Render a compiled Dag to image bytes headlessly (no browser).
  *
- * Reuses the exact same element/stylesheet factories, dagre layout options, and
+ * Reuses the exact same element/stylesheet factories, layout options, and
  * export logic as the web renderer so CLI output matches the app.
  */
 export async function renderDagToBytes(
@@ -183,11 +203,12 @@ export async function renderDagToBytes(
   // Dynamically import Cytoscape and its extensions AFTER the DOM globals are in
   // place; static imports would evaluate before the DOM exists.
   const cytoscape = (await import("cytoscape")).default;
-  const dagre = (await import("cytoscape-dagre")).default;
   // @ts-expect-error: cytoscape-svg ships no types
   const svg = (await import("cytoscape-svg")).default;
-  cytoscape.use(dagre);
   cytoscape.use(svg);
+
+  const layoutOptions = makeLayoutOptions(dag);
+  await ensureLayoutRegistered(cytoscape, layoutOptions.name);
 
   const container = document.createElement("div");
   document.body.appendChild(container);
@@ -197,21 +218,37 @@ export async function renderDagToBytes(
   });
   container.getBoundingClientRect = () =>
     getRect(CONTAINER_WIDTH, CONTAINER_HEIGHT);
+  // cy.size() subtracts the computed padding from clientWidth/clientHeight, and
+  // jsdom reports no padding at all for an unstyled div, which parses to NaN.
+  // Layouts that read the viewport (breadthfirst) then compute NaN positions.
+  container.style.padding = "0px";
 
   const cy = cytoscape({
     container,
     elements: makeCyElements(dag),
     style: makeCyStylesheets(dag, options.isDark),
     // Skip the default grid layout at construction (it reads the viewport, which
-    // is inert headless); we run dagre explicitly below.
+    // is inert headless); we run the selected layout explicitly below.
     layout: { name: "preset" },
   });
 
   try {
-    // Run the dagre layout and wait for it to settle before exporting.
-    await new Promise<void>((resolve) => {
-      cy.one("layoutstop", () => resolve());
-      cy.layout(makeDagreLayoutOptions(dag)).run();
+    // Run the layout and wait for it to settle before exporting. elk
+    // position nodes asynchronously, so the timeout keeps a layout that never
+    // reports back from hanging the CLI forever.
+    await new Promise<void>((resolve, reject) => {
+      const timer = setTimeout(() => {
+        reject(
+          new Error(
+            `Layout '${layoutOptions.name}' did not finish within ${LAYOUT_TIMEOUT_MS}ms`,
+          ),
+        );
+      }, LAYOUT_TIMEOUT_MS);
+      cy.one("layoutstop", () => {
+        clearTimeout(timer);
+        resolve();
+      });
+      cy.layout(layoutOptions).run();
     });
 
     // Description text is captured by invisible ghost nodes, mirroring the app's

--- a/src/compiler/constants.ts
+++ b/src/compiler/constants.ts
@@ -3,8 +3,26 @@ export const DESCRIPTION_PROPERTY: string = "description";
 export const DESCRIPTION_PREFIX: string = DESCRIPTION_PROPERTY + "-";
 export const BACKGROUND_COLOR_PROPERTY: string = "background-color";
 
-// Renderer directive property consumed by the cytoscape renderer's layout
-export const RANK_DIR_PROPERTY: string = "rankDir";
+// Renderer directive property selecting which cytoscape layout runs. The
+// options each layout accepts are named by its own provider (see
+// renderers/cyDag/layouts) rather than declared here, so a layout can be added
+// without touching the compiler.
+export const LAYOUT_PROPERTY: string = "layout";
+
+// Layouts selectable with '^cytoscape{ layout: "<name>" }'. All but 'manual'
+// are hierarchical layouts that position every node automatically.
+// https://blog.js.cytoscape.org/2020/05/11/layouts/#hierarchical-layouts
+export const CYTOSCAPE_LAYOUT_NAMES = [
+  "dagre",
+  "breadthfirst",
+  "elk",
+  "manual",
+] as const;
+export const DEFAULT_CYTOSCAPE_LAYOUT = "dagre";
+
+// 'manual' is not a layout algorithm: it turns the layout manager off and hands
+// node placement to the user, who drags nodes around in the rendered graph.
+export const MANUAL_CYTOSCAPE_LAYOUT = "manual";
 
 // Renderer names. These are the identifiers usable in a '^<rendererName>{ }'
 // directive and the keys used by useRendererRegistry and

--- a/src/components/OptionsPopup.vue
+++ b/src/components/OptionsPopup.vue
@@ -43,18 +43,6 @@
           ]"
           @update:model-value="$emit('update:themeMode', $event)"
         />
-        <v-select
-          label="Renderer"
-          hide-details="auto"
-          :model-value="selectedRenderer"
-          :items="
-            rendererOptions.map((opt) => ({
-              title: opt.name,
-              value: opt.id,
-            }))
-          "
-          @update:model-value="$emit('update:selectedRenderer', $event)"
-        />
       </v-card-text>
       <v-card-actions>
         <v-btn @click="$emit('update:showOptions', false)">
@@ -67,7 +55,7 @@
 </template>
 
 <script lang="ts">
-import { defineComponent, PropType } from "vue";
+import { defineComponent } from "vue";
 import { mdiCloseCircleOutline, mdiCogOutline } from "@mdi/js";
 export default defineComponent({
   name: "OptionsPopup",
@@ -88,21 +76,12 @@ export default defineComponent({
       type: String,
       required: true,
     },
-    selectedRenderer: {
-      type: String,
-      required: true,
-    },
-    rendererOptions: {
-      type: Array as PropType<Array<{ id: string; name: string }>>,
-      required: true,
-    },
   },
   emits: [
     "update:showOptions",
     "update:enableTabbingInEditor",
     "update:debugMode",
     "update:themeMode",
-    "update:selectedRenderer",
   ],
   setup() {
     return {

--- a/src/components/TextEditor.vue
+++ b/src/components/TextEditor.vue
@@ -148,7 +148,7 @@ export default defineComponent({
       type: Boolean,
       default: false,
     },
-    selectedRenderer: {
+    activeRenderer: {
       type: String,
       default: "",
     },
@@ -171,17 +171,17 @@ export default defineComponent({
 
     const createAutocompletion = (
       completionIndex?: CompletionIndex,
-      selectedRenderer?: string,
+      activeRenderer?: string,
     ) => {
       if (!completionIndex) {
         return autocompletion();
       }
       const sources = getAllDynamicCompletionSources(completionIndex);
-      if (selectedRenderer) {
+      if (activeRenderer) {
         sources.push(
           createRendererPropertyCompletionSource(
             completionIndex,
-            selectedRenderer,
+            activeRenderer,
           ),
         );
       }
@@ -302,7 +302,7 @@ export default defineComponent({
         }),
         keymapCompartment.of(getKeymap(this.enableTabbingInEditor)),
         autocompletionCompartment.of(
-          createAutocompletion(this.completionIndex, this.selectedRenderer),
+          createAutocompletion(this.completionIndex, this.activeRenderer),
         ),
         cursorTooltipCompartment.of(createCursorTooltip(this.debugMode)),
         readOnlyHeaderLengthField,
@@ -352,18 +352,18 @@ export default defineComponent({
       (completionIndex) => {
         view.dispatch({
           effects: autocompletionCompartment.reconfigure(
-            createAutocompletion(completionIndex, this.selectedRenderer),
+            createAutocompletion(completionIndex, this.activeRenderer),
           ),
         });
       },
     );
 
     watch(
-      () => this.selectedRenderer,
-      (selectedRenderer) => {
+      () => this.activeRenderer,
+      (activeRenderer) => {
         view.dispatch({
           effects: autocompletionCompartment.reconfigure(
-            createAutocompletion(this.completionIndex, selectedRenderer),
+            createAutocompletion(this.completionIndex, activeRenderer),
           ),
         });
       },

--- a/src/components/ToolBar.vue
+++ b/src/components/ToolBar.vue
@@ -90,6 +90,16 @@ export default defineComponent({
   align-items: center;
   gap: 0.5em;
   padding: 1em;
+  /* let clicks through the toolbar's empty padding and gaps
+     so nodes underneath stay draggable */
+  pointer-events: none;
+}
+.toolbar > * {
+  pointer-events: auto;
+}
+.toolbar h1 {
+  /* default heading margins inflate the toolbar's hit area */
+  margin: 0;
 }
 #logo {
   height: 2em;

--- a/src/composables/useRendererRegistry.ts
+++ b/src/composables/useRendererRegistry.ts
@@ -1,25 +1,31 @@
-import { ref, shallowRef, computed, watch, markRaw } from "vue";
+import { shallowRef, computed, markRaw } from "vue";
 import {
   CYTOSCAPE_RENDERER_NAME,
   ExportFormat,
   MINIMAL_RENDERER_NAME,
 } from "../compiler/constants";
+import { Dag } from "../compiler/dag";
 import { RendererComponent } from "../compiler/rendererTypes";
 import CytoscapeRenderer from "../renderers/cyDag/CytoscapeRenderer.vue";
 import MinimalExampleRenderer from "../renderers/minExample/MinimalExampleRenderer.vue";
 
-export function useRendererRegistry(
-  initialRenderer: string = CYTOSCAPE_RENDERER_NAME,
-  onRendererChanged?: () => void,
-) {
-  const registeredRenderers = new Map<string, RendererComponent>();
-  const selectedRenderer = ref(initialRenderer);
-  const rendererComponent = shallowRef<RendererComponent>(
-    markRaw(CytoscapeRenderer) as RendererComponent,
-  );
+/**
+ * Resolves which renderer draws the dag from the dag itself.
+ *
+ * A recipe selects its renderer with a '^<rendererName>{ }' directive. The
+ * compiler does not validate the name against this registry, so directives
+ * addressed to renderers that are not registered here are ignored. When a
+ * recipe names several registered renderers, the last one declared wins,
+ * matching the "later declarations override earlier" precedence used for
+ * style properties.
+ */
+export function useRendererRegistry(getDag: () => Dag) {
+  const registeredRenderers = shallowRef(new Map<string, RendererComponent>());
 
   function registerRenderer(id: string, renderer: RendererComponent): void {
-    registeredRenderers.set(id, renderer);
+    const updatedRenderers = new Map(registeredRenderers.value);
+    updatedRenderers.set(id, markRaw(renderer) as RendererComponent);
+    registeredRenderers.value = updatedRenderers;
   }
 
   // Register default renderers
@@ -32,11 +38,18 @@ export function useRendererRegistry(
     markRaw(MinimalExampleRenderer) as RendererComponent,
   );
 
-  const rendererOptions = computed(() =>
-    Array.from(registeredRenderers, ([id, renderer]) => ({
-      id,
-      name: renderer.displayName,
-    })),
+  const activeRendererName = computed<string>(() => {
+    const directiveNames = Array.from(getDag().getRendererDirectives().keys());
+    const selectedName = directiveNames.findLast((rendererName) =>
+      registeredRenderers.value.has(rendererName),
+    );
+    return selectedName ?? CYTOSCAPE_RENDERER_NAME;
+  });
+
+  const rendererComponent = computed<RendererComponent>(
+    () =>
+      registeredRenderers.value.get(activeRendererName.value) ??
+      (markRaw(CytoscapeRenderer) as RendererComponent),
   );
 
   const supportedExportFormats = computed<readonly ExportFormat[]>(
@@ -45,20 +58,9 @@ export function useRendererRegistry(
       Object.values(ExportFormat),
   );
 
-  watch(selectedRenderer, (newRendererId: string) => {
-    const renderer = registeredRenderers.get(newRendererId);
-    if (renderer) {
-      rendererComponent.value = renderer;
-      onRendererChanged?.();
-    } else {
-      console.error(`Renderer with id "${newRendererId}" not found`);
-    }
-  });
-
   return {
-    selectedRenderer,
+    activeRendererName,
     rendererComponent,
-    rendererOptions,
     supportedExportFormats,
     registerRenderer,
   };

--- a/src/optionsStore.ts
+++ b/src/optionsStore.ts
@@ -1,4 +1,3 @@
-import { CYTOSCAPE_RENDERER_NAME } from "./compiler/constants";
 import { VersionedStore } from "./versionedStore";
 
 export type ThemeMode = "light" | "dark" | "system";
@@ -6,18 +5,16 @@ export type ThemeMode = "light" | "dark" | "system";
 export interface Options {
   enableTabbingInEditor: boolean;
   debugMode: boolean;
-  selectedRenderer: string;
   themeMode?: ThemeMode;
 }
 
 const DEFAULTS: Options = {
   enableTabbingInEditor: false, // off by default to avoid focus trapping
   debugMode: false,
-  selectedRenderer: CYTOSCAPE_RENDERER_NAME,
 };
 
 export class OptionsStore extends VersionedStore<Options> {
   constructor() {
-    super("formulavize-options", 1, DEFAULTS);
+    super("formulavize-options", 2, DEFAULTS);
   }
 }

--- a/src/renderers/cyDag/CytoscapeRenderer.vue
+++ b/src/renderers/cyDag/CytoscapeRenderer.vue
@@ -7,8 +7,12 @@
 
 <script lang="ts">
 import { defineComponent, PropType } from "vue";
-import cytoscape, { Core, ElementsDefinition, StylesheetCSS } from "cytoscape";
-import dagre from "cytoscape-dagre";
+import cytoscape, {
+  Core,
+  ElementsDefinition,
+  Layouts,
+  StylesheetCSS,
+} from "cytoscape";
 import cytoscapePopper, {
   PopperFactory,
   PopperInstance,
@@ -25,10 +29,12 @@ import { makeCyElements } from "./cyGraphFactory";
 import { makeCyStylesheets } from "./cyStyleSheetsFactory";
 import { getCanvasBackgroundColor } from "./cyRendererDirectives";
 import {
-  makeDagreLayoutOptions,
-  getRankDirection,
-  RankDirection,
+  makeLayoutOptions,
+  getLayoutSignature,
+  getDagLayoutProvider,
 } from "./cyLayout";
+import { ensureLayoutRegistered } from "./cyLayoutExtensions";
+import { captureNodePositions, applyNodePositions } from "./cyNodePositions";
 import { exportCyToBlob } from "./cyExport";
 import {
   setupCyPoppers,
@@ -73,7 +79,8 @@ const popperFactory: PopperFactory = (
   return { update };
 };
 
-cytoscape.use(dagre);
+// Layout extensions register lazily in runLayout so the large elk bundle
+// are only fetched by recipes that ask for them.
 cytoscape.use(cytoscapePopper(popperFactory));
 cytoscape.use(svg);
 
@@ -87,10 +94,6 @@ const CytoscapeRenderer = defineComponent({
       type: Object as PropType<Dag>,
       required: true,
     },
-    lockPositions: {
-      type: Boolean,
-      default: true,
-    },
     isDark: {
       type: Boolean,
       default: false,
@@ -101,7 +104,8 @@ const CytoscapeRenderer = defineComponent({
       cy: null as Core | null,
       previousElements: null as ElementsDefinition | null,
       previousStylesheetsJson: null as string | null,
-      previousRankDir: undefined as RankDirection | undefined,
+      previousLayoutSignature: null as string | null,
+      runningLayout: null as Layouts | null,
       popperCleanup: null as PopperCleanup | null,
     };
   },
@@ -112,11 +116,6 @@ const CytoscapeRenderer = defineComponent({
     isDark() {
       this.applyThemeStyles();
     },
-    lockPositions(newValue: boolean) {
-      if (this.cy) {
-        this.cy.autoungrabify(newValue);
-      }
-    },
   },
   mounted(): void {
     this.initializeCytoscape();
@@ -124,6 +123,8 @@ const CytoscapeRenderer = defineComponent({
   beforeUnmount(): void {
     if (this.cy) {
       this.cy.destroy();
+      // A layout awaiting its extension checks this before touching the core.
+      this.cy = null;
     }
   },
   methods: {
@@ -131,17 +132,36 @@ const CytoscapeRenderer = defineComponent({
       this.cy = cytoscape({
         container: this.$refs.container as HTMLElement,
       });
-      this.cy.autoungrabify(this.lockPositions);
+      this.applyGrabbability();
       this.updateDag(this.dag);
     },
 
+    // A layout that places nothing needs its nodes draggable; otherwise the
+    // user could never manually arrange them.
+    applyGrabbability(): void {
+      if (!this.cy) return;
+      const { nodesAlwaysGrabbable } = getDagLayoutProvider(this.dag);
+      this.cy.autoungrabify(!nodesAlwaysGrabbable);
+    },
+
     // Layout is an expensive operation regardless of a change's size.
-    runLayout(): void {
-      Promise.resolve().then(() => {
-        if (this.cy) {
-          this.cy.layout(makeDagreLayoutOptions(this.dag)).run();
-        }
-      });
+    async runLayout(): Promise<void> {
+      const layoutOptions = makeLayoutOptions(this.dag);
+      try {
+        // Awaiting registration also keeps layout off the synchronous update
+        // path. elk is only downloaded when a recipe asks for it.
+        await ensureLayoutRegistered(cytoscape, layoutOptions.name);
+      } catch (error) {
+        console.error(`Failed to load the ${layoutOptions.name} layout`, error);
+        return;
+      }
+      // The component may have unmounted while the extension was downloading.
+      if (!this.cy) return;
+      // elk positions nodes asynchronously, so a superseded run has to
+      // be stopped or it would overwrite the newer layout's positions.
+      this.runningLayout?.stop();
+      this.runningLayout = this.cy.layout(layoutOptions);
+      this.runningLayout.run();
     },
 
     applyStyles(newStylesheets: StylesheetCSS[]): void {
@@ -177,6 +197,8 @@ const CytoscapeRenderer = defineComponent({
       const newElements = makeCyElements(dag);
       const newStylesheets = makeCyStylesheets(dag, this.isDark);
 
+      this.applyGrabbability();
+
       if (!this.previousElements) {
         // First render: full build
         this.cy.add(newElements);
@@ -187,12 +209,19 @@ const CytoscapeRenderer = defineComponent({
           dag,
           this.$refs.popperContainer as HTMLElement,
         );
-        this.previousRankDir = getRankDirection(dag);
+        this.previousLayoutSignature = getLayoutSignature(dag);
         this.runLayout();
       } else {
         const diff = diffCyElements(this.previousElements, newElements);
 
         if (diff.topologyChanged) {
+          // Layouts that preserve positions (such as manual mode) store node
+          // coordinates only in the Cytoscape graph instance, not in the DAG model.
+          // Capture current node positions by element ID so they survive the graph
+          // element rebuild below and are retained during the layout run.
+          const manualPositions = getDagLayoutProvider(dag).preservesPositions
+            ? captureNodePositions(this.cy)
+            : null;
           // Full replace to preserve elements' visual ordering in Dagre layout.
           // Re-added nodes would otherwise appear at the end of Cytoscape's
           // internal collection, causing Dagre's sort hint to lose to its
@@ -200,6 +229,7 @@ const CytoscapeRenderer = defineComponent({
           // This ensures we get consistent layouts for the same DAG structure.
           this.cy.elements().remove();
           this.cy.add(newElements);
+          if (manualPositions) applyNodePositions(this.cy, manualPositions);
         } else {
           applyDataUpdates(this.cy, diff);
         }
@@ -212,16 +242,16 @@ const CytoscapeRenderer = defineComponent({
           this.$refs.popperContainer as HTMLElement,
         );
 
-        // Editing only a '^cytoscape{ rankDir }' line leaves the element set
+        // Editing only a '^cytoscape{ layout }' line leaves the element set
         // identical, so the topology check alone would never relayout and the
-        // directive would appear to do nothing. Compare the resolved direction
-        // so an unrecognized value doesn't trigger a pointless relayout.
-        const rankDir = getRankDirection(dag);
-        const rankDirChanged = rankDir !== this.previousRankDir;
-        this.previousRankDir = rankDir;
+        // directive would appear to do nothing. Compare the resolved options so
+        // an unrecognized value doesn't trigger a pointless relayout.
+        const layoutSignature = getLayoutSignature(dag);
+        const layoutChanged = layoutSignature !== this.previousLayoutSignature;
+        this.previousLayoutSignature = layoutSignature;
 
         // Avoid unnecessary layout runs by checking if the topology has changed
-        if (diff.topologyChanged || rankDirChanged) this.runLayout();
+        if (diff.topologyChanged || layoutChanged) this.runLayout();
       }
 
       this.applyCanvasBackground();

--- a/src/renderers/cyDag/cyLayout.ts
+++ b/src/renderers/cyDag/cyLayout.ts
@@ -1,55 +1,96 @@
-import { LayoutOptions, NodeSingular } from "cytoscape";
+import {
+  BreadthFirstLayoutOptions,
+  LayoutOptions,
+  NodeSingular,
+  PresetLayoutOptions,
+} from "cytoscape";
 import { Dag } from "../../compiler/dag";
-import { RANK_DIR_PROPERTY } from "../../compiler/constants";
+import {
+  DEFAULT_CYTOSCAPE_LAYOUT,
+  CYTOSCAPE_LAYOUT_NAMES,
+  LAYOUT_PROPERTY,
+  MANUAL_CYTOSCAPE_LAYOUT,
+} from "../../compiler/constants";
 import { getCytoscapeDirectiveProperties } from "./cyRendererDirectives";
+import { buildLayoutOptions } from "./cyLayoutSchema";
+import { CyLayoutName, CyLayoutProvider, getLayoutProvider } from "./layouts";
 
-export const RANK_DIRECTIONS = ["TB", "BT", "LR", "RL"] as const;
-export type RankDirection = (typeof RANK_DIRECTIONS)[number];
+export type { CyLayoutName };
 
-// Dagre layout options type - refer to dagre documentation and cytoscape-dagre typings
-// https://github.com/cytoscape/cytoscape.js-dagre?tab=readme-ov-file#api
-// cytoscape's LayoutOptions has no rankDir and cytoscape-dagre ships no
-// typings, so the dagre-specific members are declared here.
+// cytoscape's LayoutOptions covers neither dagre's nor the elk extension's
+// members. None of those three ship typings, so they are declared here.
+// Refer to each layout's documentation for the full option set:
+// https://github.com/cytoscape/cytoscape.js-dagre#api
+// https://github.com/cytoscape/cytoscape.js-elk
 export type DagreLayoutOptions = LayoutOptions & {
   name: "dagre";
   sort: (a: NodeSingular, b: NodeSingular) => number;
-  rankDir?: RankDirection;
 };
 
-// We define a custom sort function to encourage the layout manager
-// to follow the insertion order of nodes in the DAG.
-// However, Dagre's crossing minimization may still rearrange nodes in a way
-// that doesn't preserve the insertion order.
-const sortByInsertionOrder = (A: NodeSingular, B: NodeSingular): number => {
-  const orderA: number[] = A.data("order") ?? [];
-  const orderB: number[] = B.data("order") ?? [];
-  for (let i = 0; i < Math.min(orderA.length, orderB.length); i++) {
-    if (orderA[i] !== orderB[i]) return orderA[i] - orderB[i];
-  }
-  return orderA.length - orderB.length;
+export type ElkLayoutOptions = LayoutOptions & {
+  name: "elk";
+  // Passed straight through to ELK as its layoutOptions map.
+  elk: Record<string, string>;
 };
+
+export type CyLayoutOptions =
+  | DagreLayoutOptions
+  | (BreadthFirstLayoutOptions & { name: "breadthfirst" })
+  | ElkLayoutOptions
+  // Preset is what the 'manual' layout runs; see layouts/manual.ts.
+  | PresetLayoutOptions;
 
 /**
- * Rank direction from a '^cytoscape{ rankDir: "LR" }' directive.
+ * Layout selected by a '^cytoscape{ layout: "elk" }' directive.
  *
- * Unrecognized values resolve to undefined so the key is omitted entirely and
- * dagre applies its own default ('TB'). Renderer directives are never
- * validated at compile time, so a typo silently changes nothing.
+ * Unrecognized layout names fall back to the default layout rather than erring:
+ * renderer directives are never validated at compile time, so a typo silently
+ * changes nothing.
  */
-export function getRankDirection(dag: Dag): RankDirection | undefined {
-  const value = getCytoscapeDirectiveProperties(dag).get(RANK_DIR_PROPERTY);
-  if (!value) return undefined;
-  const normalized = value.trim().toUpperCase();
-  return (RANK_DIRECTIONS as readonly string[]).includes(normalized)
-    ? (normalized as RankDirection)
-    : undefined;
+export function getLayoutName(dag: Dag): CyLayoutName {
+  const value = getCytoscapeDirectiveProperties(dag).get(LAYOUT_PROPERTY);
+  if (!value) return DEFAULT_CYTOSCAPE_LAYOUT;
+  const normalized = value.trim().toLowerCase();
+  return (CYTOSCAPE_LAYOUT_NAMES as readonly string[]).includes(normalized)
+    ? (normalized as CyLayoutName)
+    : DEFAULT_CYTOSCAPE_LAYOUT;
 }
 
-export function makeDagreLayoutOptions(dag: Dag): DagreLayoutOptions {
-  const rankDir = getRankDirection(dag);
-  return {
-    name: "dagre",
-    sort: sortByInsertionOrder,
-    ...(rankDir ? { rankDir } : {}),
-  } satisfies DagreLayoutOptions;
+/**
+ * Get the layout provider selected by the dag's renderer directive.
+ */
+export function getDagLayoutProvider(dag: Dag): CyLayoutProvider {
+  return getLayoutProvider(getLayoutName(dag));
+}
+
+/**
+ * Whether or not the dag allows users to manually position nodes instead
+ * of using a layout algorithm.
+ */
+export function isManualLayout(dag: Dag): boolean {
+  return getLayoutName(dag) === MANUAL_CYTOSCAPE_LAYOUT;
+}
+
+/**
+ * Cytoscape layout options for the layout selected by the dag's directive,
+ * with that layout's own options applied on top of our defaults.
+ */
+export function makeLayoutOptions(dag: Dag): CyLayoutOptions {
+  const layoutName = getLayoutName(dag);
+  const properties = getCytoscapeDirectiveProperties(dag);
+  // The schema builds a plain bag; each layout's shape is enforced by its table.
+  return buildLayoutOptions(
+    layoutName,
+    properties,
+  ) as unknown as CyLayoutOptions;
+}
+
+/**
+ * Value fingerprint of a dag's layout options, used to decide whether editing a
+ * directive needs a re-layout. JSON.stringify drops the function-valued options
+ * (the sort hints), so this signature compares only the serializable layout
+ * state and ignores comparator callbacks that do not affect the layout value.
+ */
+export function getLayoutSignature(dag: Dag): string {
+  return JSON.stringify(makeLayoutOptions(dag));
 }

--- a/src/renderers/cyDag/cyLayoutExtensions.ts
+++ b/src/renderers/cyDag/cyLayoutExtensions.ts
@@ -1,0 +1,40 @@
+import type cytoscape from "cytoscape";
+import { getLayoutProviderByCyName } from "./layouts";
+
+// The cytoscape module is taken as an argument rather than imported: the CLI
+// imports cytoscape only after installing its jsdom globals, so this module must
+// not pull the library in as a side effect of being loaded.
+type CytoscapeModule = typeof cytoscape;
+
+const registered = new Set<string>();
+
+/**
+ * Register the cytoscape extension backing a layout, at most once per process.
+ *
+ * Keyed by the cytoscape layout name (what a layout options bag carries in its
+ * 'name'), which is not necessarily the name in the recipe: 'manual' runs the
+ * built-in 'preset' layout. A layout whose provider declares no loader is built
+ * into cytoscape core and needs no registration.
+ *
+ * The loader lives on the provider (see layouts/), so elkjs is still imported
+ * on first use and code-split out of the main bundle.
+ */
+export async function ensureLayoutRegistered(
+  cy: CytoscapeModule,
+  layoutName: string,
+): Promise<void> {
+  if (registered.has(layoutName)) return;
+  const loadExtension = getLayoutProviderByCyName(layoutName)?.loadExtension;
+  if (!loadExtension) {
+    // for layouts built into cytoscape core, which need no registration
+    registered.add(layoutName);
+    return;
+  }
+  cy.use(await loadExtension());
+  registered.add(layoutName);
+}
+
+/** Test seam: forget which extensions have been registered. */
+export function resetRegisteredLayouts(): void {
+  registered.clear();
+}

--- a/src/renderers/cyDag/cyLayoutSchema.ts
+++ b/src/renderers/cyDag/cyLayoutSchema.ts
@@ -1,0 +1,74 @@
+import { StyleProperties } from "../../compiler/dag";
+import { getLayoutProvider } from "./layouts";
+import { CyLayoutName, LayoutOptionBag, OptionGroup } from "./layouts/types";
+
+export type { CyLayoutName };
+
+function setOption(
+  bag: LayoutOptionBag,
+  group: OptionGroup | undefined,
+  target: string,
+  value: unknown,
+): void {
+  if (!group) {
+    bag[target] = value;
+    return;
+  }
+  const groupBag = (bag[group] ?? {}) as LayoutOptionBag;
+  // ELK reads its layoutOptions as strings and parses them itself, so numbers
+  // and booleans are stringified rather than passed through as-is.
+  groupBag[target] = group === "elk" ? String(value) : value;
+  bag[group] = groupBag;
+}
+
+/**
+ * Build the cytoscape layout options for one layout from resolved directive
+ * properties. Keys the layout does not know are ignored, and values that fail
+ * to parse are dropped so the layout's own defaults apply.
+ */
+export function buildLayoutOptions(
+  layoutName: CyLayoutName,
+  properties: StyleProperties,
+): LayoutOptionBag {
+  const provider = getLayoutProvider(layoutName);
+  const options: LayoutOptionBag = {
+    name: provider.cyLayoutTargetName ?? layoutName,
+  };
+  for (const [key, value] of Object.entries(provider.defaultOptions)) {
+    // Clone group bags so a directive can never mutate the shared provider.
+    options[key] =
+      value && typeof value === "object" ? { ...(value as object) } : value;
+  }
+
+  const specsByKey = new Map(
+    provider.options.map((spec) => [spec.directiveKey, spec]),
+  );
+  for (const [key, rawValue] of properties) {
+    const spec = specsByKey.get(key);
+    if (spec) {
+      const parsed = spec.parse(rawValue);
+      if (parsed !== undefined) {
+        const group = spec.topLevel ? undefined : provider.optionGroup;
+        setOption(
+          options,
+          group,
+          spec.optionTargetKey ?? spec.directiveKey,
+          parsed,
+        );
+      }
+      continue;
+    }
+    // A layout may claim keys its option table does not list, forwarding the
+    // raw value; see the 'elk-*' escape hatch in layouts/elk.ts. Pass-through
+    // keys are always engine options, so they go straight into the group.
+    const extra = provider.extraOption?.(key);
+    if (extra) setOption(options, provider.optionGroup, extra, rawValue);
+  }
+
+  return options;
+}
+
+/** Returns directive keys a given layout understands, for autocomplete. */
+export function getLayoutOptionKeys(layoutName: CyLayoutName): string[] {
+  return getLayoutProvider(layoutName).options.map((spec) => spec.directiveKey);
+}

--- a/src/renderers/cyDag/cyNodePositions.ts
+++ b/src/renderers/cyDag/cyNodePositions.ts
@@ -1,0 +1,106 @@
+import { Core, NodeSingular, Position } from "cytoscape";
+
+export type NodePositions = Map<string, Position>;
+
+// How far below its predecessors a newly appeared node is dropped, and how far
+// each further new node is cascaded so a batch of them never lands in one pile.
+// Both are arbitrary pixel amounts chosen to clear a default-sized node.
+const SUCCESSOR_GAP = 100;
+const CASCADE_STEP = 30;
+
+/**
+ * Positions of the graph's leaf nodes, keyed by element id.
+ *
+ * Compound (namespace) nodes are skipped: cytoscape derives a parent's position
+ * from its children, and assigning one translates the whole subtree, so
+ * restoring a parent would move its children a second time.
+ */
+export function captureNodePositions(cy: Core): NodePositions {
+  const positions: NodePositions = new Map();
+  cy.nodes().forEach((node) => {
+    if (!node.isChildless()) return;
+    const { x, y } = node.position();
+    positions.set(node.id(), { x, y });
+  });
+  return positions;
+}
+
+// Somewhere visible for a node with nothing placed to anchor it to. cy.extent()
+// is the model-space rectangle currently on screen; manual mode does not refit
+// the viewport, so the origin may well be off screen by now.
+function viewportCenter(cy: Core): Position {
+  const extent = cy.extent();
+  return { x: (extent.x1 + extent.x2) / 2, y: (extent.y1 + extent.y2) / 2 };
+}
+
+// Below the node's placed predecessors, or above its placed successors, so a
+// node added mid-recipe shows up next to the nodes it connects to rather than
+// wherever the origin happens to be.
+function anchorToNeighbors(
+  node: NodeSingular,
+  placed: NodePositions,
+): Position | undefined {
+  // incomers/outgoers are typed as a mixed element collection even when
+  // filtered to nodes, and only the id is read here.
+  const positionsOf = (neighbors: { id(): string }[]): Position[] =>
+    neighbors
+      .map((neighbor) => placed.get(neighbor.id()))
+      .filter((position): position is Position => position !== undefined);
+
+  const incoming = positionsOf(node.incomers("node").toArray());
+  if (incoming.length > 0) {
+    const x = incoming.reduce((sum, p) => sum + p.x, 0) / incoming.length;
+    const y = Math.max(...incoming.map((p) => p.y));
+    return { x, y: y + SUCCESSOR_GAP };
+  }
+
+  const outgoing = positionsOf(node.outgoers("node").toArray());
+  if (outgoing.length > 0) {
+    const x = outgoing.reduce((sum, p) => sum + p.x, 0) / outgoing.length;
+    const y = Math.min(...outgoing.map((p) => p.y));
+    return { x, y: y - SUCCESSOR_GAP };
+  }
+
+  return undefined;
+}
+
+/**
+ * Put nodes back where they were, by id, and give any node that has no recorded
+ * position a visible one.
+ *
+ * Ids are stable across recompiles (see StableIdContext in dagFactory), so an
+ * edit that rebuilds the graph leaves a manually arranged node under the cursor
+ * it was dragged to. Ids with no surviving node are ignored.
+ *
+ * Every remembered node is restored before any new one is anchored, so a new
+ * node sees all of its surviving neighbors. New nodes are then visited in
+ * cytoscape's collection order, which is the dag's insertion order, so a chain
+ * of them anchors off the node before it rather than all landing in one spot.
+ */
+export function applyNodePositions(cy: Core, positions: NodePositions): void {
+  const placed: NodePositions = new Map();
+  const unplaced: NodeSingular[] = [];
+
+  cy.nodes().forEach((node) => {
+    if (!node.isChildless()) return;
+    const remembered = positions.get(node.id());
+    if (!remembered) {
+      unplaced.push(node);
+      return;
+    }
+    node.position(remembered);
+    placed.set(node.id(), remembered);
+  });
+
+  unplaced.forEach((node, cascade) => {
+    const anchor = anchorToNeighbors(node, placed) ?? viewportCenter(cy);
+    // Cascaded so that new nodes sharing an anchor (siblings off one
+    // predecessor, or nothing to anchor to at all) do not stack up.
+    const position = {
+      x: anchor.x + cascade * CASCADE_STEP,
+      y: anchor.y + cascade * CASCADE_STEP,
+    };
+    node.position(position);
+    placed.set(node.id(), position);
+  });
+}

--- a/src/renderers/cyDag/cyNodePositions.ts
+++ b/src/renderers/cyDag/cyNodePositions.ts
@@ -1,12 +1,16 @@
-import { Core, NodeSingular, Position } from "cytoscape";
+import { BoundingBox12, Core, NodeSingular, Position } from "cytoscape";
 
 export type NodePositions = Map<string, Position>;
 
-// How far below its predecessors a newly appeared node is dropped, and how far
-// each further new node is cascaded so a batch of them never lands in one pile.
-// Both are arbitrary pixel amounts chosen to clear a default-sized node.
+// How far below its predecessors a newly appeared node is dropped. An arbitrary
+// pixel amount chosen to clear a default-sized node.
 const SUCCESSOR_GAP = 100;
-const CASCADE_STEP = 30;
+// How far a new node is shifted, and how many times, when its first choice of
+// spot is already occupied. Diagonal so it escapes a column of nodes as
+// readily as a row of them, and small enough that it settles beside the
+// arrangement rather than being flung out of the viewport.
+const NUDGE_STEP = 30;
+const MAX_NUDGES = 200;
 
 /**
  * Positions of the graph's leaf nodes, keyed by element id.
@@ -64,6 +68,39 @@ function anchorToNeighbors(
   return undefined;
 }
 
+function boxesOverlap(a: BoundingBox12, b: BoundingBox12): boolean {
+  return a.x1 < b.x2 && b.x1 < a.x2 && a.y1 < b.y2 && b.y1 < a.y2;
+}
+
+/**
+ * Move a node to `anchor`, then step it away until it covers nothing.
+ *
+ * Labels sit under their node body (`text-valign: bottom`), so a new node
+ * dropped on an occupied spot hides the label of whatever is underneath it —
+ * from the outside that looks like labels vanishing, not like an overlap. The
+ * boxes therefore include labels, so a node clears the text as well as the
+ * bodies. Obstacles are the nodes placed so far, which is also what keeps a
+ * batch of new nodes from landing in one pile.
+ */
+function placeClearOfObstacles(
+  node: NodeSingular,
+  anchor: Position,
+  obstacles: NodeSingular[],
+): void {
+  const boxOf = (n: NodeSingular): BoundingBox12 =>
+    n.boundingBox({ includeLabels: true });
+  const isOccupied = (): boolean =>
+    obstacles.some((other) => boxesOverlap(boxOf(node), boxOf(other)));
+
+  node.position(anchor);
+  for (let nudge = 1; nudge <= MAX_NUDGES && isOccupied(); nudge++) {
+    node.position({
+      x: anchor.x + nudge * NUDGE_STEP,
+      y: anchor.y + nudge * NUDGE_STEP,
+    });
+  }
+}
+
 /**
  * Put nodes back where they were, by id, and give any node that has no recorded
  * position a visible one.
@@ -76,9 +113,13 @@ function anchorToNeighbors(
  * node sees all of its surviving neighbors. New nodes are then visited in
  * cytoscape's collection order, which is the dag's insertion order, so a chain
  * of them anchors off the node before it rather than all landing in one spot.
+ * Each is finally stepped clear of everything placed before it, since neither
+ * the viewport centre nor a fixed gap below a predecessor is guaranteed to be
+ * free.
  */
 export function applyNodePositions(cy: Core, positions: NodePositions): void {
   const placed: NodePositions = new Map();
+  const obstacles: NodeSingular[] = [];
   const unplaced: NodeSingular[] = [];
 
   cy.nodes().forEach((node) => {
@@ -90,17 +131,13 @@ export function applyNodePositions(cy: Core, positions: NodePositions): void {
     }
     node.position(remembered);
     placed.set(node.id(), remembered);
+    obstacles.push(node);
   });
 
-  unplaced.forEach((node, cascade) => {
+  unplaced.forEach((node) => {
     const anchor = anchorToNeighbors(node, placed) ?? viewportCenter(cy);
-    // Cascaded so that new nodes sharing an anchor (siblings off one
-    // predecessor, or nothing to anchor to at all) do not stack up.
-    const position = {
-      x: anchor.x + cascade * CASCADE_STEP,
-      y: anchor.y + cascade * CASCADE_STEP,
-    };
-    node.position(position);
-    placed.set(node.id(), position);
+    placeClearOfObstacles(node, anchor, obstacles);
+    placed.set(node.id(), node.position());
+    obstacles.push(node);
   });
 }

--- a/src/renderers/cyDag/cyPopperExtender.ts
+++ b/src/renderers/cyDag/cyPopperExtender.ts
@@ -232,6 +232,36 @@ function makePopperDiv(descriptionData: DescriptionData): HTMLDivElement {
   return outerDiv;
 }
 
+/**
+ * Top-left reference point poppers are anchored to, in rendered coordinates.
+ *
+ * Shifted down past the element's label so descriptions sit below it rather
+ * than overlapping it. Overlays are excluded from both boxes: cytoscape's
+ * default stylesheet gives an ':active' element an overlay, so a grabbed node's
+ * bounding box would otherwise grow by 'overlay-padding' on every side mid-drag
+ * and move the popper up and to the left until the next pan or zoom.
+ */
+export function getPopperReferencePosition(
+  ele: cytoscape.SingularElementReturnValue,
+): { x: number; y: number } {
+  const boundingBoxOptions = { includeOverlays: false };
+  const withLabels = ele.renderedBoundingBox({
+    ...boundingBoxOptions,
+    includeLabels: true,
+  });
+  const withoutLabels = ele.renderedBoundingBox({
+    ...boundingBoxOptions,
+    includeLabels: false,
+  });
+  // The label extends below the node body; shift the reference
+  // point down by that overhang so the popper clears the label.
+  const labelOverhang = withLabels.y2 - withoutLabels.y2;
+  return {
+    x: withoutLabels.x1,
+    y: withoutLabels.y1 + labelOverhang,
+  };
+}
+
 function makeDescriptionPoppers(
   cy: cytoscape.Core,
   canvasElement: HTMLElement,
@@ -245,20 +275,10 @@ function makeDescriptionPoppers(
         canvasElement.appendChild(popperDiv);
         return popperDiv;
       },
-      // Shift the reference point down so descriptions position below the
-      // label rather than overlapping it.
-      renderedPosition: (el) => {
-        const ele = el as unknown as cytoscape.SingularElementReturnValue;
-        const withLabels = ele.renderedBoundingBox({ includeLabels: true });
-        const withoutLabels = ele.renderedBoundingBox({ includeLabels: false });
-        // The label extends below the node body; shift the reference
-        // point down by that overhang so the popper clears the label.
-        const labelOverhang = withLabels.y2 - withoutLabels.y2;
-        return {
-          x: withoutLabels.x1,
-          y: withoutLabels.y1 + labelOverhang,
-        };
-      },
+      renderedPosition: (el) =>
+        getPopperReferencePosition(
+          el as unknown as cytoscape.SingularElementReturnValue,
+        ),
     });
     return [cyElement.id(), popperElement] as [string, PopperInstance];
   });

--- a/src/renderers/cyDag/layouts/breadthfirst.ts
+++ b/src/renderers/cyDag/layouts/breadthfirst.ts
@@ -1,0 +1,47 @@
+import { CyLayoutProvider, LayoutOptionSpec } from "./types";
+import {
+  parseBoolean,
+  parseEnum,
+  parsePositive,
+  sortByInsertionOrder,
+  lowerCase,
+  SHARED_OPTIONS,
+} from "./optionParsers";
+
+// https://js.cytoscape.org/#layouts/breadthfirst
+// Built into cytoscape core, so it needs no extension registration. Note that
+// breadthfirst ignores compound parents: a recipe using namespaces will draw
+// its children on top of the namespace box. 'roots' is deliberately not exposed
+// because it takes element ids, which are generated uuids a recipe cannot name.
+const BREADTHFIRST_OPTIONS: LayoutOptionSpec[] = [
+  {
+    directiveKey: "direction",
+    parse: parseEnum(
+      ["downward", "upward", "rightward", "leftward"],
+      lowerCase,
+    ),
+  },
+  {
+    directiveKey: "directed",
+    parse: parseBoolean,
+  },
+  { directiveKey: "circle", parse: parseBoolean },
+  { directiveKey: "grid", parse: parseBoolean },
+  { directiveKey: "maximal", parse: parseBoolean },
+  {
+    directiveKey: "avoidOverlap",
+    parse: parseBoolean,
+  },
+  {
+    directiveKey: "spacingFactor",
+    parse: parsePositive,
+  },
+  ...SHARED_OPTIONS,
+];
+
+export const breadthfirstLayout: CyLayoutProvider = {
+  layoutName: "breadthfirst",
+  // depthSort is breadthfirst's analogue of dagre's sort hint.
+  defaultOptions: { depthSort: sortByInsertionOrder, directed: true },
+  options: BREADTHFIRST_OPTIONS,
+};

--- a/src/renderers/cyDag/layouts/dagre.ts
+++ b/src/renderers/cyDag/layouts/dagre.ts
@@ -1,0 +1,57 @@
+import { CyLayoutProvider, LayoutOptionSpec } from "./types";
+import {
+  parseEnum,
+  parseNonNegative,
+  parsePositive,
+  sortByInsertionOrder,
+  upperCase,
+  lowerCase,
+  SHARED_OPTIONS,
+} from "./optionParsers";
+
+// https://github.com/cytoscape/cytoscape.js-dagre#api
+const DAGRE_OPTIONS: LayoutOptionSpec[] = [
+  {
+    directiveKey: "rankDir",
+    parse: parseEnum(["TB", "BT", "LR", "RL"], upperCase),
+  },
+  {
+    directiveKey: "align",
+    parse: parseEnum(["UL", "UR", "DL", "DR"], upperCase),
+  },
+  {
+    directiveKey: "ranker",
+    parse: parseEnum(
+      ["network-simplex", "tight-tree", "longest-path"],
+      lowerCase,
+    ),
+  },
+  {
+    directiveKey: "acyclicer",
+    parse: parseEnum(["greedy"], lowerCase),
+  },
+  {
+    directiveKey: "nodeSep",
+    parse: parseNonNegative,
+  },
+  {
+    directiveKey: "edgeSep",
+    parse: parseNonNegative,
+  },
+  {
+    directiveKey: "rankSep",
+    parse: parseNonNegative,
+  },
+  {
+    directiveKey: "spacingFactor",
+    parse: parsePositive,
+  },
+  ...SHARED_OPTIONS,
+];
+
+export const dagreLayout: CyLayoutProvider = {
+  layoutName: "dagre",
+  loadExtension: async () => (await import("cytoscape-dagre")).default,
+  defaultOptions: { sort: sortByInsertionOrder },
+  options: DAGRE_OPTIONS,
+};

--- a/src/renderers/cyDag/layouts/elk.ts
+++ b/src/renderers/cyDag/layouts/elk.ts
@@ -1,0 +1,150 @@
+import { CyLayoutProvider, LayoutOptionSpec } from "./types";
+import {
+  parseEnum,
+  parseNonNegative,
+  parseNumber,
+  parsePositive,
+  upperCase,
+  lowerCase,
+  SHARED_OPTIONS,
+} from "./optionParsers";
+
+// https://github.com/cytoscape/cytoscape.js-elk and
+// https://eclipse.dev/elk/reference/options.html
+// ELK option ids are dotted, but a fiz PropertyName is a cssIdentifier and
+// cannot contain '.', so they are written with dashes and rewritten on the way
+// out. Any 'elk-*' key not listed here is passed through with the same
+// rewriting (see extraOption below), which keeps the full ELK option namespace
+// reachable without curating all of it.
+export const ELK_KEY_PREFIX = "elk-";
+
+const ELK_OPTIONS: LayoutOptionSpec[] = [
+  {
+    directiveKey: "elk-algorithm",
+    // cytoscape-elk's own defaults use the bare 'algorithm' key for this one.
+    optionTargetKey: "algorithm",
+    parse: parseEnum(
+      [
+        "layered",
+        "mrtree",
+        "force",
+        "stress",
+        "radial",
+        "box",
+        "disco",
+        "random",
+      ],
+      lowerCase,
+    ),
+  },
+  {
+    directiveKey: "elk-direction",
+    optionTargetKey: "elk.direction",
+    parse: parseEnum(["DOWN", "UP", "RIGHT", "LEFT", "UNDEFINED"], upperCase),
+  },
+  {
+    directiveKey: "elk-edgeRouting",
+    optionTargetKey: "elk.edgeRouting",
+    parse: parseEnum(
+      ["ORTHOGONAL", "POLYLINE", "SPLINES", "UNDEFINED"],
+      upperCase,
+    ),
+  },
+  {
+    directiveKey: "elk-hierarchyHandling",
+    optionTargetKey: "elk.hierarchyHandling",
+    parse: parseEnum(
+      ["INCLUDE_CHILDREN", "SEPARATE_CHILDREN", "INHERIT"],
+      upperCase,
+    ),
+  },
+  {
+    directiveKey: "elk-aspectRatio",
+    optionTargetKey: "elk.aspectRatio",
+    parse: parsePositive,
+  },
+  {
+    directiveKey: "elk-randomSeed",
+    optionTargetKey: "elk.randomSeed",
+    parse: parseNumber({ isInteger: true }),
+  },
+  {
+    directiveKey: "elk-spacing-nodeNode",
+    optionTargetKey: "elk.spacing.nodeNode",
+    parse: parseNonNegative,
+  },
+  {
+    directiveKey: "elk-layered-spacing-nodeNodeBetweenLayers",
+    optionTargetKey: "elk.layered.spacing.nodeNodeBetweenLayers",
+    parse: parseNonNegative,
+  },
+  {
+    directiveKey: "elk-layered-nodePlacement-strategy",
+    optionTargetKey: "elk.layered.nodePlacement.strategy",
+    parse: parseEnum(
+      [
+        "SIMPLE",
+        "INTERACTIVE",
+        "LINEAR_SEGMENTS",
+        "BRANDES_KOEPF",
+        "NETWORK_SIMPLEX",
+      ],
+      upperCase,
+    ),
+  },
+  {
+    directiveKey: "elk-layered-crossingMinimization-strategy",
+    optionTargetKey: "elk.layered.crossingMinimization.strategy",
+    parse: parseEnum(["LAYER_SWEEP", "INTERACTIVE", "NONE"], upperCase),
+  },
+  {
+    directiveKey: "elk-layered-cycleBreaking-strategy",
+    optionTargetKey: "elk.layered.cycleBreaking.strategy",
+    parse: parseEnum(
+      [
+        "GREEDY",
+        "DEPTH_FIRST",
+        "INTERACTIVE",
+        "MODEL_ORDER",
+        "GREEDY_MODEL_ORDER",
+      ],
+      upperCase,
+    ),
+  },
+  {
+    directiveKey: "elk-layered-considerModelOrder-strategy",
+    optionTargetKey: "elk.layered.considerModelOrder.strategy",
+    parse: parseEnum(
+      ["NONE", "NODES_AND_EDGES", "PREFER_EDGES", "PREFER_NODES"],
+      upperCase,
+    ),
+  },
+  ...SHARED_OPTIONS,
+];
+
+// Rewrite an 'elk-*' directive key into its dotted ELK option id.
+function toElkOptionId(key: string): string {
+  return key.replace(/-/g, ".");
+}
+
+export const elkLayout: CyLayoutProvider = {
+  layoutName: "elk",
+  loadExtension: async () => (await import("cytoscape-elk")).default,
+  optionGroup: "elk",
+  defaultOptions: {
+    elk: {
+      algorithm: "layered",
+      // Namespaces become compound nodes with edges crossing their boundary,
+      // which ELK only routes correctly when children are included.
+      "elk.hierarchyHandling": "INCLUDE_CHILDREN",
+      // ELK's analogue of dagre's sort hint: cytoscape-elk builds the graph in
+      // collection order, which is the DAG's insertion order.
+      "elk.layered.considerModelOrder.strategy": "NODES_AND_EDGES",
+    },
+  },
+  options: ELK_OPTIONS,
+  // Unlisted 'elk-*' keys are an escape hatch to the rest of the ELK option
+  // namespace. They are unvalidated by design; ELK ignores ids it does not know.
+  extraOption: (key: string): string | undefined =>
+    key.startsWith(ELK_KEY_PREFIX) ? toElkOptionId(key) : undefined,
+};

--- a/src/renderers/cyDag/layouts/index.ts
+++ b/src/renderers/cyDag/layouts/index.ts
@@ -1,0 +1,47 @@
+import { CyLayoutName, CyLayoutProvider } from "./types";
+import { dagreLayout } from "./dagre";
+import { breadthfirstLayout } from "./breadthfirst";
+import { elkLayout } from "./elk";
+import { manualLayout } from "./manual";
+
+// Option names are taken as-is from each layout's own documentation rather
+// than normalized into a shared vocabulary, so the name in the recipe
+// reads the same as the upstream documentation.
+// Only one layout is active at a time, so keys that mean
+// different things in different layouts (e.g. 'direction') cannot collide.
+
+/**
+ * Selectable layouts keyed by the name a recipe writes in a renderer directive.
+ * e.g. '^cytoscape{ layout: "<name>" }'
+ *
+ * Typing this as a total Record over CyLayoutName keeps the registry
+ * and CYTOSCAPE_LAYOUT_NAMES in agreement: adding a name without a provider
+ * fails to compile.
+ */
+export const LAYOUT_PROVIDERS: Record<CyLayoutName, CyLayoutProvider> = {
+  dagre: dagreLayout,
+  breadthfirst: breadthfirstLayout,
+  elk: elkLayout,
+  manual: manualLayout,
+};
+
+export function getLayoutProvider(name: CyLayoutName): CyLayoutProvider {
+  return LAYOUT_PROVIDERS[name];
+}
+
+// A layout options bag carries the cytoscape name, which is not always the name
+// a recipe writes (e.g. 'manual' runs the built-in 'preset' layout),
+// so extension registration looks providers up by their cytoscape name.
+export function getLayoutProviderByCyName(
+  cyName: string,
+): CyLayoutProvider | undefined {
+  const providersByCyName = new Map<string, CyLayoutProvider>(
+    Object.values(LAYOUT_PROVIDERS).map((provider) => [
+      provider.cyLayoutTargetName ?? provider.layoutName,
+      provider,
+    ]),
+  );
+  return providersByCyName.get(cyName);
+}
+
+export type { CyLayoutName, CyLayoutProvider };

--- a/src/renderers/cyDag/layouts/manual.ts
+++ b/src/renderers/cyDag/layouts/manual.ts
@@ -1,0 +1,26 @@
+import { CyLayoutProvider, LayoutOptionSpec } from "./types";
+import { SHARED_OPTIONS } from "./optionParsers";
+
+// https://js.cytoscape.org/#layouts/preset
+// 'manual' hands placement to the user, so it runs cytoscape's 'preset' layout,
+// which leaves every node exactly where it already is. Only the options preset
+// understands are exposed; it has no notion of node dimensions or spacing.
+// 'positions', 'zoom' and 'pan' are omitted because they take coordinates,
+// which belong to the dragged graph rather than to the recipe.
+const MANUAL_OPTIONS: LayoutOptionSpec[] = SHARED_OPTIONS.filter(
+  (spec) => spec.directiveKey !== "nodeDimensionsIncludeLabels",
+);
+
+export const manualLayout: CyLayoutProvider = {
+  layoutName: "manual",
+  cyLayoutTargetName: "preset",
+  // Refitting the viewport every time the recipe changes would fight the user
+  // for control of the view, which is the one thing manual mode is for.
+  defaultOptions: { fit: false },
+  options: MANUAL_OPTIONS,
+  // Nothing places these nodes but the user, so they have to be draggable
+  // whatever the caller asked for, and their arrangement lives only in the
+  // graph — a rebuild has to carry it across by element id.
+  nodesAlwaysGrabbable: true,
+  preservesPositions: true,
+};

--- a/src/renderers/cyDag/layouts/optionParsers.ts
+++ b/src/renderers/cyDag/layouts/optionParsers.ts
@@ -1,0 +1,112 @@
+import { NodeSingular } from "cytoscape";
+import { z } from "zod";
+import { LayoutOptionSpec, OptionParser } from "./types";
+
+const toOptionParser = <T>(schema: z.ZodType<T>): OptionParser => {
+  return (raw: string) => {
+    const parsed = schema.safeParse(raw);
+    return parsed.success ? parsed.data : undefined;
+  };
+};
+
+export function parseEnum(
+  allowed: readonly string[],
+  normalize: (value: string) => string,
+): OptionParser {
+  const allowedSet = new Set(allowed);
+  const schema = z
+    .string()
+    .transform((value) => normalize(value.trim()))
+    .refine((value) => allowedSet.has(value));
+  return toOptionParser(schema);
+}
+
+export const upperCase = (value: string): string => value.toUpperCase();
+export const lowerCase = (value: string): string => value.toLowerCase();
+
+interface NumberConstraints {
+  min?: number;
+  max?: number;
+  isInteger?: boolean;
+}
+
+export function parseNumber(constraints: NumberConstraints = {}): OptionParser {
+  const { min, max, isInteger } = constraints;
+
+  let schema: z.ZodType<number> = z
+    .string()
+    .transform((value) => value.trim())
+    .refine((value) => value !== "")
+    .transform((value) => Number(value))
+    .refine((value) => Number.isFinite(value));
+
+  if (isInteger) schema = schema.refine((value) => Number.isInteger(value));
+  if (min !== undefined) schema = schema.refine((value) => value >= min);
+  if (max !== undefined) schema = schema.refine((value) => value <= max);
+
+  return toOptionParser(schema);
+}
+
+export const parseBoolean: OptionParser = toOptionParser(
+  z
+    .string()
+    .transform((value) => value.trim().toLowerCase())
+    .refine(
+      (value) =>
+        value === "true" || value === "false" || value === "1" || value === "0",
+    )
+    .transform((value) => value === "true" || value === "1"),
+);
+
+export const parseNonNegative = parseNumber({ min: 0 });
+export const parsePositive = parseNumber({ min: Number.MIN_VALUE });
+
+/**
+ * Sort hint encouraging a layout to follow the DAG's insertion order.
+ *
+ * 'order' is a list of insertion-order indices from root to node (see
+ * makeCyElements), so a lexicographic comparison preserves hierarchical
+ * ordering. Crossing minimization may still rearrange nodes despite the hint.
+ */
+export const sortByInsertionOrder = (
+  A: NodeSingular,
+  B: NodeSingular,
+): number => {
+  const orderA: number[] = A.data("order") ?? [];
+  const orderB: number[] = B.data("order") ?? [];
+  for (let i = 0; i < Math.min(orderA.length, orderB.length); i++) {
+    if (orderA[i] !== orderB[i]) return orderA[i] - orderB[i];
+  }
+  return orderA.length - orderB.length;
+};
+
+// Options every hierarchical layout understands at the top level. These are
+// read by cytoscape itself rather than by the layout engine, so they stay out
+// of the engine's option bag even for layouts that have one.
+export const SHARED_OPTIONS: LayoutOptionSpec[] = [
+  {
+    directiveKey: "fit",
+    topLevel: true,
+    parse: parseBoolean,
+  },
+  {
+    directiveKey: "padding",
+    topLevel: true,
+    parse: parseNonNegative,
+  },
+  {
+    directiveKey: "animate",
+    topLevel: true,
+    parse: parseBoolean,
+  },
+  {
+    directiveKey: "animationDuration",
+    topLevel: true,
+    parse: parseNonNegative,
+  },
+  {
+    directiveKey: "nodeDimensionsIncludeLabels",
+    topLevel: true,
+    parse: parseBoolean,
+  },
+];

--- a/src/renderers/cyDag/layouts/types.ts
+++ b/src/renderers/cyDag/layouts/types.ts
@@ -1,0 +1,76 @@
+import type cytoscape from "cytoscape";
+import { CYTOSCAPE_LAYOUT_NAMES } from "../../../compiler/constants";
+
+export type CyLayoutName = (typeof CYTOSCAPE_LAYOUT_NAMES)[number];
+
+// A directive value is always a string (StyleProperties is Map<string, string>),
+// so every option needs a parser. Returning undefined for anything unrecognized
+// implements the silent-fallback behavior: the key is omitted entirely
+// allowing the layout to apply its own default. Renderer directives are never
+// validated at compile time, so a typo silently changes nothing.
+export type OptionParser = (raw: string) => unknown;
+
+// Nested option bags. cytoscape-elk takes its engine settings in a dedicated
+// sub-object rather than at the top level.
+export type OptionGroup = "elk";
+
+export interface LayoutOptionSpec {
+  // The property name as written inside a '^cytoscape{ directiveKey: "value" }' directive.
+  directiveKey: string;
+  // The key in the emitted cytoscape layout options object.
+  // Omitted means it uses directiveKey as-is.
+  optionTargetKey?: string;
+  // A cytoscape-core option rather than one of the layout engine's own, so it
+  // stays at the top level even when the provider groups its engine options.
+  // Only SHARED_OPTIONS set this.
+  topLevel?: boolean;
+  parse: OptionParser;
+}
+
+export type LayoutOptionBag = Record<string, unknown>;
+
+/**
+ * Everything the renderer needs to know about a selectable layout.
+ *
+ * A provider is the single place a layout is described: the allowable options,
+ * the cytoscape extension backing it (if any), and the handful of
+ * renderer behaviors that depend on which layout is running. Adding a layout
+ * means adding one of these in the registry.
+ */
+export interface CyLayoutProvider {
+  // The name written in '^cytoscape{ layout: "<name>" }'.
+  layoutName: CyLayoutName;
+  // The Cytoscape layout this app-level name maps to.
+  // For example, we use 'manual' as our own name for Cytoscape’s built-in 'preset' layout.
+  // If cyLayoutTargetName is omitted, the app name and the Cytoscape name are the same.
+  cyLayoutTargetName?: string;
+  // Loads the cytoscape extension backing this layout. Omitted for layouts
+  // built into cytoscape core, which need no registration.
+  loadExtension?: () => Promise<cytoscape.Ext>;
+  // Applied before directive options so a recipe can always override them.
+  // May hold function-valued options, which directives can never express.
+  defaultOptions: LayoutOptionBag;
+  // The sub-object this layout's engine settings go in. Omitted optionGroup
+  // means the layout takes a flat options bag. Grouping is a property of the
+  // layout rather than of any one option, so it is declared once here; the only
+  // exceptions are the SHARED_OPTIONS, which are marked `topLevel`.
+  optionGroup?: OptionGroup;
+  options: LayoutOptionSpec[];
+  // The option id to use for a directive key that no spec in `options` claims.
+  // Such keys are always engine options, so they land in `optionGroup`.
+  // Layouts without an escape hatch omit it and unknown keys are ignored.
+  extraOption?: (key: string) => string | undefined;
+
+  // Renderer behaviors that depend on the running layout. All default to false
+  // or undefined, which is the behavior of every layout that places nodes
+  // itself; only 'manual' sets them.
+
+  // Nodes stay draggable even when a layout option or parent renderer requests
+  // fixed positions, otherwise the fixed-position override would make it
+  // impossible to manually arrange them in the manual layout.
+  nodesAlwaysGrabbable?: boolean;
+  // Node positions are not persisted in the underlying data; they exist only
+  // as runtime state in the graph, so a rebuild must carry positions across by
+  // element id rather than recompute them.
+  preservesPositions?: boolean;
+}

--- a/src/shims-cytoscape-ext.d.ts
+++ b/src/shims-cytoscape-ext.d.ts
@@ -1,0 +1,8 @@
+// cytoscape-elk ships no typings and has no @types package. It is a plain
+// cytoscape layout extension, so registering it is all we need typed; its
+// option shape is declared in renderers/cyDag/cyLayout.ts.
+declare module "cytoscape-elk" {
+  import { Ext } from "cytoscape";
+  const ext: Ext;
+  export default ext;
+}

--- a/tests/integration/composables/useCompilation.test.ts
+++ b/tests/integration/composables/useCompilation.test.ts
@@ -1,4 +1,4 @@
-import { describe, test, expect, vi, beforeEach } from "vitest";
+import { describe, test, expect, vi, beforeEach, afterEach } from "vitest";
 import { effectScope, nextTick } from "vue";
 import { flushPromises } from "@vue/test-utils";
 import { EditorState } from "@codemirror/state";
@@ -18,240 +18,189 @@ function createEditorStateFromSource(source: string): EditorState {
 describe("useCompilation", () => {
   let scope: ReturnType<typeof effectScope>;
 
+  // Watchers must be created inside an effect scope so their reactive
+  // effects are disposed with the test rather than leaking into the next one.
+  function setupCompilation(...args: Parameters<typeof useCompilation>) {
+    const compilation = scope.run(() => useCompilation(...args));
+    if (!compilation) throw new Error("effect scope was stopped before setup");
+    return compilation;
+  }
+
+  // Compilation is watcher driven and asynchronous, so let both the reactive
+  // update and the compiler promise resolve before asserting.
+  async function settle(): Promise<void> {
+    await nextTick();
+    await flushPromises();
+  }
+
   beforeEach(() => {
     scope = effectScope();
   });
 
-  test("initializes with default values", () => {
-    scope.run(() => {
-      const { curAst, curDag, curErrors, curDiagnostics, curImportDump } =
-        useCompilation(() => false);
-
-      expect(curAst.value).toBeInstanceOf(RecipeTreeNode);
-      expect(curDag.value).toBeInstanceOf(Dag);
-      expect(curErrors.value).toEqual([]);
-      expect(curDiagnostics.value).toEqual([]);
-      expect(curImportDump.value).toBe("(no imports)");
-    });
+  afterEach(() => {
     scope.stop();
+  });
+
+  test("initializes with default values", () => {
+    const { curAst, curDag, curErrors, curDiagnostics, curImportDump } =
+      setupCompilation(() => false);
+
+    expect(curAst.value).toBeInstanceOf(RecipeTreeNode);
+    expect(curDag.value).toBeInstanceOf(Dag);
+    expect(curErrors.value).toEqual([]);
+    expect(curDiagnostics.value).toEqual([]);
+    expect(curImportDump.value).toBe("(no imports)");
   });
 
   test("updateEditorState triggers compilation", async () => {
-    await scope.run(async () => {
-      const { updateEditorState, curDag } = useCompilation(() => false);
+    const { updateEditorState, curDag } = setupCompilation(() => false);
 
-      const editorState = createEditorStateFromSource("f()");
-      updateEditorState(editorState);
-      await nextTick();
-      await flushPromises();
+    updateEditorState(createEditorStateFromSource("f()"));
+    await settle();
 
-      expect(curDag.value.getNodeList()).toHaveLength(1);
-      expect(curDag.value.getNodeList()[0].name).toBe("f");
-    });
-    scope.stop();
+    expect(curDag.value.getNodeList()).toHaveLength(1);
+    expect(curDag.value.getNodeList()[0].name).toBe("f");
   });
 
   test("compilation with multiple nodes produces correct DAG", async () => {
-    await scope.run(async () => {
-      const { updateEditorState, curDag } = useCompilation(() => false);
+    const { updateEditorState, curDag } = setupCompilation(() => false);
 
-      const editorState = createEditorStateFromSource("a = f(); b = g(a);");
-      updateEditorState(editorState);
-      await nextTick();
-      await flushPromises();
+    updateEditorState(createEditorStateFromSource("a = f(); b = g(a);"));
+    await settle();
 
-      expect(curDag.value.getNodeList()).toHaveLength(2);
-      expect(curDag.value.getEdgeList()).toHaveLength(1);
-    });
-    scope.stop();
+    expect(curDag.value.getNodeList()).toHaveLength(2);
+    expect(curDag.value.getEdgeList()).toHaveLength(1);
   });
 
   test("compilation errors produce diagnostics", async () => {
-    await scope.run(async () => {
-      const { updateEditorState, curErrors, curDiagnostics } = useCompilation(
-        () => false,
-      );
+    const { updateEditorState, curErrors, curDiagnostics } = setupCompilation(
+      () => false,
+    );
 
-      // Reference an undefined variable
-      const editorState = createEditorStateFromSource("f(undefinedVar)");
-      updateEditorState(editorState);
-      await nextTick();
-      await flushPromises();
+    // Reference an undefined variable
+    updateEditorState(createEditorStateFromSource("f(undefinedVar)"));
+    await settle();
 
-      expect(curErrors.value.length).toBeGreaterThan(0);
-      expect(curDiagnostics.value.length).toBeGreaterThan(0);
-    });
-    scope.stop();
+    expect(curErrors.value.length).toBeGreaterThan(0);
+    expect(curDiagnostics.value.length).toBeGreaterThan(0);
   });
 
   test("onCompilationComplete callback is called", async () => {
-    await scope.run(async () => {
-      const callback = vi.fn();
-      const { updateEditorState } = useCompilation(() => false, callback);
+    const callback = vi.fn();
+    const { updateEditorState } = setupCompilation(() => false, callback);
 
-      const editorState = createEditorStateFromSource("f()");
-      updateEditorState(editorState);
-      await nextTick();
-      await flushPromises();
+    updateEditorState(createEditorStateFromSource("f()"));
+    await settle();
 
-      expect(callback).toHaveBeenCalledTimes(1);
-      expect(callback.mock.calls[0][0].DAG.getNodeList()).toHaveLength(1);
-    });
-    scope.stop();
+    expect(callback).toHaveBeenCalledTimes(1);
+    expect(callback.mock.calls[0][0].DAG.getNodeList()).toHaveLength(1);
   });
 
   test("repaint re-triggers compilation with same content", async () => {
-    await scope.run(async () => {
-      const callback = vi.fn();
-      const { updateEditorState, repaint } = useCompilation(
-        () => false,
-        callback,
-      );
+    const callback = vi.fn();
+    const { updateEditorState, repaint } = setupCompilation(
+      () => false,
+      callback,
+    );
 
-      const editorState = createEditorStateFromSource("f()");
-      updateEditorState(editorState);
-      await nextTick();
-      await flushPromises();
+    updateEditorState(createEditorStateFromSource("f()"));
+    await settle();
 
-      expect(callback).toHaveBeenCalledTimes(1);
+    expect(callback).toHaveBeenCalledTimes(1);
 
-      repaint();
-      await nextTick();
-      await flushPromises();
+    repaint();
+    await settle();
 
-      expect(callback).toHaveBeenCalledTimes(2);
-    });
-    scope.stop();
+    expect(callback).toHaveBeenCalledTimes(2);
   });
 
   test("shouldDumpImports controls import dump generation", async () => {
-    await scope.run(async () => {
-      // When shouldDumpImports returns false, import dump stays at default
-      const resultFalse = useCompilation(() => false);
-      const editorState1 = createEditorStateFromSource("f()");
-      resultFalse.updateEditorState(editorState1);
-      await nextTick();
-      await flushPromises();
-      expect(resultFalse.curImportDump.value).toBe("(no imports)");
-    });
-    scope.stop();
+    // When shouldDumpImports returns false, import dump stays at default
+    const resultFalse = setupCompilation(() => false);
+    resultFalse.updateEditorState(createEditorStateFromSource("f()"));
+    await settle();
+    expect(resultFalse.curImportDump.value).toBe("(no imports)");
 
     // When shouldDumpImports returns true, dumpImportTree is called
     // (still returns "(no imports)" for source with no imports, but the
     // code path is exercised)
-    scope = effectScope();
-    await scope.run(async () => {
-      const resultTrue = useCompilation(() => true);
-      const editorState2 = createEditorStateFromSource("f()");
-      resultTrue.updateEditorState(editorState2);
-      await nextTick();
-      await flushPromises();
-      // dumpImportTree returns "(no imports)" for source without imports
-      expect(resultTrue.curImportDump.value).toBe("(no imports)");
-    });
-    scope.stop();
+    const resultTrue = setupCompilation(() => true);
+    resultTrue.updateEditorState(createEditorStateFromSource("f()"));
+    await settle();
+    expect(resultTrue.curImportDump.value).toBe("(no imports)");
   });
 
   test("completion index is updated after compilation", async () => {
-    await scope.run(async () => {
-      const { updateEditorState, curCompletionIndex } = useCompilation(
-        () => false,
-      );
+    const { updateEditorState, curCompletionIndex } = setupCompilation(
+      () => false,
+    );
 
-      expect(curCompletionIndex.value).toBeInstanceOf(CompletionIndex);
+    expect(curCompletionIndex.value).toBeInstanceOf(CompletionIndex);
 
-      const editorState = createEditorStateFromSource("a = f()");
-      updateEditorState(editorState);
-      await nextTick();
-      await flushPromises();
+    updateEditorState(createEditorStateFromSource("a = f()"));
+    await settle();
 
-      // After compilation, the completion index should be rebuilt
-      expect(curCompletionIndex.value).toBeInstanceOf(CompletionIndex);
-    });
-    scope.stop();
+    // After compilation, the completion index should be rebuilt
+    expect(curCompletionIndex.value).toBeInstanceOf(CompletionIndex);
   });
 
   test("error reporter is updated with new document", async () => {
-    await scope.run(async () => {
-      const { updateEditorState, curErrorReporter } = useCompilation(
-        () => false,
-      );
+    const { updateEditorState, curErrorReporter } = setupCompilation(
+      () => false,
+    );
 
-      const editorState = createEditorStateFromSource("f()");
-      updateEditorState(editorState);
-      await nextTick();
-      await flushPromises();
+    updateEditorState(createEditorStateFromSource("f()"));
+    await settle();
 
-      // Error reporter should be created with the new document
-      expect(curErrorReporter.value).toBeDefined();
-    });
-    scope.stop();
+    // Error reporter should be created with the new document
+    expect(curErrorReporter.value).toBeDefined();
   });
 
   test("completion index is reused when AST structure is unchanged", async () => {
-    await scope.run(async () => {
-      const { updateEditorState, curCompletionIndex } = useCompilation(
-        () => false,
-      );
+    const { updateEditorState, curCompletionIndex } = setupCompilation(
+      () => false,
+    );
 
-      // First compilation
-      const editorState1 = createEditorStateFromSource("f()");
-      updateEditorState(editorState1);
-      await nextTick();
-      await flushPromises();
+    // First compilation
+    updateEditorState(createEditorStateFromSource("f()"));
+    await settle();
 
-      const firstIndex = curCompletionIndex.value;
+    const firstIndex = curCompletionIndex.value;
 
-      // Second compilation with trailing space — same AST structure
-      const editorState2 = createEditorStateFromSource("f() ");
-      updateEditorState(editorState2);
-      await nextTick();
-      await flushPromises();
+    // Second compilation with trailing space — same AST structure
+    updateEditorState(createEditorStateFromSource("f() "));
+    await settle();
 
-      // Reference identity should be preserved (no rebuild)
-      expect(curCompletionIndex.value).toBe(firstIndex);
-    });
-    scope.stop();
+    // Reference identity should be preserved (no rebuild)
+    expect(curCompletionIndex.value).toBe(firstIndex);
   });
 
   test("completion index is rebuilt when AST structure changes", async () => {
-    await scope.run(async () => {
-      const { updateEditorState, curCompletionIndex } = useCompilation(
-        () => false,
-      );
+    const { updateEditorState, curCompletionIndex } = setupCompilation(
+      () => false,
+    );
 
-      const editorState1 = createEditorStateFromSource("f()");
-      updateEditorState(editorState1);
-      await nextTick();
-      await flushPromises();
+    updateEditorState(createEditorStateFromSource("f()"));
+    await settle();
 
-      const firstIndex = curCompletionIndex.value;
+    const firstIndex = curCompletionIndex.value;
 
-      // Different AST structure — new node added
-      const editorState2 = createEditorStateFromSource("f(); g()");
-      updateEditorState(editorState2);
-      await nextTick();
-      await flushPromises();
+    // Different AST structure — new node added
+    updateEditorState(createEditorStateFromSource("f(); g()"));
+    await settle();
 
-      expect(curCompletionIndex.value).not.toBe(firstIndex);
-    });
-    scope.stop();
+    expect(curCompletionIndex.value).not.toBe(firstIndex);
   });
 
   test("empty source compiles without errors", async () => {
-    await scope.run(async () => {
-      const { updateEditorState, curErrors, curDag } = useCompilation(
-        () => false,
-      );
+    const { updateEditorState, curErrors, curDag } = setupCompilation(
+      () => false,
+    );
 
-      const editorState = createEditorStateFromSource("");
-      updateEditorState(editorState);
-      await nextTick();
-      await flushPromises();
+    updateEditorState(createEditorStateFromSource(""));
+    await settle();
 
-      expect(curErrors.value).toEqual([]);
-      expect(curDag.value.getNodeList()).toHaveLength(0);
-    });
-    scope.stop();
+    expect(curErrors.value).toEqual([]);
+    expect(curDag.value.getNodeList()).toHaveLength(0);
   });
 });

--- a/tests/integration/composables/useRendererRegistry.test.ts
+++ b/tests/integration/composables/useRendererRegistry.test.ts
@@ -1,4 +1,4 @@
-import { describe, test, expect, vi } from "vitest";
+import { describe, test, expect, vi, beforeEach, afterEach } from "vitest";
 import { effectScope, shallowRef, nextTick } from "vue";
 import { ExportFormat } from "src/compiler/constants";
 import { Dag, DagStyle } from "src/compiler/dag";
@@ -40,133 +40,113 @@ function makeDagWithDirectives(...rendererNames: string[]): Dag {
 describe("useRendererRegistry", () => {
   let scope: ReturnType<typeof effectScope>;
 
+  // Computeds must be created inside an effect scope so their reactive
+  // effects are disposed with the test rather than leaking into the next one.
+  function setupRegistry(getDag: () => Dag) {
+    const registry = scope.run(() => useRendererRegistry(getDag));
+    if (!registry) throw new Error("effect scope was stopped before setup");
+    return registry;
+  }
+
+  beforeEach(() => {
+    scope = effectScope();
+  });
+
+  afterEach(() => {
+    scope.stop();
+  });
+
   describe("renderer selection from renderer directives", () => {
     test("defaults to cytoscape when the dag declares no directive", () => {
-      scope = effectScope();
-      scope.run(() => {
-        const { activeRendererName, rendererComponent } = useRendererRegistry(
-          () => new Dag("empty-dag"),
-        );
-        expect(activeRendererName.value).toBe("cytoscape");
-        expect(rendererComponent.value.name).toBe("CytoscapeRenderer");
-      });
-      scope.stop();
+      const { activeRendererName, rendererComponent } = setupRegistry(
+        () => new Dag("empty-dag"),
+      );
+      expect(activeRendererName.value).toBe("cytoscape");
+      expect(rendererComponent.value.name).toBe("CytoscapeRenderer");
     });
 
     test("selects the renderer named by the directive", () => {
-      scope = effectScope();
-      scope.run(() => {
-        const { activeRendererName, rendererComponent } = useRendererRegistry(
-          () => makeDagWithDirectives("minimal"),
-        );
-        expect(activeRendererName.value).toBe("minimal");
-        expect(rendererComponent.value.name).toBe("MinimalExampleRenderer");
-      });
-      scope.stop();
+      const { activeRendererName, rendererComponent } = setupRegistry(() =>
+        makeDagWithDirectives("minimal"),
+      );
+      expect(activeRendererName.value).toBe("minimal");
+      expect(rendererComponent.value.name).toBe("MinimalExampleRenderer");
     });
 
     test("falls back to cytoscape for an unregistered renderer name", () => {
-      scope = effectScope();
-      scope.run(() => {
-        const { activeRendererName, rendererComponent } = useRendererRegistry(
-          () => makeDagWithDirectives("madeup"),
-        );
-        expect(activeRendererName.value).toBe("cytoscape");
-        expect(rendererComponent.value.name).toBe("CytoscapeRenderer");
-      });
-      scope.stop();
+      const { activeRendererName, rendererComponent } = setupRegistry(() =>
+        makeDagWithDirectives("madeup"),
+      );
+      expect(activeRendererName.value).toBe("cytoscape");
+      expect(rendererComponent.value.name).toBe("CytoscapeRenderer");
     });
 
     test("last declared registered renderer wins", () => {
-      scope = effectScope();
-      scope.run(() => {
-        const { activeRendererName } = useRendererRegistry(() =>
-          makeDagWithDirectives("cytoscape", "minimal"),
-        );
-        expect(activeRendererName.value).toBe("minimal");
-      });
-      scope.stop();
+      const { activeRendererName } = setupRegistry(() =>
+        makeDagWithDirectives("cytoscape", "minimal"),
+      );
+      expect(activeRendererName.value).toBe("minimal");
     });
 
     test("ignores unregistered names declared after a registered one", () => {
-      scope = effectScope();
-      scope.run(() => {
-        const { activeRendererName } = useRendererRegistry(() =>
-          makeDagWithDirectives("minimal", "madeup"),
-        );
-        expect(activeRendererName.value).toBe("minimal");
-      });
-      scope.stop();
+      const { activeRendererName } = setupRegistry(() =>
+        makeDagWithDirectives("minimal", "madeup"),
+      );
+      expect(activeRendererName.value).toBe("minimal");
     });
 
     test("tracks the renderer as the dag changes", async () => {
-      scope = effectScope();
-      await scope.run(async () => {
-        const curDag = shallowRef<Dag>(new Dag("empty-dag"));
-        const { activeRendererName, rendererComponent } = useRendererRegistry(
-          () => curDag.value,
-        );
-        expect(rendererComponent.value.name).toBe("CytoscapeRenderer");
+      const curDag = shallowRef<Dag>(new Dag("empty-dag"));
+      const { activeRendererName, rendererComponent } = setupRegistry(
+        () => curDag.value,
+      );
+      expect(rendererComponent.value.name).toBe("CytoscapeRenderer");
 
-        curDag.value = makeDagWithDirectives("minimal");
-        await nextTick();
+      curDag.value = makeDagWithDirectives("minimal");
+      await nextTick();
 
-        expect(activeRendererName.value).toBe("minimal");
-        expect(rendererComponent.value.name).toBe("MinimalExampleRenderer");
-      });
-      scope.stop();
+      expect(activeRendererName.value).toBe("minimal");
+      expect(rendererComponent.value.name).toBe("MinimalExampleRenderer");
     });
   });
 
   describe("supportedExportFormats", () => {
     test("returns the active renderer's formats", () => {
-      scope = effectScope();
-      scope.run(() => {
-        const { supportedExportFormats } = useRendererRegistry(
-          () => new Dag("empty-dag"),
-        );
-        expect(supportedExportFormats.value).toEqual([
-          ExportFormat.PNG,
-          ExportFormat.SVG,
-        ]);
-      });
-      scope.stop();
+      const { supportedExportFormats } = setupRegistry(
+        () => new Dag("empty-dag"),
+      );
+      expect(supportedExportFormats.value).toEqual([
+        ExportFormat.PNG,
+        ExportFormat.SVG,
+      ]);
     });
 
     test("follows the renderer the directive selects", () => {
-      scope = effectScope();
-      scope.run(() => {
-        const { supportedExportFormats } = useRendererRegistry(() =>
-          makeDagWithDirectives("minimal"),
-        );
-        expect(supportedExportFormats.value).toEqual([ExportFormat.PNG]);
-      });
-      scope.stop();
+      const { supportedExportFormats } = setupRegistry(() =>
+        makeDagWithDirectives("minimal"),
+      );
+      expect(supportedExportFormats.value).toEqual([ExportFormat.PNG]);
     });
   });
 
   describe("registerRenderer", () => {
     test("makes a new renderer name selectable by directive", async () => {
-      scope = effectScope();
-      await scope.run(async () => {
-        const curDag = shallowRef<Dag>(makeDagWithDirectives("custom"));
-        const { activeRendererName, rendererComponent, registerRenderer } =
-          useRendererRegistry(() => curDag.value);
+      const curDag = shallowRef<Dag>(makeDagWithDirectives("custom"));
+      const { activeRendererName, rendererComponent, registerRenderer } =
+        setupRegistry(() => curDag.value);
 
-        // Not registered yet, so the directive is ignored
-        expect(activeRendererName.value).toBe("cytoscape");
+      // Not registered yet, so the directive is ignored
+      expect(activeRendererName.value).toBe("cytoscape");
 
-        registerRenderer("custom", {
-          name: "CustomRenderer",
-          displayName: "Custom",
-          supportedExportFormats: [ExportFormat.TXT],
-        });
-        await nextTick();
-
-        expect(activeRendererName.value).toBe("custom");
-        expect(rendererComponent.value.name).toBe("CustomRenderer");
+      registerRenderer("custom", {
+        name: "CustomRenderer",
+        displayName: "Custom",
+        supportedExportFormats: [ExportFormat.TXT],
       });
-      scope.stop();
+      await nextTick();
+
+      expect(activeRendererName.value).toBe("custom");
+      expect(rendererComponent.value.name).toBe("CustomRenderer");
     });
   });
 });

--- a/tests/integration/composables/useRendererRegistry.test.ts
+++ b/tests/integration/composables/useRendererRegistry.test.ts
@@ -1,6 +1,7 @@
 import { describe, test, expect, vi } from "vitest";
-import { effectScope, nextTick } from "vue";
+import { effectScope, shallowRef, nextTick } from "vue";
 import { ExportFormat } from "src/compiler/constants";
+import { Dag, DagStyle } from "src/compiler/dag";
 
 // Mock the renderer components to avoid cytoscape-svg requiring window
 vi.mock("src/renderers/cyDag/CytoscapeRenderer.vue", () => ({
@@ -21,182 +22,151 @@ vi.mock("src/renderers/minExample/MinimalExampleRenderer.vue", () => ({
 
 import { useRendererRegistry } from "src/composables/useRendererRegistry";
 
+const EMPTY_STYLE: DagStyle = {
+  styleTags: [],
+  styleProperties: new Map<string, string>(),
+};
+
+// Build a dag carrying the renderer directives a recipe would declare,
+// in the order they appear in the source.
+function makeDagWithDirectives(...rendererNames: string[]): Dag {
+  const dag = new Dag("test-dag");
+  rendererNames.forEach((rendererName) =>
+    dag.addRendererDirective(rendererName, EMPTY_STYLE),
+  );
+  return dag;
+}
+
 describe("useRendererRegistry", () => {
   let scope: ReturnType<typeof effectScope>;
 
-  test("initializes with cytoscape as default renderer", () => {
-    scope = effectScope();
-    scope.run(() => {
-      const { selectedRenderer } = useRendererRegistry();
-      expect(selectedRenderer.value).toBe("cytoscape");
-    });
-    scope.stop();
-  });
-
-  test("initializes with custom default renderer", () => {
-    scope = effectScope();
-    scope.run(() => {
-      const { selectedRenderer } = useRendererRegistry("minimal");
-      expect(selectedRenderer.value).toBe("minimal");
-    });
-    scope.stop();
-  });
-
-  test("registers default renderers with display names", () => {
-    scope = effectScope();
-    scope.run(() => {
-      const { rendererOptions } = useRendererRegistry();
-      const options = rendererOptions.value;
-      expect(options).toHaveLength(2);
-      expect(options.map((o) => o.id)).toContain("cytoscape");
-      expect(options.map((o) => o.id)).toContain("minimal");
-      options.forEach((opt) => {
-        expect(opt.name).toBeTruthy();
+  describe("renderer selection from renderer directives", () => {
+    test("defaults to cytoscape when the dag declares no directive", () => {
+      scope = effectScope();
+      scope.run(() => {
+        const { activeRendererName, rendererComponent } = useRendererRegistry(
+          () => new Dag("empty-dag"),
+        );
+        expect(activeRendererName.value).toBe("cytoscape");
+        expect(rendererComponent.value.name).toBe("CytoscapeRenderer");
       });
+      scope.stop();
     });
-    scope.stop();
+
+    test("selects the renderer named by the directive", () => {
+      scope = effectScope();
+      scope.run(() => {
+        const { activeRendererName, rendererComponent } = useRendererRegistry(
+          () => makeDagWithDirectives("minimal"),
+        );
+        expect(activeRendererName.value).toBe("minimal");
+        expect(rendererComponent.value.name).toBe("MinimalExampleRenderer");
+      });
+      scope.stop();
+    });
+
+    test("falls back to cytoscape for an unregistered renderer name", () => {
+      scope = effectScope();
+      scope.run(() => {
+        const { activeRendererName, rendererComponent } = useRendererRegistry(
+          () => makeDagWithDirectives("madeup"),
+        );
+        expect(activeRendererName.value).toBe("cytoscape");
+        expect(rendererComponent.value.name).toBe("CytoscapeRenderer");
+      });
+      scope.stop();
+    });
+
+    test("last declared registered renderer wins", () => {
+      scope = effectScope();
+      scope.run(() => {
+        const { activeRendererName } = useRendererRegistry(() =>
+          makeDagWithDirectives("cytoscape", "minimal"),
+        );
+        expect(activeRendererName.value).toBe("minimal");
+      });
+      scope.stop();
+    });
+
+    test("ignores unregistered names declared after a registered one", () => {
+      scope = effectScope();
+      scope.run(() => {
+        const { activeRendererName } = useRendererRegistry(() =>
+          makeDagWithDirectives("minimal", "madeup"),
+        );
+        expect(activeRendererName.value).toBe("minimal");
+      });
+      scope.stop();
+    });
+
+    test("tracks the renderer as the dag changes", async () => {
+      scope = effectScope();
+      await scope.run(async () => {
+        const curDag = shallowRef<Dag>(new Dag("empty-dag"));
+        const { activeRendererName, rendererComponent } = useRendererRegistry(
+          () => curDag.value,
+        );
+        expect(rendererComponent.value.name).toBe("CytoscapeRenderer");
+
+        curDag.value = makeDagWithDirectives("minimal");
+        await nextTick();
+
+        expect(activeRendererName.value).toBe("minimal");
+        expect(rendererComponent.value.name).toBe("MinimalExampleRenderer");
+      });
+      scope.stop();
+    });
   });
 
-  test("renderer display names are correct", () => {
-    scope = effectScope();
-    scope.run(() => {
-      const { rendererOptions } = useRendererRegistry();
-      const cytoscape = rendererOptions.value.find((o) => o.id === "cytoscape");
-      const minimal = rendererOptions.value.find((o) => o.id === "minimal");
-      expect(cytoscape?.name).toBe("Cytoscape");
-      expect(minimal?.name).toBe("Minimal Example");
+  describe("supportedExportFormats", () => {
+    test("returns the active renderer's formats", () => {
+      scope = effectScope();
+      scope.run(() => {
+        const { supportedExportFormats } = useRendererRegistry(
+          () => new Dag("empty-dag"),
+        );
+        expect(supportedExportFormats.value).toEqual([
+          ExportFormat.PNG,
+          ExportFormat.SVG,
+        ]);
+      });
+      scope.stop();
     });
-    scope.stop();
+
+    test("follows the renderer the directive selects", () => {
+      scope = effectScope();
+      scope.run(() => {
+        const { supportedExportFormats } = useRendererRegistry(() =>
+          makeDagWithDirectives("minimal"),
+        );
+        expect(supportedExportFormats.value).toEqual([ExportFormat.PNG]);
+      });
+      scope.stop();
+    });
   });
 
-  test("switching renderer updates rendererComponent", async () => {
-    scope = effectScope();
-    await scope.run(async () => {
-      const { selectedRenderer, rendererComponent } = useRendererRegistry();
-      const initialComponent = rendererComponent.value;
+  describe("registerRenderer", () => {
+    test("makes a new renderer name selectable by directive", async () => {
+      scope = effectScope();
+      await scope.run(async () => {
+        const curDag = shallowRef<Dag>(makeDagWithDirectives("custom"));
+        const { activeRendererName, rendererComponent, registerRenderer } =
+          useRendererRegistry(() => curDag.value);
 
-      selectedRenderer.value = "minimal";
-      await nextTick();
+        // Not registered yet, so the directive is ignored
+        expect(activeRendererName.value).toBe("cytoscape");
 
-      expect(rendererComponent.value).not.toBe(initialComponent);
+        registerRenderer("custom", {
+          name: "CustomRenderer",
+          displayName: "Custom",
+          supportedExportFormats: [ExportFormat.TXT],
+        });
+        await nextTick();
+
+        expect(activeRendererName.value).toBe("custom");
+        expect(rendererComponent.value.name).toBe("CustomRenderer");
+      });
+      scope.stop();
     });
-    scope.stop();
-  });
-
-  test("switching renderer calls onRendererChanged callback", async () => {
-    scope = effectScope();
-    await scope.run(async () => {
-      const callback = vi.fn();
-      const { selectedRenderer } = useRendererRegistry("cytoscape", callback);
-
-      selectedRenderer.value = "minimal";
-      await nextTick();
-
-      expect(callback).toHaveBeenCalledTimes(1);
-    });
-    scope.stop();
-  });
-
-  test("switching to invalid renderer logs error and keeps current", async () => {
-    scope = effectScope();
-    await scope.run(async () => {
-      const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
-      const { selectedRenderer, rendererComponent } = useRendererRegistry();
-      const initialComponent = rendererComponent.value;
-
-      selectedRenderer.value = "nonexistent";
-      await nextTick();
-
-      expect(errorSpy).toHaveBeenCalledWith(
-        'Renderer with id "nonexistent" not found',
-      );
-      expect(rendererComponent.value).toBe(initialComponent);
-      errorSpy.mockRestore();
-    });
-    scope.stop();
-  });
-
-  test("invalid renderer does not call onRendererChanged", async () => {
-    scope = effectScope();
-    await scope.run(async () => {
-      const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
-      const callback = vi.fn();
-      const { selectedRenderer } = useRendererRegistry("cytoscape", callback);
-
-      selectedRenderer.value = "nonexistent";
-      await nextTick();
-
-      expect(callback).not.toHaveBeenCalled();
-      errorSpy.mockRestore();
-    });
-    scope.stop();
-  });
-
-  test("supportedExportFormats reflects current renderer", () => {
-    scope = effectScope();
-    scope.run(() => {
-      const { supportedExportFormats } = useRendererRegistry();
-      expect(supportedExportFormats.value).toEqual([
-        ExportFormat.PNG,
-        ExportFormat.SVG,
-      ]);
-    });
-    scope.stop();
-  });
-
-  test("supportedExportFormats updates when renderer changes", async () => {
-    scope = effectScope();
-    await scope.run(async () => {
-      const { selectedRenderer, supportedExportFormats } =
-        useRendererRegistry();
-      expect(supportedExportFormats.value).toEqual([
-        ExportFormat.PNG,
-        ExportFormat.SVG,
-      ]);
-
-      selectedRenderer.value = "minimal";
-      await nextTick();
-
-      expect(supportedExportFormats.value).toEqual([ExportFormat.PNG]);
-    });
-    scope.stop();
-  });
-
-  test("registerRenderer adds a new renderer option", () => {
-    scope = effectScope();
-    scope.run(() => {
-      const { registerRenderer, rendererOptions } = useRendererRegistry();
-      const mockRenderer = {
-        displayName: "Test Renderer",
-        supportedExportFormats: [],
-      };
-      registerRenderer("test", mockRenderer as never);
-
-      expect(rendererOptions.value).toHaveLength(3);
-      expect(rendererOptions.value.map((o) => o.id)).toContain("test");
-    });
-    scope.stop();
-  });
-
-  test("switching to newly registered renderer works", async () => {
-    scope = effectScope();
-    await scope.run(async () => {
-      const callback = vi.fn();
-      const { registerRenderer, selectedRenderer, rendererComponent } =
-        useRendererRegistry("cytoscape", callback);
-
-      const mockRenderer = {
-        displayName: "Custom",
-        supportedExportFormats: [],
-      };
-      registerRenderer("custom", mockRenderer as never);
-
-      selectedRenderer.value = "custom";
-      await nextTick();
-
-      expect(rendererComponent.value).toBe(mockRenderer);
-      expect(callback).toHaveBeenCalledTimes(1);
-    });
-    scope.stop();
   });
 });

--- a/tests/samples/layout_sample.fiz
+++ b/tests/samples/layout_sample.fiz
@@ -1,0 +1,19 @@
+// Layout selection and per-layout options live in the '^cytoscape' directive.
+// Swap the layout name to compare dagre, breadthfirst, and elk, or use
+// "manual" to turn the layout manager off and drag the nodes around yourself.
+^cytoscape{
+  layout: "elk"
+  elk-direction: "RIGHT"
+  elk-spacing-nodeNode: 40
+  padding: 30
+  // Booleans are written as 1/0 or "true"/"false": bare identifiers are not
+  // valid style values.
+  nodeDimensionsIncludeLabels: 1
+}
+
+raw = a()
+ingest[
+  cleaned = b(raw)
+  c(cleaned)
+]
+d(ingest.cleaned)

--- a/tests/unit/autocomplete/autocompletionFactory.test.ts
+++ b/tests/unit/autocomplete/autocompletionFactory.test.ts
@@ -223,11 +223,12 @@ describe("makeCompletionIndex captures context scenarios", () => {
       type: ContextScenarioType.StyleArgList,
       from: 11, // styleArgList.from + 1
       to: 19, // styleArgList.to - 1
-      rendererDirectiveId: "cytoscape",
+      rendererDirectiveName: "cytoscape",
+      rendererDirectiveLayout: undefined,
     });
   });
 
-  test("renderer directive carries an unregistered id through", async () => {
+  test("renderer directive carries an unregistered name through", async () => {
     const directiveNode = new RendererDirective(
       "madeup",
       new Style(new Map(), [], pos(10, 20)),
@@ -237,7 +238,21 @@ describe("makeCompletionIndex captures context scenarios", () => {
     const index = await makeCompletionIndex([directiveNode]);
 
     expect(index.contextScenarios[0]).toMatchObject({
-      rendererDirectiveId: "madeup",
+      rendererDirectiveName: "madeup",
+    });
+  });
+
+  test("renderer directive carries its declared layout", async () => {
+    const directiveNode = new RendererDirective(
+      "cytoscape",
+      new Style(new Map([["layout", "elk"]]), [], pos(10, 20)),
+      pos(0, 25),
+    );
+
+    const index = await makeCompletionIndex([directiveNode]);
+
+    expect(index.contextScenarios[0]).toMatchObject({
+      rendererDirectiveLayout: "elk",
     });
   });
 

--- a/tests/unit/autocomplete/rendererProperties.test.ts
+++ b/tests/unit/autocomplete/rendererProperties.test.ts
@@ -3,6 +3,7 @@ import {
   getRendererPropertyCompletions,
   getRendererDirectiveCompletions,
 } from "src/autocomplete/rendererProperties";
+import { DEFAULT_CYTOSCAPE_LAYOUT } from "src/compiler/constants";
 
 describe("rendererProperties", () => {
   test("cytoscape returns a non-empty array", () => {
@@ -51,11 +52,19 @@ describe("renderer directive completions", () => {
     expect(getRendererDirectiveCompletions("nonexistent")).toEqual([]);
   });
 
-  test("an unknown layout offers only base properties", () => {
+  test("an absent layout offers the default layout's properties", () => {
+    // A directive block that names no layout still gets one: the renderer
+    // resolves the missing name to the default layout, so those are the
+    // options the block will really honour.
+    expect(getRendererDirectiveCompletions("cytoscape")).toEqual(
+      getRendererDirectiveCompletions("cytoscape", DEFAULT_CYTOSCAPE_LAYOUT),
+    );
     const labels = getRendererDirectiveCompletions("cytoscape").map(
       (c) => c.label,
     );
-    expect(labels).toEqual(["background-color", "layout"]);
+    expect(labels).toContain("background-color");
+    expect(labels).toContain("layout");
+    expect(labels).toContain("rankDir");
   });
 
   test("a declared layout narrows the offered options", () => {
@@ -86,7 +95,7 @@ describe("renderer directive completions", () => {
     );
   });
 
-  test("an unrecognized layout falls back to base properties", () => {
+  test("an unrecognized layout falls back to the default layout", () => {
     expect(getRendererDirectiveCompletions("cytoscape", "elkk")).toEqual(
       getRendererDirectiveCompletions("cytoscape"),
     );

--- a/tests/unit/autocomplete/rendererProperties.test.ts
+++ b/tests/unit/autocomplete/rendererProperties.test.ts
@@ -31,7 +31,7 @@ describe("rendererProperties", () => {
 
 describe("renderer directive completions", () => {
   test("cytoscape directives cover the supported keys", () => {
-    const labels = getRendererDirectiveCompletions("cytoscape").map(
+    const labels = getRendererDirectiveCompletions("cytoscape", "dagre").map(
       (c) => c.label,
     );
     expect(labels).toContain("rankDir");
@@ -49,5 +49,46 @@ describe("renderer directive completions", () => {
   test("renderer without directives returns empty array", () => {
     expect(getRendererDirectiveCompletions("minimal")).toEqual([]);
     expect(getRendererDirectiveCompletions("nonexistent")).toEqual([]);
+  });
+
+  test("an unknown layout offers only base properties", () => {
+    const labels = getRendererDirectiveCompletions("cytoscape").map(
+      (c) => c.label,
+    );
+    expect(labels).toEqual(["background-color", "layout"]);
+  });
+
+  test("a declared layout narrows the offered options", () => {
+    const labels = getRendererDirectiveCompletions("cytoscape", "elk").map(
+      (c) => c.label,
+    );
+    expect(labels).toContain("elk-direction");
+    expect(labels).toContain("layout");
+    expect(labels).not.toContain("rankDir");
+    expect(labels).not.toContain("thoroughness");
+  });
+
+  test("the manual layout offers only what it can honour", () => {
+    const labels = getRendererDirectiveCompletions("cytoscape", "manual").map(
+      (c) => c.label,
+    );
+    expect(labels).toContain("layout");
+    expect(labels).toContain("padding");
+    // Nothing that would imply the renderer positions nodes for you.
+    expect(labels).not.toContain("rankDir");
+    expect(labels).not.toContain("spacingFactor");
+    expect(labels).not.toContain("nodeDimensionsIncludeLabels");
+  });
+
+  test("layout names are matched case-insensitively", () => {
+    expect(getRendererDirectiveCompletions("cytoscape", " ELK ")).toEqual(
+      getRendererDirectiveCompletions("cytoscape", "elk"),
+    );
+  });
+
+  test("an unrecognized layout falls back to base properties", () => {
+    expect(getRendererDirectiveCompletions("cytoscape", "elkk")).toEqual(
+      getRendererDirectiveCompletions("cytoscape"),
+    );
   });
 });

--- a/tests/unit/autocomplete/rendererPropertyCompleter.test.ts
+++ b/tests/unit/autocomplete/rendererPropertyCompleter.test.ts
@@ -206,7 +206,10 @@ describe("rendererPropertyCompleter", () => {
 });
 
 describe("renderer directive completions", () => {
-  function makeDirectiveIndex(rendererDirectiveName: string): CompletionIndex {
+  function makeDirectiveIndex(
+    rendererDirectiveName: string,
+    rendererDirectiveLayout?: string,
+  ): CompletionIndex {
     return new CompletionIndex(
       [],
       [
@@ -215,6 +218,7 @@ describe("renderer directive completions", () => {
           from: 10,
           to: 30,
           rendererDirectiveName: rendererDirectiveName,
+          rendererDirectiveLayout: rendererDirectiveLayout,
         },
       ],
       [],
@@ -259,6 +263,50 @@ describe("renderer directive completions", () => {
     const labels = result!.options.map((o) => o.label);
     expect(labels).toContain("background-color");
     expect(labels).not.toContain("background-opacity");
+  });
+
+  test("a declared layout narrows the indexed directive properties", async () => {
+    const completionIndex = new CompletionIndex(
+      [],
+      [
+        {
+          type: ContextScenarioType.StyleArgList,
+          from: 10,
+          to: 60,
+          rendererDirectiveName: "cytoscape",
+          rendererDirectiveLayout: "elk",
+        },
+      ],
+      [],
+    );
+    const source = createRendererPropertyCompletionSource(
+      completionIndex,
+      "cytoscape",
+    );
+    const text = '^cytoscape{ layout:"elk"; elk-';
+    const result = await runSource(
+      source,
+      createMockContext(text.length, text, false),
+    );
+    expect(result).not.toBeNull();
+    const labels = result!.options.map((o) => o.label);
+    expect(labels).toContain("elk-direction");
+  });
+
+  test("regex fallback reads the layout from the raw text", async () => {
+    const source = createRendererPropertyCompletionSource(
+      new CompletionIndex([], [], []),
+      "cytoscape",
+    );
+    const text = '^cytoscape{ layout:"elk"; elk-';
+    const result = await runSource(
+      source,
+      createMockContext(text.length, text, false),
+    );
+    expect(result).not.toBeNull();
+    const labels = result!.options.map((o) => o.label);
+    expect(labels).toContain("elk-direction");
+    expect(labels).not.toContain("rankDir");
   });
 
   test("regex fallback offers nothing for another renderer", async () => {

--- a/tests/unit/cli/headlessCytoscape.test.ts
+++ b/tests/unit/cli/headlessCytoscape.test.ts
@@ -124,6 +124,71 @@ describe("headless CLI rendering", () => {
     expect(otherRenderer.toString("utf8")).toEqual(baseline.toString("utf8"));
   });
 
+  test.each(["breadthfirst", "elk"])(
+    "the %s layout renders headlessly and moves nodes",
+    async (layoutName) => {
+      const recipe = "a = alpha()\nbeta(a)\n";
+      const svgOptions = {
+        fileType: ExportFormat.SVG,
+        includeDescriptions: false,
+      };
+      const baseline = await render(recipe, svgOptions);
+      const rendered = await render(
+        `^cytoscape{ layout: "${layoutName}" }\n${recipe}`,
+        svgOptions,
+      );
+      const svg = rendered.toString("utf8");
+      expect(svg).toContain("<svg");
+      expect(svg).toContain("alpha");
+      expect(svg).not.toEqual(baseline.toString("utf8"));
+    },
+    30_000,
+  );
+
+  test("the manual layout leaves nodes unarranged headlessly", async () => {
+    const recipe = "a = alpha()\nbeta(a)\n";
+    const svgOptions = {
+      fileType: ExportFormat.SVG,
+      includeDescriptions: false,
+    };
+    const baseline = await render(recipe, svgOptions);
+    const manual = await render(
+      `^cytoscape{ layout: "manual" }\n${recipe}`,
+      svgOptions,
+    );
+    const manualSvg = manual.toString("utf8");
+    expect(manualSvg).not.toEqual(baseline.toString("utf8"));
+    expect(manualSvg).toMatch(/<svg[^>]*width="46" height="50"/);
+  });
+
+  test("a layout option changes the rendered layout", async () => {
+    const recipe = "a = alpha()\nbeta(a)\n";
+    const svgOptions = {
+      fileType: ExportFormat.SVG,
+      includeDescriptions: false,
+    };
+    const baseline = await render(recipe, svgOptions);
+    const spaced = await render(
+      `^cytoscape{ rankSep: 300 }\n${recipe}`,
+      svgOptions,
+    );
+    expect(spaced.toString("utf8")).not.toEqual(baseline.toString("utf8"));
+  });
+
+  test("unrecognized layout falls back to the default layout", async () => {
+    const recipe = "a = alpha()\nbeta(a)\n";
+    const svgOptions = {
+      fileType: ExportFormat.SVG,
+      includeDescriptions: false,
+    };
+    const baseline = await render(recipe, svgOptions);
+    const typo = await render(
+      `^cytoscape{ layout: "elkk" }\n${recipe}`,
+      svgOptions,
+    );
+    expect(typo.toString("utf8")).toEqual(baseline.toString("utf8"));
+  });
+
   test("scaling factor increases the rendered image size", async () => {
     const small = await render("a = load()\nprocess(a)\n", {
       scalingFactor: 1,

--- a/tests/unit/optionsStore.test.ts
+++ b/tests/unit/optionsStore.test.ts
@@ -19,16 +19,11 @@ describe("OptionsStore", () => {
     expect(new OptionsStore().load().debugMode).toBe(false);
   });
 
-  test("defaults to cytoscape renderer", () => {
-    expect(new OptionsStore().load().selectedRenderer).toBe("cytoscape");
-  });
-
   test("round-trips all option fields", () => {
     const store = new OptionsStore();
     const options = {
       enableTabbingInEditor: true,
       debugMode: true,
-      selectedRenderer: "minimal",
     };
     store.save(options);
     expect(store.load()).toEqual(options);

--- a/tests/unit/renderers/cyDag/cyLayout.test.ts
+++ b/tests/unit/renderers/cyDag/cyLayout.test.ts
@@ -2,8 +2,10 @@ import { describe, test, expect } from "vitest";
 import { NodeSingular } from "cytoscape";
 import { Dag } from "src/compiler/dag";
 import {
-  getRankDirection,
-  makeDagreLayoutOptions,
+  getLayoutName,
+  getLayoutSignature,
+  isManualLayout,
+  makeLayoutOptions,
 } from "src/renderers/cyDag/cyLayout";
 
 function makeDagWithDirective(
@@ -18,41 +20,93 @@ function makeDagWithDirective(
   return dag;
 }
 
+// The layout options are a discriminated union; tests read them as a plain bag.
+type OptionBag = Record<string, unknown>;
+
+function optionsFor(properties: [string, string][]): OptionBag {
+  const dag = makeDagWithDirective("cytoscape", properties);
+  return makeLayoutOptions(dag) as unknown as OptionBag;
+}
+
+function groupFor(properties: [string, string][], group: string): OptionBag {
+  return optionsFor(properties)[group] as OptionBag;
+}
+
 // Minimal stand-in for a cytoscape node exposing only data("order"),
 // which is all the sort hint reads.
 function makeOrderedNode(order: number[]): NodeSingular {
   return { data: () => order } as unknown as NodeSingular;
 }
 
+type SortHint = (a: NodeSingular, b: NodeSingular) => number;
+
+describe("layout selection", () => {
+  test("no directive uses the default layout", () => {
+    const dag = new Dag("DagId");
+    expect(getLayoutName(dag)).toBe("dagre");
+    expect(makeLayoutOptions(dag).name).toBe("dagre");
+  });
+  test.each(["dagre", "breadthfirst", "elk"])(
+    "%s is selectable",
+    (layoutName) => {
+      const dag = makeDagWithDirective("cytoscape", [["layout", layoutName]]);
+      expect(getLayoutName(dag)).toBe(layoutName);
+      expect(makeLayoutOptions(dag).name).toBe(layoutName);
+    },
+  );
+  test("manual is selectable and runs cytoscape's preset layout", () => {
+    const dag = makeDagWithDirective("cytoscape", [["layout", "manual"]]);
+    expect(getLayoutName(dag)).toBe("manual");
+    expect(makeLayoutOptions(dag).name).toBe("preset");
+  });
+  test("case and surrounding whitespace are tolerated", () => {
+    const dag = makeDagWithDirective("cytoscape", [["layout", " ELK "]]);
+    expect(getLayoutName(dag)).toBe("elk");
+  });
+  test("unrecognized layout falls back to the default", () => {
+    // Directives are not validated, so a typo silently renders as usual.
+    const dag = makeDagWithDirective("cytoscape", [["layout", "elkk"]]);
+    expect(getLayoutName(dag)).toBe("dagre");
+  });
+  test("directive for another renderer is ignored", () => {
+    const dag = makeDagWithDirective("minimal", [["layout", "elk"]]);
+    expect(getLayoutName(dag)).toBe("dagre");
+  });
+  test("layout resolves through a style tag", () => {
+    const dag = new Dag("DagId");
+    dag.setStyle("hierarchical", new Map([["layout", "elk"]]));
+    dag.addRendererDirective("cytoscape", {
+      styleTags: [["hierarchical"]],
+      styleProperties: new Map(),
+    });
+    expect(getLayoutName(dag)).toBe("elk");
+  });
+});
+
+// rankDir is dagre's own option, resolved by its entry in the dagre provider's
+// option table like any other; these cover the directive reaching the emitted
+// options bag rather than a rankDir-specific code path.
 describe("rank direction resolution", () => {
   test("no directive leaves rankDir unset", () => {
-    const dag = new Dag("DagId");
-    expect(getRankDirection(dag)).toBeUndefined();
-    expect(makeDagreLayoutOptions(dag)).not.toHaveProperty("rankDir");
+    expect(makeLayoutOptions(new Dag("DagId"))).not.toHaveProperty("rankDir");
   });
   test("recognized direction is applied", () => {
-    const dag = makeDagWithDirective("cytoscape", [["rankDir", "LR"]]);
-    expect(getRankDirection(dag)).toBe("LR");
-    expect(makeDagreLayoutOptions(dag).rankDir).toBe("LR");
+    expect(optionsFor([["rankDir", "LR"]]).rankDir).toBe("LR");
   });
   test("lowercase direction is normalized", () => {
-    const dag = makeDagWithDirective("cytoscape", [["rankDir", "lr"]]);
-    expect(getRankDirection(dag)).toBe("LR");
+    expect(optionsFor([["rankDir", "lr"]]).rankDir).toBe("LR");
   });
   test("surrounding whitespace is tolerated", () => {
-    const dag = makeDagWithDirective("cytoscape", [["rankDir", " BT "]]);
-    expect(getRankDirection(dag)).toBe("BT");
+    expect(optionsFor([["rankDir", " BT "]]).rankDir).toBe("BT");
   });
   test("unrecognized direction is omitted entirely", () => {
     // Directives are not validated, so a typo silently falls back to the
     // dagre default rather than emitting an invalid option.
-    const dag = makeDagWithDirective("cytoscape", [["rankDir", "sideways"]]);
-    expect(getRankDirection(dag)).toBeUndefined();
-    expect(makeDagreLayoutOptions(dag)).not.toHaveProperty("rankDir");
+    expect(optionsFor([["rankDir", "sideways"]])).not.toHaveProperty("rankDir");
   });
   test("directive for another renderer is ignored", () => {
     const dag = makeDagWithDirective("minimal", [["rankDir", "LR"]]);
-    expect(getRankDirection(dag)).toBeUndefined();
+    expect(makeLayoutOptions(dag)).not.toHaveProperty("rankDir");
   });
   test("rankDir resolves through a style tag", () => {
     const dag = new Dag("DagId");
@@ -61,31 +115,236 @@ describe("rank direction resolution", () => {
       styleTags: [["compact"]],
       styleProperties: new Map(),
     });
-    expect(getRankDirection(dag)).toBe("RL");
+    const options = makeLayoutOptions(dag) as unknown as OptionBag;
+    expect(options.rankDir).toBe("RL");
   });
 });
 
 describe("dagre layout options", () => {
-  test("layout name is always dagre", () => {
-    expect(makeDagreLayoutOptions(new Dag("DagId")).name).toBe("dagre");
+  test("layout name is dagre by default", () => {
+    expect(makeLayoutOptions(new Dag("DagId")).name).toBe("dagre");
   });
   test("insertion order sort hint is preserved", () => {
-    const { sort } = makeDagreLayoutOptions(new Dag("DagId"));
+    const sort = optionsFor([]).sort as SortHint;
     expect(sort(makeOrderedNode([0]), makeOrderedNode([1]))).toBeLessThan(0);
     expect(sort(makeOrderedNode([2]), makeOrderedNode([1]))).toBeGreaterThan(0);
     expect(sort(makeOrderedNode([1]), makeOrderedNode([1]))).toBe(0);
   });
   test("sort hint compares nested lineage order", () => {
-    const { sort } = makeDagreLayoutOptions(new Dag("DagId"));
+    const sort = optionsFor([]).sort as SortHint;
     expect(sort(makeOrderedNode([1, 0]), makeOrderedNode([1, 1]))).toBeLessThan(
       0,
     );
     expect(sort(makeOrderedNode([1]), makeOrderedNode([1, 0]))).toBeLessThan(0);
   });
   test("sort hint is present alongside a rankDir", () => {
-    const dag = makeDagWithDirective("cytoscape", [["rankDir", "LR"]]);
-    const options = makeDagreLayoutOptions(dag);
+    const options = optionsFor([["rankDir", "LR"]]);
     expect(options.rankDir).toBe("LR");
     expect(typeof options.sort).toBe("function");
+  });
+  test("spacing options are parsed as numbers", () => {
+    const options = optionsFor([
+      ["nodeSep", "40"],
+      ["rankSep", "80"],
+      ["edgeSep", "10"],
+    ]);
+    expect(options.nodeSep).toBe(40);
+    expect(options.rankSep).toBe(80);
+    expect(options.edgeSep).toBe(10);
+  });
+  test("non-numeric spacing is dropped", () => {
+    expect(optionsFor([["nodeSep", "wide"]])).not.toHaveProperty("nodeSep");
+  });
+  test("negative spacing is dropped", () => {
+    expect(optionsFor([["nodeSep", "-5"]])).not.toHaveProperty("nodeSep");
+  });
+  test("spacingFactor must be strictly positive", () => {
+    expect(optionsFor([["spacingFactor", "1.5"]]).spacingFactor).toBe(1.5);
+    expect(optionsFor([["spacingFactor", "0"]])).not.toHaveProperty(
+      "spacingFactor",
+    );
+  });
+  test("enum options are normalized", () => {
+    expect(optionsFor([["ranker", "TIGHT-TREE"]]).ranker).toBe("tight-tree");
+    expect(optionsFor([["align", "ul"]]).align).toBe("UL");
+  });
+  test("options belonging to another layout are ignored", () => {
+    expect(optionsFor([["thoroughness", "9"]])).not.toHaveProperty(
+      "thoroughness",
+    );
+  });
+});
+
+describe("breadthfirst layout options", () => {
+  const asBreadthfirst = (
+    properties: [string, string][] = [],
+  ): [string, string][] => [["layout", "breadthfirst"], ...properties];
+
+  test("defaults carry a depth sort hint and directed edges", () => {
+    const options = optionsFor(asBreadthfirst());
+    expect(options.name).toBe("breadthfirst");
+    expect(typeof options.depthSort).toBe("function");
+    expect(options.directed).toBe(true);
+  });
+  test("defaults are overridable", () => {
+    expect(optionsFor(asBreadthfirst([["directed", "false"]])).directed).toBe(
+      false,
+    );
+  });
+  test("direction is normalized to lower case", () => {
+    expect(
+      optionsFor(asBreadthfirst([["direction", "RIGHTWARD"]])).direction,
+    ).toBe("rightward");
+  });
+  test("booleans accept numeric literals", () => {
+    const options = optionsFor(
+      asBreadthfirst([
+        ["circle", "1"],
+        ["grid", "0"],
+      ]),
+    );
+    expect(options.circle).toBe(true);
+    expect(options.grid).toBe(false);
+  });
+  test("unparseable booleans are dropped", () => {
+    expect(optionsFor(asBreadthfirst([["maximal", "yes"]]))).not.toHaveProperty(
+      "maximal",
+    );
+  });
+  test("dagre options are ignored", () => {
+    expect(optionsFor(asBreadthfirst([["rankDir", "LR"]]))).not.toHaveProperty(
+      "rankDir",
+    );
+  });
+});
+
+describe("elk layout options", () => {
+  const asElk = (properties: [string, string][] = []): [string, string][] => [
+    ["layout", "elk"],
+    ...properties,
+  ];
+
+  test("defaults handle compound nodes and model order", () => {
+    const elk = groupFor(asElk(), "elk");
+    expect(elk.algorithm).toBe("layered");
+    expect(elk["elk.hierarchyHandling"]).toBe("INCLUDE_CHILDREN");
+    expect(elk["elk.layered.considerModelOrder.strategy"]).toBe(
+      "NODES_AND_EDGES",
+    );
+  });
+  test("dashed keys become dotted elk option ids", () => {
+    const elk = groupFor(asElk([["elk-direction", "right"]]), "elk");
+    expect(elk["elk.direction"]).toBe("RIGHT");
+  });
+  test("algorithm overrides the default under the bare key", () => {
+    const elk = groupFor(asElk([["elk-algorithm", "MrTree"]]), "elk");
+    expect(elk.algorithm).toBe("mrtree");
+  });
+  test("numeric options are stringified for elk", () => {
+    const elk = groupFor(asElk([["elk-spacing-nodeNode", "40"]]), "elk");
+    expect(elk["elk.spacing.nodeNode"]).toBe("40");
+  });
+  test("unlisted elk keys pass through unvalidated", () => {
+    const elk = groupFor(asElk([["elk-spacing-edgeNode", "12"]]), "elk");
+    expect(elk["elk.spacing.edgeNode"]).toBe("12");
+  });
+  test("unparseable values leave the default in place", () => {
+    const elk = groupFor(asElk([["elk-algorithm", "spaghetti"]]), "elk");
+    expect(elk.algorithm).toBe("layered");
+  });
+  test("shared options stay at the top level", () => {
+    const options = optionsFor(asElk([["padding", "30"]]));
+    expect(options.padding).toBe(30);
+    expect(groupFor(asElk([["padding", "30"]]), "elk")).not.toHaveProperty(
+      "padding",
+    );
+  });
+  test("elk keys are ignored by other layouts", () => {
+    expect(optionsFor([["elk-direction", "RIGHT"]])).not.toHaveProperty("elk");
+  });
+  test("schema defaults are not mutated between calls", () => {
+    groupFor(asElk([["elk-algorithm", "force"]]), "elk");
+    expect(groupFor(asElk(), "elk").algorithm).toBe("layered");
+  });
+});
+
+describe("manual layout options", () => {
+  const asManual = (
+    properties: [string, string][] = [],
+  ): [string, string][] => [["layout", "manual"], ...properties];
+
+  test("is reported as manual only when selected", () => {
+    expect(isManualLayout(makeDagWithDirective("cytoscape", asManual()))).toBe(
+      true,
+    );
+    expect(isManualLayout(new Dag("DagId"))).toBe(false);
+    expect(
+      isManualLayout(makeDagWithDirective("cytoscape", [["layout", "elk"]])),
+    ).toBe(false);
+  });
+  test("defaults leave the viewport where the user put it", () => {
+    expect(optionsFor(asManual()).fit).toBe(false);
+  });
+  test("viewport options are overridable", () => {
+    const options = optionsFor(
+      asManual([
+        ["fit", "true"],
+        ["padding", "40"],
+      ]),
+    );
+    expect(options.fit).toBe(true);
+    expect(options.padding).toBe(40);
+  });
+  test("carries no sort hint, having nothing to order", () => {
+    expect(optionsFor(asManual())).not.toHaveProperty("sort");
+  });
+  test("options belonging to a positioning layout are ignored", () => {
+    const options = optionsFor(
+      asManual([
+        ["rankDir", "LR"],
+        ["spacingFactor", "2"],
+        ["nodeDimensionsIncludeLabels", "true"],
+      ]),
+    );
+    expect(options).not.toHaveProperty("rankDir");
+    expect(options).not.toHaveProperty("spacingFactor");
+    expect(options).not.toHaveProperty("nodeDimensionsIncludeLabels");
+  });
+});
+
+describe("layout signature", () => {
+  test("is stable for the same directive", () => {
+    const properties: [string, string][] = [
+      ["layout", "elk"],
+      ["elk-direction", "RIGHT"],
+    ];
+    const first = makeDagWithDirective("cytoscape", properties);
+    const second = makeDagWithDirective("cytoscape", properties);
+    expect(getLayoutSignature(first)).toBe(getLayoutSignature(second));
+  });
+  test("changes when an option changes", () => {
+    const before = makeDagWithDirective("cytoscape", [["nodeSep", "40"]]);
+    const after = makeDagWithDirective("cytoscape", [["nodeSep", "80"]]);
+    expect(getLayoutSignature(before)).not.toBe(getLayoutSignature(after));
+  });
+  test("changes when the layout changes", () => {
+    const before = makeDagWithDirective("cytoscape", [["layout", "dagre"]]);
+    const after = makeDagWithDirective("cytoscape", [["layout", "elk"]]);
+    expect(getLayoutSignature(before)).not.toBe(getLayoutSignature(after));
+  });
+  test("ignores an unrecognized value that changes nothing", () => {
+    const plain = makeDagWithDirective("cytoscape", []);
+    const typo = makeDagWithDirective("cytoscape", [["nodeSep", "wide"]]);
+    expect(getLayoutSignature(plain)).toBe(getLayoutSignature(typo));
+  });
+  test("changes when a positioning layout is swapped for manual", () => {
+    // Editing only the layout line leaves the element set identical, so the
+    // renderer relies on this to notice it should stop repositioning nodes.
+    const before = makeDagWithDirective("cytoscape", [["layout", "dagre"]]);
+    const after = makeDagWithDirective("cytoscape", [["layout", "manual"]]);
+    expect(getLayoutSignature(before)).not.toBe(getLayoutSignature(after));
+  });
+  test("omits the function-valued sort hints", () => {
+    expect(getLayoutSignature(new Dag("DagId"))).not.toContain("sort");
   });
 });

--- a/tests/unit/renderers/cyDag/cyLayoutExtensions.test.ts
+++ b/tests/unit/renderers/cyDag/cyLayoutExtensions.test.ts
@@ -1,0 +1,53 @@
+import { describe, test, expect, beforeEach, vi } from "vitest";
+import cytoscape from "cytoscape";
+import {
+  ensureLayoutRegistered,
+  resetRegisteredLayouts,
+} from "src/renderers/cyDag/cyLayoutExtensions";
+
+// Only 'use' is exercised, so a stub stands in for the cytoscape module.
+function makeCytoscapeStub() {
+  return { use: vi.fn() } as unknown as typeof cytoscape & {
+    use: ReturnType<typeof vi.fn>;
+  };
+}
+
+describe("layout extension registration", () => {
+  beforeEach(() => {
+    resetRegisteredLayouts();
+  });
+
+  test.each(["dagre", "elk"] as const)(
+    "%s registers its extension",
+    async (layoutName) => {
+      const cy = makeCytoscapeStub();
+      await ensureLayoutRegistered(cy, layoutName);
+      expect(cy.use).toHaveBeenCalledTimes(1);
+      expect(typeof cy.use.mock.calls[0][0]).toBe("function");
+    },
+  );
+
+  // 'preset' is what the 'manual' layout runs.
+  test.each(["breadthfirst", "preset"])(
+    "%s is built into cytoscape core",
+    async (layoutName) => {
+      const cy = makeCytoscapeStub();
+      await ensureLayoutRegistered(cy, layoutName);
+      expect(cy.use).not.toHaveBeenCalled();
+    },
+  );
+
+  test("repeat registration is skipped", async () => {
+    const cy = makeCytoscapeStub();
+    await ensureLayoutRegistered(cy, "dagre");
+    await ensureLayoutRegistered(cy, "dagre");
+    expect(cy.use).toHaveBeenCalledTimes(1);
+  });
+
+  test("each layout registers independently", async () => {
+    const cy = makeCytoscapeStub();
+    await ensureLayoutRegistered(cy, "dagre");
+    await ensureLayoutRegistered(cy, "elk");
+    expect(cy.use).toHaveBeenCalledTimes(2);
+  });
+});

--- a/tests/unit/renderers/cyDag/cyNodePositions.test.ts
+++ b/tests/unit/renderers/cyDag/cyNodePositions.test.ts
@@ -1,0 +1,172 @@
+import { describe, test, expect } from "vitest";
+import cytoscape, { Core, ElementsDefinition } from "cytoscape";
+import {
+  captureNodePositions,
+  applyNodePositions,
+} from "src/renderers/cyDag/cyNodePositions";
+
+function makeCy(elements: ElementsDefinition): Core {
+  return cytoscape({ headless: true, elements });
+}
+
+function chain(): ElementsDefinition {
+  return {
+    nodes: [{ data: { id: "a" } }, { data: { id: "b" } }],
+    edges: [{ data: { id: "a->b", source: "a", target: "b" } }],
+  };
+}
+
+describe("capturing node positions", () => {
+  test("records every leaf node by id", () => {
+    const cy = makeCy(chain());
+    cy.getElementById("a").position({ x: 10, y: 20 });
+    cy.getElementById("b").position({ x: 30, y: 40 });
+
+    expect(captureNodePositions(cy)).toEqual(
+      new Map([
+        ["a", { x: 10, y: 20 }],
+        ["b", { x: 30, y: 40 }],
+      ]),
+    );
+  });
+
+  test("skips compound nodes, whose position follows their children", () => {
+    const cy = makeCy({
+      nodes: [
+        { data: { id: "group" } },
+        { data: { id: "child", parent: "group" } },
+      ],
+      edges: [],
+    });
+    cy.getElementById("child").position({ x: 5, y: 5 });
+
+    expect([...captureNodePositions(cy).keys()]).toEqual(["child"]);
+  });
+});
+
+describe("applying node positions", () => {
+  test("puts surviving nodes back where they were", () => {
+    const cy = makeCy(chain());
+    cy.getElementById("a").position({ x: 10, y: 20 });
+    cy.getElementById("b").position({ x: 30, y: 40 });
+    const positions = captureNodePositions(cy);
+
+    // The renderer rebuilds the graph from scratch on a topology change.
+    cy.elements().remove();
+    cy.add(chain());
+    expect(cy.getElementById("a").position()).toEqual({ x: 0, y: 0 });
+
+    applyNodePositions(cy, positions);
+    expect(cy.getElementById("a").position()).toEqual({ x: 10, y: 20 });
+    expect(cy.getElementById("b").position()).toEqual({ x: 30, y: 40 });
+  });
+
+  test("ignores ids that no longer exist", () => {
+    const cy = makeCy(chain());
+    const positions = new Map([
+      ["a", { x: 10, y: 20 }],
+      ["gone", { x: 99, y: 99 }],
+    ]);
+
+    expect(() => applyNodePositions(cy, positions)).not.toThrow();
+    expect(cy.getElementById("a").position()).toEqual({ x: 10, y: 20 });
+  });
+
+  test("does not move a compound parent out from under its children", () => {
+    const cy = makeCy({
+      nodes: [
+        { data: { id: "group" } },
+        { data: { id: "child", parent: "group" } },
+      ],
+      edges: [],
+    });
+
+    applyNodePositions(cy, new Map([["group", { x: 500, y: 500 }]]));
+    expect(cy.getElementById("child").position()).not.toEqual({
+      x: 500,
+      y: 500,
+    });
+  });
+
+  test("drops a new node below the predecessor it was added after", () => {
+    const cy = makeCy(chain());
+    applyNodePositions(cy, new Map([["a", { x: 10, y: 20 }]]));
+
+    const added = cy.getElementById("b").position();
+    expect(added.x).toBe(10);
+    expect(added.y).toBeGreaterThan(20);
+  });
+
+  test("lifts a new node above the successor it feeds", () => {
+    const cy = makeCy(chain());
+    applyNodePositions(cy, new Map([["b", { x: 10, y: 20 }]]));
+
+    const added = cy.getElementById("a").position();
+    expect(added.x).toBe(10);
+    expect(added.y).toBeLessThan(20);
+  });
+
+  test("anchors a new node between its placed predecessors", () => {
+    const cy = makeCy({
+      nodes: [
+        { data: { id: "a" } },
+        { data: { id: "b" } },
+        { data: { id: "c" } },
+      ],
+      edges: [
+        { data: { id: "a->c", source: "a", target: "c" } },
+        { data: { id: "b->c", source: "b", target: "c" } },
+      ],
+    });
+
+    applyNodePositions(
+      cy,
+      new Map([
+        ["a", { x: 0, y: 0 }],
+        ["b", { x: 100, y: 40 }],
+      ]),
+    );
+
+    const added = cy.getElementById("c").position();
+    expect(added.x).toBe(50);
+    expect(added.y).toBeGreaterThan(40);
+  });
+
+  test("chains of new nodes follow each other rather than piling up", () => {
+    const cy = makeCy({
+      nodes: [
+        { data: { id: "a" } },
+        { data: { id: "b" } },
+        { data: { id: "c" } },
+      ],
+      edges: [
+        { data: { id: "a->b", source: "a", target: "b" } },
+        { data: { id: "b->c", source: "b", target: "c" } },
+      ],
+    });
+
+    applyNodePositions(cy, new Map([["a", { x: 0, y: 0 }]]));
+
+    const b = cy.getElementById("b").position();
+    const c = cy.getElementById("c").position();
+    expect(b.y).toBeGreaterThan(0);
+    expect(c.y).toBeGreaterThan(b.y);
+  });
+
+  test("unconnected new nodes land on screen instead of at the origin", () => {
+    const cy = makeCy({
+      nodes: [{ data: { id: "a" } }, { data: { id: "b" } }],
+      edges: [],
+    });
+    // Stand in for a panned viewport; headless cytoscape reports a unit extent.
+    cy.extent = () => ({ x1: 100, x2: 300, y1: 100, y2: 300, w: 200, h: 200 });
+
+    applyNodePositions(cy, new Map());
+
+    const first = cy.getElementById("a").position();
+    const second = cy.getElementById("b").position();
+    expect(first).toEqual({ x: 200, y: 200 });
+    // Cascaded so a batch of unconnected nodes is not one unclickable stack.
+    expect(second).not.toEqual(first);
+  });
+});

--- a/tests/unit/renderers/cyDag/cyNodePositions.test.ts
+++ b/tests/unit/renderers/cyDag/cyNodePositions.test.ts
@@ -1,5 +1,5 @@
 import { describe, test, expect } from "vitest";
-import cytoscape, { Core, ElementsDefinition } from "cytoscape";
+import cytoscape, { Core, ElementsDefinition, NodeSingular } from "cytoscape";
 import {
   captureNodePositions,
   applyNodePositions,
@@ -14,6 +14,12 @@ function chain(): ElementsDefinition {
     nodes: [{ data: { id: "a" } }, { data: { id: "b" } }],
     edges: [{ data: { id: "a->b", source: "a", target: "b" } }],
   };
+}
+
+function overlap(first: NodeSingular, second: NodeSingular): boolean {
+  const a = first.boundingBox();
+  const b = second.boundingBox();
+  return a.x1 < b.x2 && b.x1 < a.x2 && a.y1 < b.y2 && b.y1 < a.y2;
 }
 
 describe("capturing node positions", () => {
@@ -166,7 +172,60 @@ describe("applying node positions", () => {
     const first = cy.getElementById("a").position();
     const second = cy.getElementById("b").position();
     expect(first).toEqual({ x: 200, y: 200 });
-    // Cascaded so a batch of unconnected nodes is not one unclickable stack.
+    // Stepped aside so a batch of unconnected nodes is not one unclickable stack.
     expect(second).not.toEqual(first);
+  });
+
+  test("keeps an unconnected new node off the nodes already placed", () => {
+    const cy = makeCy({
+      nodes: [
+        { data: { id: "a" } },
+        { data: { id: "b" } },
+        { data: { id: "c" } },
+      ],
+      edges: [{ data: { id: "b->a", source: "b", target: "a" } }],
+    });
+    // A fitted graph sits in the middle of the viewport, so the centre an
+    // unanchored node falls back to is the one spot already occupied. Dropping
+    // it there hides the labels of whatever it covers.
+    cy.extent = () => ({ x1: -85, x2: 115, y1: 20, y2: 170, w: 200, h: 150 });
+
+    applyNodePositions(
+      cy,
+      new Map([
+        ["a", { x: 15, y: 95 }],
+        ["b", { x: 15, y: 15 }],
+      ]),
+    );
+
+    const added = cy.getElementById("c");
+    expect(overlap(added, cy.getElementById("a"))).toBe(false);
+    expect(overlap(added, cy.getElementById("b"))).toBe(false);
+  });
+
+  test("keeps a new successor off a sibling already sitting below", () => {
+    const cy = makeCy({
+      nodes: [
+        { data: { id: "a" } },
+        { data: { id: "b" } },
+        { data: { id: "c" } },
+      ],
+      edges: [
+        { data: { id: "a->b", source: "a", target: "b" } },
+        { data: { id: "a->c", source: "a", target: "c" } },
+      ],
+    });
+
+    // 'b' is parked exactly one successor gap below 'a', which is where 'c'
+    // would otherwise be dropped.
+    applyNodePositions(
+      cy,
+      new Map([
+        ["a", { x: 0, y: 0 }],
+        ["b", { x: 0, y: 100 }],
+      ]),
+    );
+
+    expect(overlap(cy.getElementById("c"), cy.getElementById("b"))).toBe(false);
   });
 });

--- a/tests/unit/renderers/cyDag/cyPopperExtender.test.ts
+++ b/tests/unit/renderers/cyDag/cyPopperExtender.test.ts
@@ -9,6 +9,7 @@ import {
   SelectorDescriptionPair,
   makeCyPopperMapFromDag,
   setupCyPoppers,
+  getPopperReferencePosition,
 } from "src/renderers/cyDag/cyPopperExtender";
 import { DESCRIPTION_PROPERTY } from "src/compiler/constants";
 import { Dag, StyleProperties } from "src/compiler/dag";
@@ -464,6 +465,49 @@ describe("subdag descriptions", () => {
       ["node[id = 'childId2']", makeDescriptionData("d1")],
     ];
     expect(getNodeDescriptions(childDag2)).toEqual(expectedDescs);
+  });
+});
+
+describe("popper reference position", () => {
+  const NODE_BOX = { x1: 100, y1: 200, x2: 160, y2: 260 };
+  const LABEL_OVERHANG = 20;
+  const OVERLAY_PADDING = 10;
+
+  // Stands in for a cytoscape element whose ':active' overlay grows its
+  // bounding box, which is what a grabbed node looks like mid-drag.
+  function makeElement(overlayPadding: number) {
+    const boxes = vi.fn(
+      (options: { includeLabels?: boolean; includeOverlays?: boolean }) => {
+        const pad = options.includeOverlays === false ? 0 : overlayPadding;
+        return {
+          x1: NODE_BOX.x1 - pad,
+          y1: NODE_BOX.y1 - pad,
+          x2: NODE_BOX.x2 + pad,
+          y2: NODE_BOX.y2 + pad + (options.includeLabels ? LABEL_OVERHANG : 0),
+        };
+      },
+    );
+    return { renderedBoundingBox: boxes };
+  }
+
+  type Element = Parameters<typeof getPopperReferencePosition>[0];
+
+  test("anchors below the label", () => {
+    const ele = makeElement(0) as unknown as Element;
+
+    expect(getPopperReferencePosition(ele)).toEqual({
+      x: NODE_BOX.x1,
+      y: NODE_BOX.y1 + LABEL_OVERHANG,
+    });
+  });
+
+  test("a grabbed element's overlay does not move the reference point", () => {
+    const grabbed = makeElement(OVERLAY_PADDING) as unknown as Element;
+    const free = makeElement(0) as unknown as Element;
+
+    expect(getPopperReferencePosition(grabbed)).toEqual(
+      getPopperReferencePosition(free),
+    );
   });
 });
 

--- a/tests/unit/renderers/cyDag/manualLayoutIntegration.test.ts
+++ b/tests/unit/renderers/cyDag/manualLayoutIntegration.test.ts
@@ -1,0 +1,104 @@
+import { describe, test, expect } from "vitest";
+import cytoscape, { Core } from "cytoscape";
+import { Compiler } from "src/compiler/driver";
+import { makeCyElements } from "src/renderers/cyDag/cyGraphFactory";
+import {
+  makeLayoutOptions,
+  isManualLayout,
+} from "src/renderers/cyDag/cyLayout";
+import {
+  captureNodePositions,
+  applyNodePositions,
+} from "src/renderers/cyDag/cyNodePositions";
+
+const MANUAL_DIRECTIVE = '^cytoscape{ layout: "manual" }\n';
+
+async function addRecipe(cy: Core, source: string) {
+  const { DAG } = await new Compiler().compileFromSource(source);
+  cy.add(makeCyElements(DAG));
+  return DAG;
+}
+
+/**
+ * Mirrors what CytoscapeRenderer.updateDag does on a topology change: capture
+ * the arrangement, rebuild the element set from the new dag, put it back.
+ */
+async function recompileInto(cy: Core, source: string) {
+  const dag = (await new Compiler().compileFromSource(source)).DAG;
+  const positions = isManualLayout(dag) ? captureNodePositions(cy) : null;
+  cy.elements().remove();
+  cy.add(makeCyElements(dag));
+  if (positions) applyNodePositions(cy, positions);
+  return dag;
+}
+
+describe("manual layout integration", () => {
+  test("running the layout leaves dragged nodes alone", async () => {
+    const cy = cytoscape({ headless: true });
+    const dag = await addRecipe(cy, `${MANUAL_DIRECTIVE}a = load()\nrun(a)\n`);
+
+    const dragged = cy.getElementById("root-n-load-0");
+    dragged.position({ x: 250, y: 75 });
+    cy.layout(makeLayoutOptions(dag)).run();
+
+    expect(dragged.position()).toEqual({ x: 250, y: 75 });
+    cy.destroy();
+  });
+
+  test("an arrangement survives an edit that rebuilds the graph", async () => {
+    const cy = cytoscape({ headless: true });
+    const recipe = `${MANUAL_DIRECTIVE}a = load()\nrun(a)\n`;
+    await addRecipe(cy, recipe);
+
+    cy.getElementById("root-n-load-0").position({ x: 250, y: 75 });
+    cy.getElementById("root-n-run-0").position({ x: 250, y: 275 });
+
+    // Node ids are stable across recompiles, so appending a statement leaves
+    // the two arranged nodes addressable by the same ids.
+    await recompileInto(cy, `${recipe}report(a)\n`);
+
+    expect(cy.getElementById("root-n-load-0").position()).toEqual({
+      x: 250,
+      y: 75,
+    });
+    expect(cy.getElementById("root-n-run-0").position()).toEqual({
+      x: 250,
+      y: 275,
+    });
+    cy.destroy();
+  });
+
+  test("a node added by an edit appears below the node it consumes", async () => {
+    const cy = cytoscape({ headless: true });
+    const recipe = `${MANUAL_DIRECTIVE}a = load()\nrun(a)\n`;
+    await addRecipe(cy, recipe);
+
+    cy.getElementById("root-n-load-0").position({ x: 250, y: 75 });
+    cy.getElementById("root-n-run-0").position({ x: 250, y: 275 });
+
+    await recompileInto(cy, `${recipe}report(a)\n`);
+
+    const added = cy.getElementById("root-n-report-0").position();
+    expect(added.x).toBeCloseTo(250);
+    expect(added.y).toBeGreaterThan(75);
+    cy.destroy();
+  });
+
+  test("nodes inside a namespace keep their positions", async () => {
+    const cy = cytoscape({ headless: true });
+    const recipe = `${MANUAL_DIRECTIVE}group[\n  x = step()\n]\n`;
+    await addRecipe(cy, recipe);
+
+    const inner = cy.getElementById("root-ns-group-0-n-step-0");
+    expect(inner.length).toBe(1);
+    inner.position({ x: 120, y: 340 });
+
+    await recompileInto(cy, `${recipe}after()\n`);
+
+    expect(cy.getElementById("root-ns-group-0-n-step-0").position()).toEqual({
+      x: 120,
+      y: 340,
+    });
+    cy.destroy();
+  });
+});

--- a/tests/unit/renderers/cyDag/optionParsers.test.ts
+++ b/tests/unit/renderers/cyDag/optionParsers.test.ts
@@ -1,0 +1,129 @@
+import { describe, expect, test } from "vitest";
+import { NodeSingular } from "cytoscape";
+import {
+  SHARED_OPTIONS,
+  parseBoolean,
+  parseEnum,
+  parseNonNegative,
+  parseNumber,
+  parsePositive,
+  sortByInsertionOrder,
+  upperCase,
+} from "src/renderers/cyDag/layouts/optionParsers";
+
+function makeOrderedNode(order: number[]): NodeSingular {
+  return { data: () => order } as unknown as NodeSingular;
+}
+
+describe("parseEnum", () => {
+  test("normalizes and trims recognized values", () => {
+    const parser = parseEnum(["LR", "TB"], upperCase);
+    expect(parser(" lr ")).toBe("LR");
+  });
+
+  test("returns undefined for unrecognized values", () => {
+    const parser = parseEnum(["LR", "TB"], upperCase);
+    expect(parser("left")).toBeUndefined();
+  });
+});
+
+describe("parseNumber", () => {
+  test("parses finite numeric input", () => {
+    const parser = parseNumber();
+    expect(parser(" 12.5 ")).toBe(12.5);
+  });
+
+  test("returns undefined for empty or non-numeric input", () => {
+    const parser = parseNumber();
+    expect(parser("")).toBeUndefined();
+    expect(parser("  ")).toBeUndefined();
+    expect(parser("wide")).toBeUndefined();
+  });
+
+  test("returns undefined for non-finite values", () => {
+    const parser = parseNumber();
+    expect(parser("Infinity")).toBeUndefined();
+    expect(parser("-Infinity")).toBeUndefined();
+    expect(parser("NaN")).toBeUndefined();
+  });
+
+  test("respects integer constraint", () => {
+    const parser = parseNumber({ isInteger: true });
+    expect(parser("4")).toBe(4);
+    expect(parser("4.2")).toBeUndefined();
+  });
+
+  test("respects min constraints", () => {
+    const parser = parseNumber({ min: 0 });
+    expect(parser("0")).toBe(0);
+    expect(parser("0.1")).toBe(0.1);
+    expect(parser("-0.1")).toBeUndefined();
+  });
+
+  test("respects max constraint", () => {
+    const parser = parseNumber({ max: 10 });
+    expect(parser("10")).toBe(10);
+    expect(parser("10.1")).toBeUndefined();
+  });
+});
+
+describe("parseBoolean", () => {
+  test("accepts true and false tokens", () => {
+    expect(parseBoolean("true")).toBe(true);
+    expect(parseBoolean(" TRUE ")).toBe(true);
+    expect(parseBoolean("1")).toBe(true);
+    expect(parseBoolean("false")).toBe(false);
+    expect(parseBoolean(" 0 ")).toBe(false);
+  });
+
+  test("returns undefined for unrecognized tokens", () => {
+    expect(parseBoolean("yes")).toBeUndefined();
+  });
+});
+
+describe("parseNonNegative and parsePositive", () => {
+  test("enforce zero boundary as expected", () => {
+    expect(parseNonNegative("0")).toBe(0);
+    expect(parseNonNegative("-1")).toBeUndefined();
+    expect(parsePositive("0")).toBeUndefined();
+    expect(parsePositive("0.01")).toBe(0.01);
+  });
+});
+
+describe("sortByInsertionOrder", () => {
+  test("compares the first differing lineage index", () => {
+    expect(
+      sortByInsertionOrder(makeOrderedNode([0]), makeOrderedNode([1])),
+    ).toBe(-1);
+    expect(
+      sortByInsertionOrder(makeOrderedNode([2]), makeOrderedNode([1])),
+    ).toBe(1);
+  });
+
+  test("uses length as tie-breaker when one order is a prefix", () => {
+    expect(
+      sortByInsertionOrder(makeOrderedNode([1]), makeOrderedNode([1, 0])),
+    ).toBeLessThan(0);
+    expect(
+      sortByInsertionOrder(makeOrderedNode([1, 0]), makeOrderedNode([1])),
+    ).toBeGreaterThan(0);
+  });
+});
+
+describe("SHARED_OPTIONS", () => {
+  test("marks each shared option as top-level", () => {
+    expect(SHARED_OPTIONS.every((option) => option.topLevel === true)).toBe(
+      true,
+    );
+  });
+
+  test("contains the expected directive keys", () => {
+    expect(SHARED_OPTIONS.map((option) => option.directiveKey)).toEqual([
+      "fit",
+      "padding",
+      "animate",
+      "animationDuration",
+      "nodeDimensionsIncludeLabels",
+    ]);
+  });
+});


### PR DESCRIPTION
This pull request introduces several important improvements to the renderer system, focusing on extensibility, autocompletion accuracy, and code maintainability. The most significant changes include support for multiple Cytoscape layouts (via the new `cytoscape-elk` dependency), enhanced autocompletion that adapts to the selected layout, and code cleanup around renderer selection and option persistence.

**Renderer extensibility and layout support:**

* Added the `cytoscape-elk` and `elkjs` dependencies to support additional Cytoscape layouts, and updated `pnpm-lock.yaml` accordingly. [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R36) [[2]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR59-R61) [[3]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR1561-R1565) [[4]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR1629-R1631) [[5]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR4312-R4316) [[6]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR4377-R4378)
* Refactored layout option handling in headless rendering: replaced `makeDagreLayoutOptions` with a generic `makeLayoutOptions` and ensured the appropriate layout extension is registered dynamically. [[1]](diffhunk://#diff-f6d4c60d673e4e49e9f70a305610bfd03a998322475dda80caf0a296068efa76L8-R15) [[2]](diffhunk://#diff-f6d4c60d673e4e49e9f70a305610bfd03a998322475dda80caf0a296068efa76L174-R194) [[3]](diffhunk://#diff-f6d4c60d673e4e49e9f70a305610bfd03a998322475dda80caf0a296068efa76L186-R212)

**Autocompletion improvements:**

* Autocompletion for renderer directives now adapts to the layout specified in the block, offering only relevant options for the chosen layout. This includes passing layout information through context and updating completion logic. [[1]](diffhunk://#diff-0dd4d81f3db9a9a4e45f5d57e9ea15631a4db6e50b60c769ddbe005caa92b27aR28-R31) [[2]](diffhunk://#diff-03d2581e99f35ba82c85afbc41b7077d749da893442dad2e12574d51ff2b9f2eL15-R18) [[3]](diffhunk://#diff-03d2581e99f35ba82c85afbc41b7077d749da893442dad2e12574d51ff2b9f2eL187-R192) [[4]](diffhunk://#diff-e03fcb51bc84e83155a492d8e64f8dad3f7b95530c5cd89b7def29c53e63f7aaL249-R283) [[5]](diffhunk://#diff-e03fcb51bc84e83155a492d8e64f8dad3f7b95530c5cd89b7def29c53e63f7aaR295-R334) [[6]](diffhunk://#diff-c9687bcad0d3feb5e5eed1909cf8937f95a6ee8966115bb5dd4828520a8c3868L55-R58) [[7]](diffhunk://#diff-c9687bcad0d3feb5e5eed1909cf8937f95a6ee8966115bb5dd4828520a8c3868R79-R83)

**Code cleanup and renderer option persistence:**

* Simplified renderer selection state management in `App.vue` by removing the persisted `selectedRenderer` option and related watchers, using `activeRendererName` instead. [[1]](diffhunk://#diff-7a7a37b12ee1265d7e27577ec286120d2cbc0940908635e264a2be44ccb9a8a0L12-R12) [[2]](diffhunk://#diff-7a7a37b12ee1265d7e27577ec286120d2cbc0940908635e264a2be44ccb9a8a0L77-L78) [[3]](diffhunk://#diff-7a7a37b12ee1265d7e27577ec286120d2cbc0940908635e264a2be44ccb9a8a0L155-R154) [[4]](diffhunk://#diff-7a7a37b12ee1265d7e27577ec286120d2cbc0940908635e264a2be44ccb9a8a0L178) [[5]](diffhunk://#diff-7a7a37b12ee1265d7e27577ec286120d2cbc0940908635e264a2be44ccb9a8a0L191) [[6]](diffhunk://#diff-7a7a37b12ee1265d7e27577ec286120d2cbc0940908635e264a2be44ccb9a8a0L249)

**Dependency updates:**

* Added the `zod` dependency for schema validation and updated `pnpm-lock.yaml` accordingly. [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L47-R49) [[2]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR98-R100) [[3]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR2988-R2990) [[4]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR5640-R5641)

**Headless rendering bugfix:**

* Fixed a bug where offscreen canvas elements from jsdom caused errors during headless rendering by unwrapping and patching the `drawImage` method.

These changes collectively make the renderer system more flexible, improve the user experience with smarter autocompletion, and simplify the codebase for future development.